### PR TITLE
smaller logo on readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,7 @@
-.. image:: readthedocs/_static/matchms.png
-  :width: 600
-  :alt: matchms logo
+.. raw:: html
 
-################################################################################
-matchms
-################################################################################
+    <img src="readthedocs/_static/matchms.png" height="60px" width="380px" alt="matchms" />
+
 Vector representation and similarity measure for mass spectrometry data.
 
 |


### PR DESCRIPTION
Also removed matchms header, as the logo IS the header. 
Because image height is ignored by github while rendering rst (https://github.com/github/markup/issues/295 from 2014), I'm using raw html to get the logo the size that I want.