### PR TITLE
add ParentmassMatch similarity measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added similarity score based on comparing parent masses [#79](https://github.com/matchms/matchms/pull/79)
+
 ## [0.4.0] - 2020-06-11
 
 ### Added

--- a/matchms/similarity/ParentmassMatch.py
+++ b/matchms/similarity/ParentmassMatch.py
@@ -15,8 +15,8 @@ class ParentmassMatch:
 
     def __call__(self, spectrum: SpectrumType, reference_spectrum: SpectrumType) -> int:
         """Compare parent masses"""
-        parentmass = spectrum.get("parentmass")
-        parentmass_ref = reference_spectrum.get("parentmass")
+        parentmass = spectrum.get("parent_mass")
+        parentmass_ref = reference_spectrum.get("parent_mass")
         assert parentmass is not None and parentmass_ref is not None, "Missing parent mass."
         if abs(parentmass-parentmass_ref) <= self.tolerance:
             return 1

--- a/matchms/similarity/ParentmassMatch.py
+++ b/matchms/similarity/ParentmassMatch.py
@@ -13,7 +13,7 @@ class ParentmassMatch:
         """
         self.tolerance = tolerance
 
-    def __call__(self, spectrum: SpectrumType, reference_spectrum: SpectrumType) -> int:
+    def __call__(self, spectrum: SpectrumType, reference_spectrum: SpectrumType) -> bool:
         """Compare parent masses"""
         parentmass = spectrum.get("parent_mass")
         parentmass_ref = reference_spectrum.get("parent_mass")

--- a/matchms/similarity/ParentmassMatch.py
+++ b/matchms/similarity/ParentmassMatch.py
@@ -18,7 +18,4 @@ class ParentmassMatch:
         parentmass = spectrum.get("parent_mass")
         parentmass_ref = reference_spectrum.get("parent_mass")
         assert parentmass is not None and parentmass_ref is not None, "Missing parent mass."
-        if abs(parentmass-parentmass_ref) <= self.tolerance:
-            return 1
-
-        return 0
+        return abs(parentmass-parentmass_ref) <= self.tolerance

--- a/matchms/similarity/ParentmassMatch.py
+++ b/matchms/similarity/ParentmassMatch.py
@@ -4,9 +4,10 @@ from matchms.typing import SpectrumType
 class ParentmassMatch:
     """Return 1 if spectrums match in parent mass (within tolerance), and 0 otherwise."""
 
-    def __init__(self, tolerance: float = 0.1):
-        """Parameters:
-            ----------
+    def __init__(self, tolerance: float = 0.1) -> int:
+        """
+        Parameters:
+        ----------
         tolerance
             Specify tolerance below which two masses are counted as match.
         """

--- a/matchms/similarity/ParentmassMatch.py
+++ b/matchms/similarity/ParentmassMatch.py
@@ -1,0 +1,23 @@
+from matchms.typing import SpectrumType
+
+
+class ParentmassMatch:
+    """Return 1 if spectrums match in parent mass (within tolerance), and 0 otherwise."""
+
+    def __init__(self, tolerance: float = 0.1):
+        """Parameters:
+            ----------
+        tolerance
+            Specify tolerance below which two masses are counted as match.
+        """
+        self.tolerance = tolerance
+
+    def __call__(self, spectrum: SpectrumType, reference_spectrum: SpectrumType) -> float:
+        """Compare parent masses"""
+        parentmass = spectrum.get("parentmass")
+        parentmass_ref = reference_spectrum.get("parentmass")
+        assert parentmass is not None and parentmass_ref is not None, "Missing parent mass."
+        if abs(parentmass-parentmass_ref) <= self.tolerance:
+            return 1
+
+        return 0

--- a/matchms/similarity/ParentmassMatch.py
+++ b/matchms/similarity/ParentmassMatch.py
@@ -2,7 +2,7 @@ from matchms.typing import SpectrumType
 
 
 class ParentmassMatch:
-    """Return 1 if spectrums match in parent mass (within tolerance), and 0 otherwise."""
+    """Return True if spectrums match in parent mass (within tolerance), and False otherwise."""
 
     def __init__(self, tolerance: float = 0.1):
         """

--- a/matchms/similarity/ParentmassMatch.py
+++ b/matchms/similarity/ParentmassMatch.py
@@ -4,7 +4,7 @@ from matchms.typing import SpectrumType
 class ParentmassMatch:
     """Return 1 if spectrums match in parent mass (within tolerance), and 0 otherwise."""
 
-    def __init__(self, tolerance: float = 0.1) -> int:
+    def __init__(self, tolerance: float = 0.1):
         """
         Parameters:
         ----------
@@ -13,7 +13,7 @@ class ParentmassMatch:
         """
         self.tolerance = tolerance
 
-    def __call__(self, spectrum: SpectrumType, reference_spectrum: SpectrumType) -> float:
+    def __call__(self, spectrum: SpectrumType, reference_spectrum: SpectrumType) -> int:
         """Compare parent masses"""
         parentmass = spectrum.get("parentmass")
         parentmass_ref = reference_spectrum.get("parentmass")

--- a/matchms/similarity/ParentmassMatchParallel.py
+++ b/matchms/similarity/ParentmassMatchParallel.py
@@ -38,5 +38,5 @@ def calculate_parentmass_scores(parentmasses_ref, parentmasses_query, tolerance)
     scores = numpy.zeros((len(parentmasses_ref), len(parentmasses_query)))
     for i, parentmass_ref in enumerate(parentmasses_ref):
         for j, parentmass_query in enumerate(parentmasses_query):
-            scores[i, j] = 1 if (abs(parentmass_ref-parentmass_query) <= tolerance) else 0
+            scores[i, j] = (abs(parentmass_ref-parentmass_query) <= tolerance)
     return scores

--- a/matchms/similarity/ParentmassMatchParallel.py
+++ b/matchms/similarity/ParentmassMatchParallel.py
@@ -36,5 +36,5 @@ def calculate_parentmass_scores(parentmasses_ref, parentmasses_query, tolerance)
     scores = numpy.zeros((len(parentmasses_ref), len(parentmasses_query)))
     for i, parentmass_ref in enumerate(parentmasses_ref):
         for j, parentmass_query in enumerate(parentmasses_query):
-            scores[i,j] = 1 if (abs(parentmass_ref-parentmass_query) <= tolerance) else 0
+            scores[i, j] = 1 if (abs(parentmass_ref-parentmass_query) <= tolerance) else 0
     return scores

--- a/matchms/similarity/ParentmassMatchParallel.py
+++ b/matchms/similarity/ParentmassMatchParallel.py
@@ -23,7 +23,9 @@ class ParentmassMatchParallel:
             """Collect parentmasses."""
             parentmasses = []
             for spectrum in spectrums:
-                parentmasses.append(spectrum.get("parentmass"))
+                parentmass = spectrum.get("parent_mass")
+                assert parentmass is not None, "Missing parent mass."
+                parentmasses.append(parentmass)
             return numpy.asarray(parentmasses)
 
         parentmasses_ref = collect_parentmasses(reference_spectrums)

--- a/matchms/similarity/ParentmassMatchParallel.py
+++ b/matchms/similarity/ParentmassMatchParallel.py
@@ -1,0 +1,40 @@
+from typing import List
+import numba
+import numpy
+from matchms.typing import SpectrumType
+
+
+class ParentmassMatchParallel:
+    """Return 1 if spectrums match in parent mass (within tolerance), and 0 otherwise."""
+
+    def __init__(self, tolerance: float = 0.1):
+        """
+        Parameters:
+        ----------
+        tolerance
+            Specify tolerance below which two masses are counted as match.
+        """
+        self.tolerance = tolerance
+
+    def __call__(self, reference_spectrums: List[SpectrumType],
+                 spectrums: List[SpectrumType]) -> numpy.ndarray:
+        """Compare parent masses between all reference_spectrums and spectrums."""
+        def collect_parentmasses(spectrums):
+            """Collect parentmasses."""
+            parentmasses = []
+            for spectrum in spectrums:
+                parentmasses.append(spectrum.get("parentmass"))
+            return numpy.asarray(parentmasses)
+
+        parentmasses_ref = collect_parentmasses(reference_spectrums)
+        parentmasses_query = collect_parentmasses(spectrums)
+        return calculate_parentmass_scores(parentmasses_ref, parentmasses_query, self.tolerance)
+
+
+@numba.njit
+def calculate_parentmass_scores(parentmasses_ref, parentmasses_query, tolerance):
+    scores = numpy.zeros((len(parentmasses_ref), len(parentmasses_query)))
+    for i, parentmass_ref in enumerate(parentmasses_ref):
+        for j, parentmass_query in enumerate(parentmasses_query):
+            scores[i,j] = 1 if (abs(parentmass_ref-parentmass_query) <= tolerance) else 0
+    return scores

--- a/matchms/similarity/ParentmassMatchParallel.py
+++ b/matchms/similarity/ParentmassMatchParallel.py
@@ -5,7 +5,7 @@ from matchms.typing import SpectrumType
 
 
 class ParentmassMatchParallel:
-    """Return 1 if spectrums match in parent mass (within tolerance), and 0 otherwise."""
+    """Return True if spectrums match in parent mass (within tolerance), and False otherwise."""
 
     def __init__(self, tolerance: float = 0.1):
         """

--- a/matchms/similarity/__init__.py
+++ b/matchms/similarity/__init__.py
@@ -5,6 +5,7 @@ from .CosineHungarian import CosineHungarian
 from .FingerprintSimilarityParallel import FingerprintSimilarityParallel
 from .IntersectMz import IntersectMz
 from .ModifiedCosine import ModifiedCosine
+from .ParentmassMatch import ParentmassMatch
 
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "FingerprintSimilarityParallel",
     "IntersectMz",
     "ModifiedCosine",
+    "ParentmassMatch",
 ]

--- a/matchms/similarity/__init__.py
+++ b/matchms/similarity/__init__.py
@@ -6,6 +6,7 @@ from .FingerprintSimilarityParallel import FingerprintSimilarityParallel
 from .IntersectMz import IntersectMz
 from .ModifiedCosine import ModifiedCosine
 from .ParentmassMatch import ParentmassMatch
+from .ParentmassMatchParallel import ParentmassMatchParallel
 
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "IntersectMz",
     "ModifiedCosine",
     "ParentmassMatch",
+    "ParentmassMatchParallel",
 ]

--- a/tests/test_ParentmassMatch.py
+++ b/tests/test_ParentmassMatch.py
@@ -1,0 +1,53 @@
+import numpy
+import pytest
+from matchms import Spectrum
+from matchms.similarity import ParentmassMatch
+
+
+def test_parentmass_match():
+    "Test with default tolerance."
+    spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 100.0})
+
+    spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 101.0})
+
+    similarity_score = ParentmassMatch()
+    score = similarity_score(spectrum_1, spectrum_2)
+    assert score == 0, "Expected different score."
+
+
+def test_parentmass_match_tolerance2():
+    "Test with tolerance > difference."
+    spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 100.0})
+
+    spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 101.0})
+
+    similarity_score = ParentmassMatch(tolerance=2.0)
+    score = similarity_score(spectrum_1, spectrum_2)
+    assert score == 1, "Expected different score."
+
+
+def test_parentmass_match_missing_parentmass():
+    "Test with missing parentmass."
+    spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 100.0})
+
+    spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={})
+
+    similarity_score = ParentmassMatch(tolerance=2.0)
+
+    with pytest.raises(AssertionError) as msg:
+        _ = similarity_score(spectrum_1, spectrum_2)
+
+    expected_message_part = "Missing parent mass."
+    assert expected_message_part in str(msg.value), "Expected particular error message."

--- a/tests/test_ParentmassMatch.py
+++ b/tests/test_ParentmassMatch.py
@@ -31,7 +31,7 @@ def test_parentmass_match_tolerance2():
 
     similarity_score = ParentmassMatch(tolerance=2.0)
     score = similarity_score(spectrum_1, spectrum_2)
-    assert score == 1, "Expected different score."
+    assert score, "Expected different score."
 
 
 def test_parentmass_match_missing_parentmass():

--- a/tests/test_ParentmassMatch.py
+++ b/tests/test_ParentmassMatch.py
@@ -8,11 +8,11 @@ def test_parentmass_match():
     "Test with default tolerance."
     spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 100.0})
+                          metadata={"parent_mass": 100.0})
 
     spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 101.0})
+                          metadata={"parent_mass": 101.0})
 
     similarity_score = ParentmassMatch()
     score = similarity_score(spectrum_1, spectrum_2)
@@ -23,11 +23,11 @@ def test_parentmass_match_tolerance2():
     "Test with tolerance > difference."
     spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 100.0})
+                          metadata={"parent_mass": 100.0})
 
     spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 101.0})
+                          metadata={"parent_mass": 101.0})
 
     similarity_score = ParentmassMatch(tolerance=2.0)
     score = similarity_score(spectrum_1, spectrum_2)
@@ -38,7 +38,7 @@ def test_parentmass_match_missing_parentmass():
     "Test with missing parentmass."
     spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 100.0})
+                          metadata={"parent_mass": 100.0})
 
     spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),

--- a/tests/test_ParentmassMatch.py
+++ b/tests/test_ParentmassMatch.py
@@ -16,7 +16,7 @@ def test_parentmass_match():
 
     similarity_score = ParentmassMatch()
     score = similarity_score(spectrum_1, spectrum_2)
-    assert score == 0, "Expected different score."
+    assert not score, "Expected different score."
 
 
 def test_parentmass_match_tolerance2():

--- a/tests/test_ParentmassMatchParallel.py
+++ b/tests/test_ParentmassMatchParallel.py
@@ -49,8 +49,8 @@ def test_parentmass_match_tolerance2():
 
     similarity_score = ParentmassMatchParallel(tolerance=2.0)
     scores = similarity_score([spectrum_1, spectrum_2], [spectrum_a, spectrum_b])
-    assert numpy.all(scores == numpy.array([[1., 1.],
-                                            [1., 0.]])), "Expected different scores."
+    assert numpy.all(scores == numpy.array([[True, True],
+                                            [True, False]])), "Expected different scores."
 
 
 def test_calculate_parentmass_scores_compiled():

--- a/tests/test_ParentmassMatchParallel.py
+++ b/tests/test_ParentmassMatchParallel.py
@@ -9,19 +9,19 @@ def test_parentmass_match():
     "Test with default tolerance."
     spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 100.0})
+                          metadata={"parent_mass": 100.0})
 
     spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 101.0})
+                          metadata={"parent_mass": 101.0})
 
     spectrum_a = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 99.0})
+                          metadata={"parent_mass": 99.0})
 
     spectrum_b = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 98.0})
+                          metadata={"parent_mass": 98.0})
 
     similarity_score = ParentmassMatchParallel()
     scores = similarity_score([spectrum_1, spectrum_2], [spectrum_a, spectrum_b])
@@ -33,19 +33,19 @@ def test_parentmass_match_tolerance2():
     """Test with tolerance=2."""
     spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 100.0})
+                          metadata={"parent_mass": 100.0})
 
     spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 101.0})
+                          metadata={"parent_mass": 101.0})
 
     spectrum_a = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 99.0})
+                          metadata={"parent_mass": 99.0})
 
     spectrum_b = Spectrum(mz=numpy.array([], dtype="float"),
                           intensities=numpy.array([], dtype="float"),
-                          metadata={"parentmass": 98.0})
+                          metadata={"parent_mass": 98.0})
 
     similarity_score = ParentmassMatchParallel(tolerance=2.0)
     scores = similarity_score([spectrum_1, spectrum_2], [spectrum_a, spectrum_b])

--- a/tests/test_ParentmassMatchParallel.py
+++ b/tests/test_ParentmassMatchParallel.py
@@ -1,0 +1,49 @@
+import numpy
+from matchms import Spectrum
+from matchms.similarity import ParentmassMatchParallel
+
+
+def test_parentmass_match():
+    "Test with default tolerance."
+    spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 100.0})
+
+    spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 101.0})
+
+    spectrum_a = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 99.0})
+
+    spectrum_b = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 98.0})
+
+    similarity_score = ParentmassMatchParallel()
+    scores = similarity_score([spectrum_1, spectrum_2], [spectrum_a, spectrum_b])
+    assert numpy.all(scores == numpy.array([[0., 0.], [0., 0.]])), "Expected different score."
+
+
+def test_parentmass_match_tolerance2():
+    """Test with tolerance=2."""
+    spectrum_1 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 100.0})
+
+    spectrum_2 = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 101.0})
+
+    spectrum_a = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 99.0})
+
+    spectrum_b = Spectrum(mz=numpy.array([], dtype="float"),
+                          intensities=numpy.array([], dtype="float"),
+                          metadata={"parentmass": 98.0})
+
+    similarity_score = ParentmassMatchParallel(tolerance=2.0)
+    scores = similarity_score([spectrum_1, spectrum_2], [spectrum_a, spectrum_b])
+    assert numpy.all(scores == numpy.array([[1., 1.], [1., 0.]])), "Expected different score."

--- a/tests/test_ParentmassMatchParallel.py
+++ b/tests/test_ParentmassMatchParallel.py
@@ -1,6 +1,7 @@
 import numpy
 from matchms import Spectrum
 from matchms.similarity import ParentmassMatchParallel
+from matchms.similarity.ParentmassMatchParallel import calculate_parentmass_scores
 
 
 def test_parentmass_match():
@@ -23,7 +24,8 @@ def test_parentmass_match():
 
     similarity_score = ParentmassMatchParallel()
     scores = similarity_score([spectrum_1, spectrum_2], [spectrum_a, spectrum_b])
-    assert numpy.all(scores == numpy.array([[0., 0.], [0., 0.]])), "Expected different score."
+    assert numpy.all(scores == numpy.array([[0., 0.],
+                                            [0., 0.]])), "Expected different scores."
 
 
 def test_parentmass_match_tolerance2():
@@ -46,4 +48,25 @@ def test_parentmass_match_tolerance2():
 
     similarity_score = ParentmassMatchParallel(tolerance=2.0)
     scores = similarity_score([spectrum_1, spectrum_2], [spectrum_a, spectrum_b])
-    assert numpy.all(scores == numpy.array([[1., 1.], [1., 0.]])), "Expected different score."
+    assert numpy.all(scores == numpy.array([[1., 1.],
+                                            [1., 0.]])), "Expected different scores."
+
+
+def test_calculate_parentmass_scores_compiled():
+    """Test the underlying score function (numba compiled)."""
+    parentmasses_ref = numpy.asarray([101, 200, 300])
+    parentmasses_query = numpy.asarray([100, 301])
+    scores = calculate_parentmass_scores(parentmasses_ref, parentmasses_query, tolerance=2.0)
+    assert numpy.all(scores == numpy.array([[1., 0.],
+                                            [0., 0.],
+                                            [0., 1.]])), "Expected different scores."
+
+
+def test_calculate_parentmass_scores():
+    """Test the underlying score function (non-compiled)."""
+    parentmasses_ref = numpy.asarray([101, 200, 300])
+    parentmasses_query = numpy.asarray([100, 301])
+    scores = calculate_parentmass_scores.py_func(parentmasses_ref, parentmasses_query, tolerance=2.0)
+    assert numpy.all(scores == numpy.array([[1., 0.],
+                                            [0., 0.],
+                                            [0., 1.]])), "Expected different scores."

--- a/tests/test_ParentmassMatchParallel.py
+++ b/tests/test_ParentmassMatchParallel.py
@@ -68,6 +68,6 @@ def test_calculate_parentmass_scores():
     parentmasses_ref = numpy.asarray([101, 200, 300])
     parentmasses_query = numpy.asarray([100, 301])
     scores = calculate_parentmass_scores.py_func(parentmasses_ref, parentmasses_query, tolerance=2.0)
-    assert numpy.all(scores == numpy.array([[1., 0.],
-                                            [0., 0.],
-                                            [0., 1.]])), "Expected different scores."
+    assert numpy.all(scores == numpy.array([[True, False],
+                                            [False, False],
+                                            [False, True]])), "Expected different scores."

--- a/tests/test_ParentmassMatchParallel.py
+++ b/tests/test_ParentmassMatchParallel.py
@@ -25,8 +25,8 @@ def test_parentmass_match():
 
     similarity_score = ParentmassMatchParallel()
     scores = similarity_score([spectrum_1, spectrum_2], [spectrum_a, spectrum_b])
-    assert numpy.all(scores == numpy.array([[0., 0.],
-                                            [0., 0.]])), "Expected different scores."
+    assert numpy.all(scores == numpy.array([[False, False],
+                                            [False, False]])), "Expected different scores."
 
 
 def test_parentmass_match_tolerance2():

--- a/tests/test_ParentmassMatchParallel.py
+++ b/tests/test_ParentmassMatchParallel.py
@@ -1,7 +1,8 @@
 import numpy
 from matchms import Spectrum
 from matchms.similarity import ParentmassMatchParallel
-from matchms.similarity.ParentmassMatchParallel import calculate_parentmass_scores
+from matchms.similarity.ParentmassMatchParallel import \
+    calculate_parentmass_scores
 
 
 def test_parentmass_match():


### PR DESCRIPTION
Add a simple measure to allow comparing spectra only based on their parent mass.
A typical use-case for this would be library matching.
- ``ParentmassMatch`` and ``ParentmassMatchParallel``:
Will return ``True`` if parent masses match (within tolerance), and ``False`` otherwise.