### PR TITLE
Creating spectrum from metabolomics USI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added similarity score based on comparing parent masses [#79](https://github.com/matchms/matchms/pull/79)
+- Added a method for instantiating a spectrum from the metabolomics USI 
 
 ## [0.4.0] - 2020-06-11
 

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy
   - pip
   - pyteomics >=4.2
+  - requests
   - python >=3.7,<3.8
   - pyyaml
   - rdkit >=2020.03.1

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - numba >=0.47
   - numpy
   - pyteomics >=4.2
+  - requests
   - python >=3.7,<3.8
   - pyyaml
   - rdkit >=2020.03.1

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - numpy
     - pip
     - pyteomics >=4.2
+    - requests
     - python >=3.7,<3.8
     - pyyaml
     - rdkit >=2020.03.1

--- a/matchms/importing/load_from_usi.py
+++ b/matchms/importing/load_from_usi.py
@@ -1,0 +1,40 @@
+from typing import Optional
+import requests
+import numpy as np
+from matchms import Spectrum
+
+def load_from_usi(usi: str ,server = 'https://metabolomics-usi.ucsd.edu'):
+    """Load spectrum from metabolomics USI.
+
+USI returns JSON data with keys 'peaks', 'n_peaks' and 'precuror_mz'
+
+    Args:
+    ----
+    usi: str
+        Provide the usi.
+
+    server: string
+        USI server
+    """
+
+    # create the url
+    url = server + '/json/?usi=' + usi
+    metadata = {'usi':usi, 'server': server}
+    response = requests.get(url)
+
+    # extract data and create Spectrum object
+    try:
+        spectral_data = response.json()
+        peaks = spectral_data['peaks']
+        mz_list,intensity_list = zip(*peaks)
+        mz_array = np.array(mz_list)
+        intensity_array = np.array(intensity_list)
+
+        metadata['precursor_mz'] = spectral_data.get('precursor_mz',None)
+
+        s = Spectrum(mz_array,intensity_array,metadata)
+
+        return s
+    except:
+        # failed
+        return None

--- a/matchms/importing/load_from_usi.py
+++ b/matchms/importing/load_from_usi.py
@@ -1,9 +1,9 @@
-from typing import Optional
 import requests
 import numpy as np
 from matchms import Spectrum
 
-def load_from_usi(usi: str ,server = 'https://metabolomics-usi.ucsd.edu'):
+
+def load_from_usi(usi: str, server = 'https://metabolomics-usi.ucsd.edu'):
     """Load spectrum from metabolomics USI.
 
 USI returns JSON data with keys 'peaks', 'n_peaks' and 'precuror_mz'
@@ -19,7 +19,7 @@ USI returns JSON data with keys 'peaks', 'n_peaks' and 'precuror_mz'
 
     # create the url
     url = server + '/json/?usi=' + usi
-    metadata = {'usi':usi, 'server': server}
+    metadata = {'usi': usi, 'server': server}
     response = requests.get(url)
 
     # extract data and create Spectrum object
@@ -32,9 +32,9 @@ USI returns JSON data with keys 'peaks', 'n_peaks' and 'precuror_mz'
 
         metadata['precursor_mz'] = spectral_data.get('precursor_mz',None)
 
-        s = Spectrum(mz_array,intensity_array,metadata)
+        s = Spectrum(mz_array, intensity_array, metadata)
 
         return s
     except:
-        # failed
+        # failed to unpack json
         return None

--- a/matchms/importing/load_from_usi.py
+++ b/matchms/importing/load_from_usi.py
@@ -1,9 +1,10 @@
 import requests
 import numpy as np
+import json
 from matchms import Spectrum
 
 
-def load_from_usi(usi: str, server = 'https://metabolomics-usi.ucsd.edu'):
+def load_from_usi(usi: str, server='https://metabolomics-usi.ucsd.edu'):
     """Load spectrum from metabolomics USI.
 
 USI returns JSON data with keys 'peaks', 'n_peaks' and 'precuror_mz'
@@ -17,24 +18,25 @@ USI returns JSON data with keys 'peaks', 'n_peaks' and 'precuror_mz'
         USI server
     """
 
-    # create the url
+    # Create the url
     url = server + '/json/?usi=' + usi
     metadata = {'usi': usi, 'server': server}
     response = requests.get(url)
 
-    # extract data and create Spectrum object
+    # Extract data and create Spectrum object
     try:
         spectral_data = response.json()
         peaks = spectral_data['peaks']
-        mz_list,intensity_list = zip(*peaks)
+        mz_list, intensity_list = zip(*peaks)
         mz_array = np.array(mz_list)
         intensity_array = np.array(intensity_list)
 
-        metadata['precursor_mz'] = spectral_data.get('precursor_mz',None)
+        metadata['precursor_mz'] = spectral_data.get('precursor_mz', None)
 
         s = Spectrum(mz_array, intensity_array, metadata)
 
         return s
-    except:
+        
+    except json.decoder.JSONDecodeError:
         # failed to unpack json
         return None

--- a/matchms/importing/load_from_usi.py
+++ b/matchms/importing/load_from_usi.py
@@ -23,10 +23,16 @@ USI returns JSON data with keys 'peaks', 'n_peaks' and 'precuror_mz'
     metadata = {'usi': usi, 'server': server}
     response = requests.get(url)
 
+    if response.statuscode == 404:
+        return None
     # Extract data and create Spectrum object
     try:
         spectral_data = response.json()
+        if spectral_data is None or not 'peaks' in spectral_data:
+            return None
         peaks = spectral_data['peaks']
+        if len(peaks) == 0:
+            return None
         mz_list, intensity_list = zip(*peaks)
         mz_array = np.array(mz_list)
         intensity_array = np.array(intensity_list)

--- a/matchms/importing/load_from_usi.py
+++ b/matchms/importing/load_from_usi.py
@@ -36,7 +36,7 @@ USI returns JSON data with keys 'peaks', 'n_peaks' and 'precuror_mz'
         s = Spectrum(mz_array, intensity_array, metadata)
 
         return s
-        
+
     except json.decoder.JSONDecodeError:
         # failed to unpack json
         return None

--- a/matchms/importing/load_from_usi.py
+++ b/matchms/importing/load_from_usi.py
@@ -1,6 +1,6 @@
-import requests
-import numpy as np
 import json
+import numpy as np
+import requests
 from matchms import Spectrum
 
 

--- a/matchms/importing/load_from_usi.py
+++ b/matchms/importing/load_from_usi.py
@@ -28,7 +28,7 @@ USI returns JSON data with keys 'peaks', 'n_peaks' and 'precuror_mz'
     # Extract data and create Spectrum object
     try:
         spectral_data = response.json()
-        if spectral_data is None or not 'peaks' in spectral_data:
+        if spectral_data is None or 'peaks' not in spectral_data:
             return None
         peaks = spectral_data['peaks']
         if len(peaks) == 0:

--- a/tests/test_usi.py
+++ b/tests/test_usi.py
@@ -7,10 +7,10 @@ from matchms.importing.load_from_usi import load_from_usi
 @patch('matchms.importing.load_from_usi.requests.get')
 def normal_test(mock_get):
     mock_get.return_value = Mock(ok=True)
-    mock_get.return_value.json.return_value = {'peaks': [[1., 2.],[3., 4.]]}
+    mock_get.return_value.json.return_value = {'peaks': [[1., 2.], [3., 4.]]}
     spec = load_from_usi('something')
     expected_metadata = {'usi': 'something', 'url': 'https://metabolomics-usi.ucsd.edu/json/?usi=something', 'precursor_mz': None}
-    expected = Spectrum(np.array([1.,3.]),np.array([2.,4.]),expected_metadata)
+    expected = Spectrum(np.array([1., 3.]), np.array([2., 4.]), expected_metadata)
     assert spec == expected
 
 

--- a/tests/test_usi.py
+++ b/tests/test_usi.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+from unittest.mock import patch
 import numpy as np
 from matchms import Spectrum
 from matchms.importing.load_from_usi import load_from_usi

--- a/tests/test_usi.py
+++ b/tests/test_usi.py
@@ -4,38 +4,27 @@ from matchms import Spectrum
 from matchms.importing.load_from_usi import load_from_usi
 
 
-
 @patch('matchms.importing.load_from_usi.requests.get')
 def normal_test(mock_get):
-  mock_get.return_value = Mock(ok=True)
-  mock_get.return_value.json.return_value = {'peaks':[[1.,2.],[3.,4.]]}
-
-  spec = load_from_usi('something')
-  
-  
-  expected = Spectrum(np.array([1.,3.]),np.array([2.,4.]),spec._metadata)
-  assert spec == expected
+    mock_get.return_value = Mock(ok=True)
+    mock_get.return_value.json.return_value = {'peaks':[[1.,2.],[3.,4.]]}
+    spec = load_from_usi('something')
+    expected = Spectrum(np.array([1.,3. ]),np.array([2.,4.]),spec._metadata)
+    assert spec == expected
 
 @patch('matchms.importing.load_from_usi.requests.get')
 def test_404(mock_get):
-	mock_get.return_value = Mock(ok=True)
-	mock_get.return_value.status_code = 404
-	mock_get.return_value.json.return_value = None
-
-	spec = load_from_usi('something')
-	expected = None
-
-	assert spec == expected
+    mock_get.return_value = Mock(ok=True)
+    mock_get.return_value.status_code = 404
+    mock_get.return_value.json.return_value = None
+    spec = load_from_usi('something')
+    expected = None
+    assert spec == expected
 
 @patch('matchms.importing.load_from_usi.requests.get')
 def test_no_peaks(mock_get):
-	mock_get.return_value = Mock(ok=True)
-	mock_get.return_value.json.return_value = {'peaks':[]}
-
-	spec = load_from_usi('something')
-	expected = None
-
-	assert spec == expected
-
-
-  
+    mock_get.return_value = Mock(ok=True)
+    mock_get.return_value.json.return_value = {'peaks':[]}
+    spec = load_from_usi('something')
+    expected = None
+    assert spec == expected

--- a/tests/test_usi.py
+++ b/tests/test_usi.py
@@ -1,0 +1,41 @@
+from unittest.mock import Mock, patch
+import numpy as np
+from matchms import Spectrum
+from matchms.importing.load_from_usi import load_from_usi
+
+
+
+@patch('matchms.importing.load_from_usi.requests.get')
+def normal_test(mock_get):
+  mock_get.return_value = Mock(ok=True)
+  mock_get.return_value.json.return_value = {'peaks':[[1.,2.],[3.,4.]]}
+
+  spec = load_from_usi('something')
+  
+  
+  expected = Spectrum(np.array([1.,3.]),np.array([2.,4.]),spec._metadata)
+  assert spec == expected
+
+@patch('matchms.importing.load_from_usi.requests.get')
+def test_404(mock_get):
+	mock_get.return_value = Mock(ok=True)
+	mock_get.return_value.status_code = 404
+	mock_get.return_value.json.return_value = None
+
+	spec = load_from_usi('something')
+	expected = None
+
+	assert spec == expected
+
+@patch('matchms.importing.load_from_usi.requests.get')
+def test_no_peaks(mock_get):
+	mock_get.return_value = Mock(ok=True)
+	mock_get.return_value.json.return_value = {'peaks':[]}
+
+	spec = load_from_usi('something')
+	expected = None
+
+	assert spec == expected
+
+
+  

--- a/tests/test_usi.py
+++ b/tests/test_usi.py
@@ -7,9 +7,10 @@ from matchms.importing.load_from_usi import load_from_usi
 @patch('matchms.importing.load_from_usi.requests.get')
 def normal_test(mock_get):
     mock_get.return_value = Mock(ok=True)
-    mock_get.return_value.json.return_value = {'peaks':[[1.,2.],[3.,4.]]}
+    mock_get.return_value.json.return_value = {'peaks': [[1.,2.],[3.,4.]]}
     spec = load_from_usi('something')
-    expected = Spectrum(np.array([1.,3. ]),np.array([2.,4.]),spec._metadata)
+    expected_metadata = {'usi': 'something', 'url': 'https://metabolomics-usi.ucsd.edu/json/?usi=something', 'precursor_mz': None}
+    expected = Spectrum(np.array([1.,3. ]),np.array([2.,4.]),expected_metadata)
     assert spec == expected
 
 @patch('matchms.importing.load_from_usi.requests.get')
@@ -24,7 +25,7 @@ def test_404(mock_get):
 @patch('matchms.importing.load_from_usi.requests.get')
 def test_no_peaks(mock_get):
     mock_get.return_value = Mock(ok=True)
-    mock_get.return_value.json.return_value = {'peaks':[]}
+    mock_get.return_value.json.return_value = {'peaks': []}
     spec = load_from_usi('something')
     expected = None
     assert spec == expected

--- a/tests/test_usi.py
+++ b/tests/test_usi.py
@@ -7,11 +7,12 @@ from matchms.importing.load_from_usi import load_from_usi
 @patch('matchms.importing.load_from_usi.requests.get')
 def normal_test(mock_get):
     mock_get.return_value = Mock(ok=True)
-    mock_get.return_value.json.return_value = {'peaks': [[1.,2.],[3.,4.]]}
+    mock_get.return_value.json.return_value = {'peaks': [[1., 2.],[3., 4.]]}
     spec = load_from_usi('something')
     expected_metadata = {'usi': 'something', 'url': 'https://metabolomics-usi.ucsd.edu/json/?usi=something', 'precursor_mz': None}
-    expected = Spectrum(np.array([1.,3. ]),np.array([2.,4.]),expected_metadata)
+    expected = Spectrum(np.array([1.,3.]),np.array([2.,4.]),expected_metadata)
     assert spec == expected
+
 
 @patch('matchms.importing.load_from_usi.requests.get')
 def test_404(mock_get):
@@ -21,6 +22,7 @@ def test_404(mock_get):
     spec = load_from_usi('something')
     expected = None
     assert spec == expected
+
 
 @patch('matchms.importing.load_from_usi.requests.get')
 def test_no_peaks(mock_get):


### PR DESCRIPTION
Added a new method to allow a `Spectrum` object to be created from the json returned in a post request from the  metabolomics USI (https://metabolomics-usi.ucsd.edu).
The USI provides a single access point for a large number of metabolomics MS2 data resources including both experimental and library spectra.