### PR TITLE
Fix wrong ordering of losses and add unit tests

### DIFF
--- a/matchms/filtering/add_losses.py
+++ b/matchms/filtering/add_losses.py
@@ -1,8 +1,20 @@
+import numpy
 from ..Spikes import Spikes
+from ..typing import SpectrumType
 
 
-def add_losses(spectrum_in):
-    """Derive losses based on precursor mass."""
+def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -> SpectrumType:
+    """Derive losses based on precursor mass.
+
+    Args:
+    ----
+    spectrum_in: matchms.Spectrum
+        Input spectrum.
+    loss_mz_from: float
+        Minimum allowed m/z value for losses. Default is 0.0.
+    loss_mz_to: float
+        Maximum allowed m/z value for losses. Default is 1000.0.
+    """
     def precursor_mz_is_number():
         if isinstance(precursor_mz, int):
             return True
@@ -17,10 +29,15 @@ def add_losses(spectrum_in):
 
     precursor_mz = spectrum.get("precursor_mz")
     if precursor_mz is not None:
-        assert precursor_mz_is_number(), "Expected 'precursor_mz' to be a scalar number."
+        assert precursor_mz_is_number(), ("Expected 'precursor_mz' to be a scalar number.",
+                                          "Consider applying 'add_precursor_mz' filter first.")
         peaks_mz, peaks_intensities = spectrum.peaks
         losses_mz = (precursor_mz - peaks_mz)[::-1]
-        losses_intensities = peaks_intensities
-        spectrum.losses = Spikes(mz=losses_mz, intensities=losses_intensities)
+        losses_intensities = peaks_intensities[::-1]
+        # Add losses which are within given boundaries
+        keep_idx = numpy.where((losses_mz >= loss_mz_from)
+                               & (losses_mz <= loss_mz_to))[0]
+        spectrum.losses = Spikes(mz=losses_mz[keep_idx],
+                                 intensities=losses_intensities[keep_idx])
 
     return spectrum

--- a/matchms/filtering/add_losses.py
+++ b/matchms/filtering/add_losses.py
@@ -36,7 +36,7 @@ def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -
         losses_intensities = peaks_intensities[::-1]
         # Add losses which are within given boundaries
         keep_idx = numpy.where((losses_mz >= loss_mz_from)
-                               & (losses_mz <= loss_mz_to))[0]
+                               & (losses_mz <= loss_mz_to))
         spectrum.losses = Spikes(mz=losses_mz[keep_idx],
                                  intensities=losses_intensities[keep_idx])
 

--- a/matchms/filtering/add_losses.py
+++ b/matchms/filtering/add_losses.py
@@ -37,7 +37,7 @@ def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -
         # Add losses which are within given boundaries
         mask = numpy.where((losses_mz >= loss_mz_from)
                                & (losses_mz <= loss_mz_to))
-        spectrum.losses = Spikes(mz=losses_mz[keep_idx],
+        spectrum.losses = Spikes(mz=losses_mz[mask],
                                  intensities=losses_intensities[keep_idx])
 
     return spectrum

--- a/matchms/filtering/add_losses.py
+++ b/matchms/filtering/add_losses.py
@@ -28,7 +28,7 @@ def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -
     spectrum = spectrum_in.clone()
 
     precursor_mz = spectrum.get("precursor_mz")
-    if precursor_mz is not None:
+    if precursor_mz:
         assert precursor_mz_is_number(), ("Expected 'precursor_mz' to be a scalar number.",
                                           "Consider applying 'add_precursor_mz' filter first.")
         peaks_mz, peaks_intensities = spectrum.peaks

--- a/matchms/filtering/add_losses.py
+++ b/matchms/filtering/add_losses.py
@@ -36,7 +36,7 @@ def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -
         losses_intensities = peaks_intensities[::-1]
         # Add losses which are within given boundaries
         mask = numpy.where((losses_mz >= loss_mz_from)
-                               & (losses_mz <= loss_mz_to))
+                           & (losses_mz <= loss_mz_to))
         spectrum.losses = Spikes(mz=losses_mz[mask],
                                  intensities=losses_intensities[mask])
 

--- a/matchms/filtering/add_losses.py
+++ b/matchms/filtering/add_losses.py
@@ -35,7 +35,7 @@ def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -
         losses_mz = (precursor_mz - peaks_mz)[::-1]
         losses_intensities = peaks_intensities[::-1]
         # Add losses which are within given boundaries
-        keep_idx = numpy.where((losses_mz >= loss_mz_from)
+        mask = numpy.where((losses_mz >= loss_mz_from)
                                & (losses_mz <= loss_mz_to))
         spectrum.losses = Spikes(mz=losses_mz[keep_idx],
                                  intensities=losses_intensities[keep_idx])

--- a/matchms/filtering/add_losses.py
+++ b/matchms/filtering/add_losses.py
@@ -38,6 +38,6 @@ def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -
         mask = numpy.where((losses_mz >= loss_mz_from)
                                & (losses_mz <= loss_mz_to))
         spectrum.losses = Spikes(mz=losses_mz[mask],
-                                 intensities=losses_intensities[keep_idx])
+                                 intensities=losses_intensities[mask])
 
     return spectrum

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -13,8 +13,8 @@ def test_add_losses():
     spectrum = add_losses(spectrum_in)
 
     expected_mz = numpy.array([145, 245, 295, 345], "float")
-    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
     expected_intensities = numpy.array([1000, 100, 200, 700], "float")
+    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
     assert numpy.allclose(spectrum.losses.intensities, expected_intensities), "Expected different intensities."
 
 
@@ -66,8 +66,8 @@ def test_add_losses_with_peakmz_larger_precursormz():
     spectrum = add_losses(spectrum_in)
 
     expected_mz = numpy.array([245, 295, 345], "float")
-    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
     expected_intensities = numpy.array([100, 200, 700], "float")
+    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
     assert numpy.allclose(spectrum.losses.intensities, expected_intensities), "Expected different intensities."
 
 
@@ -80,6 +80,6 @@ def test_add_losses_with_max_loss_mz_250():
     spectrum = add_losses(spectrum_in, loss_mz_to=250)
 
     expected_mz = numpy.array([145, 245], "float")
-    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
     expected_intensities = numpy.array([1000, 100], "float")
+    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
     assert numpy.allclose(spectrum.losses.intensities, expected_intensities), "Expected different intensities."

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -13,7 +13,7 @@ def test_add_losses():
 
     expected_mz = numpy.array([145, 245, 295, 345], "float")
     assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
-    aim_intensities = numpy.array([1000, 100, 200, 700], "float")
+    expected_intensities = numpy.array([1000, 100, 200, 700], "float")
     assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."
 
 

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -11,7 +11,7 @@ def test_add_losses():
 
     spectrum = add_losses(spectrum_in)
 
-    aim_mz = numpy.array([145, 245, 295, 345], "float")
+    expected_mz = numpy.array([145, 245, 295, 345], "float")
     assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
     aim_intensities = numpy.array([1000, 100, 200, 700], "float")
     assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -5,6 +5,7 @@ from matchms.filtering import add_losses
 
 
 def test_add_losses():
+    """Test if all losses are correctly generated form mz values and precursor-m/z."""
     spectrum_in = Spectrum(mz=numpy.array([100, 150, 200, 300], dtype="float"),
                            intensities=numpy.array([700, 200, 100, 1000], dtype="float"),
                            metadata={"precursor_mz": 445.0})
@@ -18,6 +19,7 @@ def test_add_losses():
 
 
 def test_add_losses_without_precursor_mz():
+    """Test if no changes are done without having a precursor-m/z."""
     spectrum_in = Spectrum(mz=numpy.array([100, 150, 200, 300], dtype="float"),
                            intensities=numpy.array([700, 200, 100, 1000], dtype="float"))
 
@@ -27,7 +29,7 @@ def test_add_losses_without_precursor_mz():
 
 
 def test_add_losses_with_precursor_mz_wrong_type():
-
+    """Test if correct assert error is raised for precursor-mz as string."""
     spectrum_in = Spectrum(mz=numpy.array([100, 150, 200, 300], dtype="float"),
                            intensities=numpy.array([700, 200, 100, 1000], dtype="float"),
                            metadata={"precursor_mz": "445.0"})
@@ -39,6 +41,7 @@ def test_add_losses_with_precursor_mz_wrong_type():
 
 
 def test_add_losses_returns_new_spectrum_instance():
+    """Test if no change is done to empty spectrum."""
     spectrum_in = Spectrum(mz=numpy.array([], dtype="float"),
                            intensities=numpy.array([], dtype="float"))
 
@@ -48,12 +51,14 @@ def test_add_losses_returns_new_spectrum_instance():
 
 
 def test_add_losses_with_input_none():
+    """Test if input spectrum is None."""
     spectrum_in = None
     spectrum = add_losses(spectrum_in)
     assert spectrum is None
 
 
 def test_add_losses_with_peakmz_larger_precursormz():
+    """Test if losses are correctly generated and loss < 0 is discarded."""
     spectrum_in = Spectrum(mz=numpy.array([100, 150, 200, 450], dtype="float"),
                            intensities=numpy.array([700, 200, 100, 1000], dtype="float"),
                            metadata={"precursor_mz": 445.0})
@@ -67,6 +72,7 @@ def test_add_losses_with_peakmz_larger_precursormz():
 
 
 def test_add_losses_with_max_loss_mz_250():
+    """Test if losses are correctly generated and losses with mz > 250 are discarded."""
     spectrum_in = Spectrum(mz=numpy.array([100, 150, 200, 300], dtype="float"),
                            intensities=numpy.array([700, 200, 100, 1000], dtype="float"),
                            metadata={"precursor_mz": 445.0})

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -14,7 +14,7 @@ def test_add_losses():
     expected_mz = numpy.array([145, 245, 295, 345], "float")
     assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
     expected_intensities = numpy.array([1000, 100, 200, 700], "float")
-    assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."
+    assert numpy.allclose(spectrum.losses.intensities, expected_intensities), "Expected different intensities."
 
 
 def test_add_losses_without_precursor_mz():

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -60,10 +60,10 @@ def test_add_losses_with_peakmz_larger_precursormz():
 
     spectrum = add_losses(spectrum_in)
 
-    aim_mz = numpy.array([245, 295, 345], "float")
-    assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
-    aim_intensities = numpy.array([100, 200, 700], "float")
-    assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."
+    expected_mz = numpy.array([245, 295, 345], "float")
+    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
+    expected_intensities = numpy.array([100, 200, 700], "float")
+    assert numpy.allclose(spectrum.losses.intensities, expected_intensities), "Expected different intensities."
 
 
 def test_add_losses_with_max_loss_mz_250():
@@ -73,7 +73,7 @@ def test_add_losses_with_max_loss_mz_250():
 
     spectrum = add_losses(spectrum_in, loss_mz_to=250)
 
-    aim_mz = numpy.array([145, 245], "float")
-    assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
-    aim_intensities = numpy.array([1000, 100], "float")
-    assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."
+    expected_mz = numpy.array([145, 245], "float")
+    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
+    expected_intensities = numpy.array([1000, 100], "float")
+    assert numpy.allclose(spectrum.losses.intensities, expected_intensities), "Expected different intensities."

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -11,7 +11,10 @@ def test_add_losses():
 
     spectrum = add_losses(spectrum_in)
 
-    assert numpy.allclose(spectrum.losses.mz, numpy.array([145, 245, 295, 345], "float"))
+    aim_mz = numpy.array([145, 245, 295, 345], "float")
+    assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
+    aim_intensities = numpy.array([1000, 100, 200, 700], "float")
+    assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."
 
 
 def test_add_losses_without_precursor_mz():
@@ -32,7 +35,7 @@ def test_add_losses_with_precursor_mz_wrong_type():
     with pytest.raises(AssertionError) as msg:
         _ = add_losses(spectrum_in)
 
-    assert str(msg.value) == "Expected 'precursor_mz' to be a scalar number."
+    assert "Expected 'precursor_mz' to be a scalar number." in str(msg.value)
 
 
 def test_add_losses_returns_new_spectrum_instance():
@@ -48,3 +51,29 @@ def test_add_losses_with_input_none():
     spectrum_in = None
     spectrum = add_losses(spectrum_in)
     assert spectrum is None
+
+
+def test_add_losses_with_peakmz_larger_precursormz():
+    spectrum_in = Spectrum(mz=numpy.array([100, 150, 200, 450], dtype="float"),
+                           intensities=numpy.array([700, 200, 100, 1000], dtype="float"),
+                           metadata={"precursor_mz": 445.0})
+
+    spectrum = add_losses(spectrum_in)
+
+    aim_mz = numpy.array([245, 295, 345], "float")
+    assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
+    aim_intensities = numpy.array([100, 200, 700], "float")
+    assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."
+
+
+def test_add_losses_with_max_loss_mz_250():
+    spectrum_in = Spectrum(mz=numpy.array([100, 150, 200, 300], dtype="float"),
+                           intensities=numpy.array([700, 200, 100, 1000], dtype="float"),
+                           metadata={"precursor_mz": 445.0})
+
+    spectrum = add_losses(spectrum_in, loss_mz_to=250)
+
+    aim_mz = numpy.array([145, 245], "float")
+    assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
+    aim_intensities = numpy.array([1000, 100], "float")
+    assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -12,7 +12,7 @@ def test_add_losses():
     spectrum = add_losses(spectrum_in)
 
     expected_mz = numpy.array([145, 245, 295, 345], "float")
-    assert numpy.allclose(spectrum.losses.mz, aim_mz), "Expected different loss m/z."
+    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
     aim_intensities = numpy.array([1000, 100, 200, 700], "float")
     assert numpy.allclose(spectrum.losses.intensities, aim_intensities), "Expected different intensities."
 


### PR DESCRIPTION
Originally here https://github.com/matchms/matchms-backup/pull/233


-   fix intensity order in ``add_losses``
-   add unit tests
-   add ``loss_mz_from`` and ``loss_mz_to`` parameters to ``add_losses``

Closses #20 