### PR TITLE
adapt unit test to also run on not compiled numba function

### DIFF
--- a/tests/test_collect_peak_pairs.py
+++ b/tests/test_collect_peak_pairs.py
@@ -1,56 +1,37 @@
 """Test function to collect matching peaks. Run tests both on numba compiled and
 pure Python version."""
 import numpy
+import pytest
 from matchms.similarity.collect_peak_pairs import collect_peak_pairs
 
 
-def test_cosine_hungarian_tolerance_01_compiled():
-    """Test finding expected peak matches within tolerance=0.2."""
+@pytest.mark.parametrize("tolerance, expected_pairs",
+                         [(0.2, [(2, 2, 1.0), (3, 3, 1.0)]),
+                          (5.0, [(0, 0, 1.0), (1, 1, 1.0)])])
+def test_cosine_hungarian_compiled(tolerance, expected_pairs):
+    """Test finding expected peak matches for given tolerance."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     spec2 = numpy.array([[105, 205.1, 300, 500.1],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
-    matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2)
+    matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=tolerance)
     assert len(matching_pairs) == 2, "Expected different number of matching peaks"
-    assert matching_pairs == [(2, 2, 1.0), (3, 3, 1.0)], "Expected different matchin pairs."
+    assert matching_pairs == expected_pairs, "Expected different matchin pairs."
 
 
-def test_cosine_hungarian_tolerance_01_shift_min5_compiled():
-    """Test finding expected peak matches when given a mass_shift of -5.0."""
-    spec1 = numpy.array([[100, 200, 300, 500],
-                         [1.0, 1.0, 0.1, 0.1]], dtype="float").T
-
-    spec2 = numpy.array([[105, 205.1, 300, 500.1],
-                         [1.0, 1.0, 0.1, 0.1]], dtype="float").T
-
-    matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=-5.0)
-    assert len(matching_pairs) == 2, "Expected different number of matching peaks"
-    assert matching_pairs == [(0, 0, 1.0), (1, 1, 1.0)], "Expected different matchin pairs."
-
-
-def test_cosine_hungarian_tolerance_01():
-    """Test finding expected peak matches within tolerance=0.2."""
+@pytest.mark.parametrize("tolerance, expected_pairs",
+                         [(0.2, [(2, 2, 1.0), (3, 3, 1.0)]),
+                          (5.0, [(0, 0, 1.0), (1, 1, 1.0)])])
+def test_cosine_hungarian(tolerance, expected_pairs):
+    """Test finding expected peak matches for given tolerance."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     spec2 = numpy.array([[105, 205.1, 300, 500.1],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
-    matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2)
+    matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=tolerance)
     assert len(matching_pairs) == 2, "Expected different number of matching peaks"
-    assert matching_pairs == [(2, 2, 1.0), (3, 3, 1.0)], "Expected different matchin pairs."
-
-
-def test_cosine_hungarian_tolerance_01_shift_min5():
-    """Test finding expected peak matches when given a mass_shift of -5.0."""
-    spec1 = numpy.array([[100, 200, 300, 500],
-                         [1.0, 1.0, 0.1, 0.1]], dtype="float").T
-
-    spec2 = numpy.array([[105, 205.1, 300, 500.1],
-                         [1.0, 1.0, 0.1, 0.1]], dtype="float").T
-
-    matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=-5.0)
-    assert len(matching_pairs) == 2, "Expected different number of matching peaks"
-    assert matching_pairs == [(0, 0, 1.0), (1, 1, 1.0)], "Expected different matchin pairs."
+    assert matching_pairs == expected_pairs, "Expected different matchin pairs."

--- a/tests/test_collect_peak_pairs.py
+++ b/tests/test_collect_peak_pairs.py
@@ -18,11 +18,11 @@ def test_cosine_hungarian_compiled(shift, expected_pairs):
 
     matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=shift)
     assert len(matching_pairs) == 2, "Expected different number of matching peaks"
-    assert matching_pairs == expected_pairs, "Expected different matchin pairs."
+    assert matching_pairs == [pytest.approx(x, 1e-9) for x in expected_pairs], "Expected different pairs."
 
 
 @pytest.mark.parametrize("shift, expected_pairs",
-                         [(0.2, [(2, 2, 1.0), (3, 3, 1.0)]),
+                         [(0.0, [(2, 2, 1.0), (3, 3, 1.0)]),
                           (-5.0, [(0, 0, 0.01), (1, 1, 0.01)])])
 def test_cosine_hungarian(shift, expected_pairs):
     """Test finding expected peak matches for tolerance=0.2 and given shift."""
@@ -34,4 +34,4 @@ def test_cosine_hungarian(shift, expected_pairs):
 
     matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift)
     assert len(matching_pairs) == 2, "Expected different number of matching peaks"
-    assert matching_pairs == pytest.approx(expected_pairs, 1e-9), "Expected different matchin pairs."
+    assert matching_pairs == [pytest.approx(x, 1e-9) for x in expected_pairs], "Expected different pairs."

--- a/tests/test_collect_peak_pairs.py
+++ b/tests/test_collect_peak_pairs.py
@@ -7,7 +7,7 @@ from matchms.similarity.collect_peak_pairs import collect_peak_pairs
 
 @pytest.mark.parametrize("shift, expected_pairs",
                          [(0.0, [(2, 2, 1.0), (3, 3, 1.0)]),
-                          (-5.0, [(0, 0, 1.0), (1, 1, 1.0)])])
+                          (-5.0, [(0, 0, 0.01), (1, 1, 0.01)])])
 def test_cosine_hungarian_compiled(shift, expected_pairs):
     """Test finding expected peak matches for given tolerance."""
     spec1 = numpy.array([[100, 200, 300, 500],
@@ -23,7 +23,7 @@ def test_cosine_hungarian_compiled(shift, expected_pairs):
 
 @pytest.mark.parametrize("shift, expected_pairs",
                          [(0.2, [(2, 2, 1.0), (3, 3, 1.0)]),
-                          (5.0, [(0, 0, 1.0), (1, 1, 1.0)])])
+                          (-5.0, [(0, 0, 0.01), (1, 1, 0.01)])])
 def test_cosine_hungarian(shift, expected_pairs):
     """Test finding expected peak matches for tolerance=0.2 and given shift."""
     spec1 = numpy.array([[100, 200, 300, 500],
@@ -34,4 +34,4 @@ def test_cosine_hungarian(shift, expected_pairs):
 
     matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift)
     assert len(matching_pairs) == 2, "Expected different number of matching peaks"
-    assert matching_pairs == expected_pairs, "Expected different matchin pairs."
+    assert matching_pairs == pytest.approx(expected_pairs, 1e-9), "Expected different matchin pairs."

--- a/tests/test_collect_peak_pairs.py
+++ b/tests/test_collect_peak_pairs.py
@@ -1,8 +1,10 @@
+"""Test function to collect matching peaks. Run tests both on numba compiled and
+pure Python version."""
 import numpy
 from matchms.similarity.collect_peak_pairs import collect_peak_pairs
 
 
-def test_cosine_hungarian_tolerance_01():
+def test_cosine_hungarian_tolerance_01_compiled():
     """Test finding expected peak matches within tolerance=0.2."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
@@ -15,7 +17,7 @@ def test_cosine_hungarian_tolerance_01():
     assert matching_pairs == [(2, 2, 1.0), (3, 3, 1.0)], "Expected different matchin pairs."
 
 
-def test_cosine_hungarian_tolerance_01_shift_min5():
+def test_cosine_hungarian_tolerance_01_shift_min5_compiled():
     """Test finding expected peak matches when given a mass_shift of -5.0."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [1.0, 1.0, 0.1, 0.1]], dtype="float").T
@@ -24,5 +26,31 @@ def test_cosine_hungarian_tolerance_01_shift_min5():
                          [1.0, 1.0, 0.1, 0.1]], dtype="float").T
 
     matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=-5.0)
+    assert len(matching_pairs) == 2, "Expected different number of matching peaks"
+    assert matching_pairs == [(0, 0, 1.0), (1, 1, 1.0)], "Expected different matchin pairs."
+
+
+def test_cosine_hungarian_tolerance_01():
+    """Test finding expected peak matches within tolerance=0.2."""
+    spec1 = numpy.array([[100, 200, 300, 500],
+                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+
+    spec2 = numpy.array([[105, 205.1, 300, 500.1],
+                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+
+    matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2)
+    assert len(matching_pairs) == 2, "Expected different number of matching peaks"
+    assert matching_pairs == [(2, 2, 1.0), (3, 3, 1.0)], "Expected different matchin pairs."
+
+
+def test_cosine_hungarian_tolerance_01_shift_min5():
+    """Test finding expected peak matches when given a mass_shift of -5.0."""
+    spec1 = numpy.array([[100, 200, 300, 500],
+                         [1.0, 1.0, 0.1, 0.1]], dtype="float").T
+
+    spec2 = numpy.array([[105, 205.1, 300, 500.1],
+                         [1.0, 1.0, 0.1, 0.1]], dtype="float").T
+
+    matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=-5.0)
     assert len(matching_pairs) == 2, "Expected different number of matching peaks"
     assert matching_pairs == [(0, 0, 1.0), (1, 1, 1.0)], "Expected different matchin pairs."

--- a/tests/test_collect_peak_pairs.py
+++ b/tests/test_collect_peak_pairs.py
@@ -5,10 +5,10 @@ import pytest
 from matchms.similarity.collect_peak_pairs import collect_peak_pairs
 
 
-@pytest.mark.parametrize("tolerance, expected_pairs",
-                         [(0.2, [(2, 2, 1.0), (3, 3, 1.0)]),
-                          (5.0, [(0, 0, 1.0), (1, 1, 1.0)])])
-def test_cosine_hungarian_compiled(tolerance, expected_pairs):
+@pytest.mark.parametrize("shift, expected_pairs",
+                         [(0.0, [(2, 2, 1.0), (3, 3, 1.0)]),
+                          (-5.0, [(0, 0, 1.0), (1, 1, 1.0)])])
+def test_cosine_hungarian_compiled(shift, expected_pairs):
     """Test finding expected peak matches for given tolerance."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
@@ -16,22 +16,22 @@ def test_cosine_hungarian_compiled(tolerance, expected_pairs):
     spec2 = numpy.array([[105, 205.1, 300, 500.1],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
-    matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=tolerance)
+    matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=shift)
     assert len(matching_pairs) == 2, "Expected different number of matching peaks"
     assert matching_pairs == expected_pairs, "Expected different matchin pairs."
 
 
-@pytest.mark.parametrize("tolerance, expected_pairs",
+@pytest.mark.parametrize("shift, expected_pairs",
                          [(0.2, [(2, 2, 1.0), (3, 3, 1.0)]),
                           (5.0, [(0, 0, 1.0), (1, 1, 1.0)])])
-def test_cosine_hungarian(tolerance, expected_pairs):
-    """Test finding expected peak matches for given tolerance."""
+def test_cosine_hungarian(shift, expected_pairs):
+    """Test finding expected peak matches for tolerance=0.2 and given shift."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     spec2 = numpy.array([[105, 205.1, 300, 500.1],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
-    matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=tolerance)
+    matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift)
     assert len(matching_pairs) == 2, "Expected different number of matching peaks"
     assert matching_pairs == expected_pairs, "Expected different matchin pairs."


### PR DESCRIPTION
Added tests on numba functions using ``.py_func`` to run them without compiling. This way they will also be covered according to Sonarcloud.