### PR TITLE
Improve cosine score performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Small performance improvement in  CosineGreedy [#159](https://github.com/matchms/matchms/pull/159)
+- Considerable performance improvement for CosineGreedy and CosineHungarian [#159](https://github.com/matchms/matchms/pull/159)
 
 ## [0.6.1] - 2020-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Small performance improvement in  CosineGreedy [#159](https://github.com/matchms/matchms/pull/159)
+
 ## [0.6.1] - 2020-11-26
 
 ### Added

--- a/conda/environment-dev.yml
+++ b/conda/environment-dev.yml
@@ -13,6 +13,6 @@ dependencies:
   - python >=3.7,<3.9
   - pyyaml
   - rdkit >=2020.03.1
-  - scipy
+  - scipy >=1.4.0
   - pip:
     - -e ..[dev]

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - python >=3.7,<3.9
   - pyyaml
   - rdkit >=2020.03.1
-  - scipy
+  - scipy >=1.4.0

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - python >=3.7,<3.9
     - pyyaml
     - rdkit >=2020.03.1
-    - scipy
+    - scipy >=1.4.0
 
 test:
   imports:

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -181,7 +181,7 @@ class Scores:
             scores = Scores(references, queries, CosineGreedy()).calculate()
             selected_scores = scores.scores_by_query(spectrum_4)
             selected_scores.sort(key=lambda s: s[1], reverse=True)
-            print([x[1].round(3) for x in selected_scores])
+            print([np.round(x[1], 3) for x in selected_scores])
 
         Should output
 

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+import numpy
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
 from .spectrum_similarity_functions import collect_peak_pairs

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -87,11 +87,11 @@ class CosineGreedy(BaseSimilarity):
             matching_pairs = collect_peak_pairs(spec1, spec2, self.tolerance,
                                                 shift=0.0, mz_power=self.mz_power,
                                                 intensity_power=self.intensity_power)
-            if matching_pairs is not None:
-                matching_pairs = numpy.array(matching_pairs)
-                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
-                return matching_pairs
-            return None
+            if matching_pairs is None:
+                return None
+            matching_pairs = numpy.array(matching_pairs)
+            matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
+            return matching_pairs
 
         spec1 = get_peaks_array(reference)
         spec2 = get_peaks_array(query)

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -86,7 +86,8 @@ class CosineGreedy(BaseSimilarity):
             matching_pairs = collect_peak_pairs(spec1, spec2, self.tolerance, shift=0.0,
                                                 mz_power=self.mz_power,
                                                 intensity_power=self.intensity_power)
-            matching_pairs = sorted(matching_pairs, key=lambda x: x[2], reverse=True)
+            if matching_pairs.shape[0] > 0:
+                matching_pairs = matching_pairs[np.argsort(matching_pairs[:,2])[::-1], :]
             return matching_pairs
 
         spec1 = get_peaks_array(reference)

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -94,5 +94,7 @@ class CosineGreedy(BaseSimilarity):
         spec1 = get_peaks_array(reference)
         spec2 = get_peaks_array(query)
         matching_pairs = get_matching_pairs()
-        return score_best_matches(matching_pairs, spec1, spec2,
-                                  self.mz_power, self.intensity_power)
+        if matching_pairs.shape[0] > 0:
+            return score_best_matches(matching_pairs, spec1, spec2,
+                                      self.mz_power, self.intensity_power)
+        return float(0), 0

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -87,7 +87,7 @@ class CosineGreedy(BaseSimilarity):
                                                 mz_power=self.mz_power,
                                                 intensity_power=self.intensity_power)
             if matching_pairs.shape[0] > 0:
-                matching_pairs = matching_pairs[np.argsort(matching_pairs[:,2])[::-1], :]
+                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:,2])[::-1], :]
             return matching_pairs
 
         spec1 = get_peaks_array(reference)

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -84,17 +84,19 @@ class CosineGreedy(BaseSimilarity):
         """
         def get_matching_pairs():
             """Get pairs of peaks that match within the given tolerance."""
-            matching_pairs = collect_peak_pairs(spec1, spec2, self.tolerance, shift=0.0,
-                                                mz_power=self.mz_power,
+            matching_pairs = collect_peak_pairs(spec1, spec2, self.tolerance,
+                                                shift=0.0, mz_power=self.mz_power,
                                                 intensity_power=self.intensity_power)
-            if matching_pairs.shape[0] > 0:
-                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
-            return matching_pairs
+            if matching_pairs is not None:
+                matching_pairs = numpy.array(matching_pairs)
+                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:,2])[::-1], :]
+                return matching_pairs
+            return None
 
         spec1 = get_peaks_array(reference)
         spec2 = get_peaks_array(query)
         matching_pairs = get_matching_pairs()
-        if matching_pairs.shape[0] > 0:
+        if matching_pairs is not None:
             return score_best_matches(matching_pairs, spec1, spec2,
                                       self.mz_power, self.intensity_power)
         return float(0), 0

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -87,7 +87,7 @@ class CosineGreedy(BaseSimilarity):
                                                 mz_power=self.mz_power,
                                                 intensity_power=self.intensity_power)
             if matching_pairs.shape[0] > 0:
-                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:,2])[::-1], :]
+                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
             return matching_pairs
 
         spec1 = get_peaks_array(reference)

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -89,7 +89,6 @@ class CosineGreedy(BaseSimilarity):
                                                 intensity_power=self.intensity_power)
             if matching_pairs is None:
                 return None
-            matching_pairs = numpy.array(matching_pairs)
             matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
             return matching_pairs
 

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -89,7 +89,7 @@ class CosineGreedy(BaseSimilarity):
                                                 intensity_power=self.intensity_power)
             if matching_pairs is not None:
                 matching_pairs = numpy.array(matching_pairs)
-                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:,2])[::-1], :]
+                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
                 return matching_pairs
             return None
 

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -58,7 +58,7 @@ class CosineHungarian(BaseSimilarity):
                                                 intensity_power=self.intensity_power)
             if matching_pairs is not None:
                 matching_pairs = numpy.array(matching_pairs)
-                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:,2])[::-1], :]
+                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
                 return matching_pairs
             return None
 

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -58,7 +58,6 @@ class CosineHungarian(BaseSimilarity):
                                                 intensity_power=self.intensity_power)
             if matching_pairs is None:
                 return None
-            matching_pairs = numpy.array(matching_pairs)
             matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
             return matching_pairs
 

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -104,7 +104,6 @@ class CosineHungarian(BaseSimilarity):
             score = score/(numpy.sqrt(numpy.sum(spec1_power**2)) * numpy.sqrt(numpy.sum(spec2_power**2)))
             return score, len(used_matches)
 
-
         spec1 = get_peaks_array(reference)
         spec2 = get_peaks_array(query)
         matching_pairs = get_matching_pairs()

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -56,7 +56,9 @@ class CosineHungarian(BaseSimilarity):
             matching_pairs = collect_peak_pairs(spec1, spec2, self.tolerance, shift=0.0,
                                                 mz_power=self.mz_power,
                                                 intensity_power=self.intensity_power)
-            return sorted(matching_pairs, key=lambda x: x[2], reverse=True)
+            if matching_pairs.shape[0] > 0:
+                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
+            return matching_pairs
 
         def get_matching_pairs_matrix():
             """Create matrix of multiplied intensities of all matching pairs
@@ -69,15 +71,15 @@ class CosineHungarian(BaseSimilarity):
             matching_pairs_matrix:
                 Array of multiplied intensities between all matching peaks.
             """
-            if len(matching_pairs) == 0:
+            if matching_pairs.shape[0] == 0:
                 return None, None, None
-            paired_peaks1 = list({x[0] for x in matching_pairs})
-            paired_peaks2 = list({x[1] for x in matching_pairs})
+            paired_peaks1 = list({x for x in matching_pairs[:, 0]})
+            paired_peaks2 = list({x for x in matching_pairs[:, 1]})
             matrix_size = (len(paired_peaks1), len(paired_peaks2))
             matching_pairs_matrix = numpy.ones(matrix_size)
-            for match in matching_pairs:
-                matching_pairs_matrix[paired_peaks1.index(match[0]),
-                                      paired_peaks2.index(match[1])] = 1 - match[2]
+            for i in range(matching_pairs.shape[0]):
+                matching_pairs_matrix[paired_peaks1.index(matching_pairs[i, 0]),
+                                      paired_peaks2.index(matching_pairs[i, 1])] = 1 - matching_pairs[i, 2]
             return paired_peaks1, paired_peaks2, matching_pairs_matrix
 
         def solve_hungarian():

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -73,8 +73,8 @@ class CosineHungarian(BaseSimilarity):
             """
             if matching_pairs.shape[0] == 0:
                 return None, None, None
-            paired_peaks1 = list({x for x in matching_pairs[:, 0]})
-            paired_peaks2 = list({x for x in matching_pairs[:, 1]})
+            paired_peaks1 = list(set(matching_pairs[:, 0]))
+            paired_peaks2 = list(set(matching_pairs[:, 1]))
             matrix_size = (len(paired_peaks1), len(paired_peaks2))
             matching_pairs_matrix = numpy.ones(matrix_size)
             for i in range(matching_pairs.shape[0]):

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -56,11 +56,11 @@ class CosineHungarian(BaseSimilarity):
             matching_pairs = collect_peak_pairs(spec1, spec2, self.tolerance, shift=0.0,
                                                 mz_power=self.mz_power,
                                                 intensity_power=self.intensity_power)
-            if matching_pairs is not None:
-                matching_pairs = numpy.array(matching_pairs)
-                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
-                return matching_pairs
-            return None
+            if matching_pairs is None:
+                return None
+            matching_pairs = numpy.array(matching_pairs)
+            matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
+            return matching_pairs
 
         def get_matching_pairs_matrix():
             """Create matrix of multiplied intensities of all matching pairs
@@ -85,7 +85,7 @@ class CosineHungarian(BaseSimilarity):
             return paired_peaks1, paired_peaks2, matching_pairs_matrix
 
         def solve_hungarian():
-            """Use hungarian agorithm to solve the linear sum assignment problem."""
+            """Use hungarian algorithm to solve the linear sum assignment problem."""
             row_ind, col_ind = linear_sum_assignment(matching_pairs_matrix)
             score = len(row_ind) - matching_pairs_matrix[row_ind, col_ind].sum()
             used_matches = [(paired_peaks1[x], paired_peaks2[y]) for (x, y) in zip(row_ind, col_ind)]
@@ -93,16 +93,17 @@ class CosineHungarian(BaseSimilarity):
 
         def calc_score():
             """Calculate cosine similarity score."""
-            if matching_pairs_matrix is not None:
-                score, used_matches = solve_hungarian()
-                # Normalize score:
-                spec1_power = numpy.power(spec1[:, 0], self.mz_power) \
-                    * numpy.power(spec1[:, 1], self.intensity_power)
-                spec2_power = numpy.power(spec2[:, 0], self.mz_power) \
-                    * numpy.power(spec2[:, 1], self.intensity_power)
-                score = score/(numpy.sqrt(numpy.sum(spec1_power**2)) * numpy.sqrt(numpy.sum(spec2_power**2)))
-                return score, len(used_matches)
-            return 0.0, 0
+            if matching_pairs_matrix is None:
+                return 0.0, 0
+            score, used_matches = solve_hungarian()
+            # Normalize score:
+            spec1_power = numpy.power(spec1[:, 0], self.mz_power) \
+                * numpy.power(spec1[:, 1], self.intensity_power)
+            spec2_power = numpy.power(spec2[:, 0], self.mz_power) \
+                * numpy.power(spec2[:, 1], self.intensity_power)
+            score = score/(numpy.sqrt(numpy.sum(spec1_power**2)) * numpy.sqrt(numpy.sum(spec2_power**2)))
+            return score, len(used_matches)
+
 
         spec1 = get_peaks_array(reference)
         spec2 = get_peaks_array(query)

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -56,9 +56,11 @@ class CosineHungarian(BaseSimilarity):
             matching_pairs = collect_peak_pairs(spec1, spec2, self.tolerance, shift=0.0,
                                                 mz_power=self.mz_power,
                                                 intensity_power=self.intensity_power)
-            if matching_pairs.shape[0] > 0:
-                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
-            return matching_pairs
+            if matching_pairs is not None:
+                matching_pairs = numpy.array(matching_pairs)
+                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:,2])[::-1], :]
+                return matching_pairs
+            return None
 
         def get_matching_pairs_matrix():
             """Create matrix of multiplied intensities of all matching pairs
@@ -71,7 +73,7 @@ class CosineHungarian(BaseSimilarity):
             matching_pairs_matrix:
                 Array of multiplied intensities between all matching peaks.
             """
-            if matching_pairs.shape[0] == 0:
+            if matching_pairs is None:
                 return None, None, None
             paired_peaks1 = list(set(matching_pairs[:, 0]))
             paired_peaks2 = list(set(matching_pairs[:, 1]))

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -96,9 +96,9 @@ class ModifiedCosine(BaseSimilarity):
                                                intensity_power=self.intensity_power)
 
             if zero_pairs.shape[1] != 3:
-                zero_pairs = numpy.zeros((0,3))
+                zero_pairs = numpy.zeros((0, 3))
             if nonzero_pairs.shape[1] != 3:
-                nonzero_pairs = numpy.zeros((0,3))
+                nonzero_pairs = numpy.zeros((0, 3))
             matching_pairs = numpy.concatenate((zero_pairs, nonzero_pairs), axis=0)
             if matching_pairs.shape[0] > 0:
                 matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -93,8 +93,15 @@ class ModifiedCosine(BaseSimilarity):
             nonzero_pairs = collect_peak_pairs(spec1, spec2, self.tolerance, shift=mass_shift,
                                                mz_power=self.mz_power,
                                                intensity_power=self.intensity_power)
-            unsorted_matching_pairs = zero_pairs + nonzero_pairs
-            return sorted(unsorted_matching_pairs, key=lambda x: x[2], reverse=True)
+
+            if zero_pairs.shape[1] != 3:
+                zero_pairs = np.zeros((0,3))
+            if nonzero_pairs.shape[1] != 3:
+                nonzero_pairs = np.zeros((0,3))
+            matching_pairs = np.concatenate((zero_pairs, npnzero_pairs), axis=0)
+            if matching_pairs.shape[0] > 0:
+                matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
+            return matching_pairs
 
         spec1 = get_peaks_array(reference)
         spec2 = get_peaks_array(query)

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -98,7 +98,7 @@ class ModifiedCosine(BaseSimilarity):
                 zero_pairs = np.zeros((0,3))
             if nonzero_pairs.shape[1] != 3:
                 nonzero_pairs = np.zeros((0,3))
-            matching_pairs = np.concatenate((zero_pairs, npnzero_pairs), axis=0)
+            matching_pairs = numpy.concatenate((zero_pairs, npnzero_pairs), axis=0)
             if matching_pairs.shape[0] > 0:
                 matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
             return matching_pairs

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -107,7 +107,7 @@ class ModifiedCosine(BaseSimilarity):
         spec1 = get_peaks_array(reference)
         spec2 = get_peaks_array(query)
         matching_pairs = get_matching_pairs()
-        if matching_pairs.shape[0] > 0:
-            return score_best_matches(matching_pairs, spec1, spec2,
-                                      self.mz_power, self.intensity_power)
-        return float(0), 0
+        if matching_pairs.shape[0] == 0:
+            return float(0), 0
+        return score_best_matches(matching_pairs, spec1, spec2,
+                                  self.mz_power, self.intensity_power)

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -107,5 +107,7 @@ class ModifiedCosine(BaseSimilarity):
         spec1 = get_peaks_array(reference)
         spec2 = get_peaks_array(query)
         matching_pairs = get_matching_pairs()
-        return score_best_matches(matching_pairs, spec1, spec2,
-                                  self.mz_power, self.intensity_power)
+       if matching_pairs.shape[0] > 0:
+            return score_best_matches(matching_pairs, spec1, spec2,
+                                      self.mz_power, self.intensity_power)
+        return float(0), 0

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+import numpy
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
 from .spectrum_similarity_functions import collect_peak_pairs
@@ -95,9 +96,9 @@ class ModifiedCosine(BaseSimilarity):
                                                intensity_power=self.intensity_power)
 
             if zero_pairs.shape[1] != 3:
-                zero_pairs = np.zeros((0,3))
+                zero_pairs = numpy.zeros((0,3))
             if nonzero_pairs.shape[1] != 3:
-                nonzero_pairs = np.zeros((0,3))
+                nonzero_pairs = numpy.zeros((0,3))
             matching_pairs = numpy.concatenate((zero_pairs, npnzero_pairs), axis=0)
             if matching_pairs.shape[0] > 0:
                 matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -95,9 +95,9 @@ class ModifiedCosine(BaseSimilarity):
                                                mz_power=self.mz_power,
                                                intensity_power=self.intensity_power)
 
-            if zero_pairs.shape[1] != 3:
+            if zero_pairs is None:
                 zero_pairs = numpy.zeros((0, 3))
-            if nonzero_pairs.shape[1] != 3:
+            if nonzero_pairs is None:
                 nonzero_pairs = numpy.zeros((0, 3))
             matching_pairs = numpy.concatenate((zero_pairs, nonzero_pairs), axis=0)
             if matching_pairs.shape[0] > 0:

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -99,7 +99,7 @@ class ModifiedCosine(BaseSimilarity):
                 zero_pairs = numpy.zeros((0,3))
             if nonzero_pairs.shape[1] != 3:
                 nonzero_pairs = numpy.zeros((0,3))
-            matching_pairs = numpy.concatenate((zero_pairs, npnzero_pairs), axis=0)
+            matching_pairs = numpy.concatenate((zero_pairs, nonzero_pairs), axis=0)
             if matching_pairs.shape[0] > 0:
                 matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
             return matching_pairs

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -107,7 +107,7 @@ class ModifiedCosine(BaseSimilarity):
         spec1 = get_peaks_array(reference)
         spec2 = get_peaks_array(query)
         matching_pairs = get_matching_pairs()
-       if matching_pairs.shape[0] > 0:
+        if matching_pairs.shape[0] > 0:
             return score_best_matches(matching_pairs, spec1, spec2,
                                       self.mz_power, self.intensity_power)
         return float(0), 0

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -45,7 +45,7 @@ def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
 
     if len(matching_pairs) > 0:
         return numpy.array(matching_pairs)
-    return numpy.empty((0, 0))
+    return numpy.empty((0, 3))
 
 
 def get_peaks_array(spectrum: SpectrumType) -> numpy.ndarray:
@@ -59,12 +59,11 @@ def score_best_matches(matching_pairs: numpy.ndarray, spec1: numpy.ndarray,
                        intensity_power: float = 1.0) -> Tuple[float, int]:
     """Calculate cosine-like score by multiplying matches. Does require a sorted
     list of matching peaks (sorted by intensity product)."""
-    if matching_pairs.shape[0] == 0:
-        return 0.0, 0
+    score  = float(0.0)
+    used_matches = int(0)
+    # if len(matching_pairs) > 0:
     used1 = set()
     used2 = set()
-    score = 0.0
-    used_matches = 0
     for i in range(matching_pairs.shape[0]):
         if not matching_pairs[i, 0] in used1 and not matching_pairs[i, 1] in used2:
             score += matching_pairs[i, 2]

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -59,9 +59,8 @@ def score_best_matches(matching_pairs: numpy.ndarray, spec1: numpy.ndarray,
                        intensity_power: float = 1.0) -> Tuple[float, int]:
     """Calculate cosine-like score by multiplying matches. Does require a sorted
     list of matching peaks (sorted by intensity product)."""
-    score  = float(0.0)
+    score = float(0.0)
     used_matches = int(0)
-    # if len(matching_pairs) > 0:
     used1 = set()
     used2 = set()
     for i in range(matching_pairs.shape[0]):

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -45,7 +45,7 @@ def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
 
     if len(matching_pairs) > 0:
         return numpy.array(matching_pairs)
-    return numpy.empty((0, 3))
+    return numpy.empty((0, 0))
 
 
 def get_peaks_array(spectrum: SpectrumType) -> numpy.ndarray:

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -1,3 +1,4 @@
+from typing import List
 from typing import Tuple
 import numba
 import numpy
@@ -46,7 +47,8 @@ def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
 
 
 @numba.njit
-def find_matches(spec1: numpy.ndarray, spec2: numpy.ndarray, tolerance: float, shift: float = 0) -> List[Tuple[int, int]]:
+def find_matches(spec1: numpy.ndarray, spec2: numpy.ndarray,
+                 tolerance: float, shift: float = 0) -> List[Tuple[int, int]]:
     """Faster search for matching peaks.
     Makes use of the fact that spec1 and spec2 contain ordered peak m/z (from
     low to high m/z).
@@ -60,7 +62,7 @@ def find_matches(spec1: numpy.ndarray, spec2: numpy.ndarray, tolerance: float, s
     tolerance
         Peaks will be considered a match when <= tolerance appart.
     shift
-        Shift spectra peaks by shift. The default is 0.
+        Shift peaks of second spectra by shift. The default is 0.
 
     Returns
     -------

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -38,8 +38,8 @@ def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
     if len(idx1) == 0:
         return None
     matching_pairs = []
-    for i in range(len(idx1)):
-        power_prod_spec1 = (spec1[idx1[i], 0] ** mz_power) * (spec1[idx1[i], 1] ** intensity_power)
+    for i, idx in enumerate(idx1):
+        power_prod_spec1 = (spec1[idx, 0] ** mz_power) * (spec1[idx, 1] ** intensity_power)
         power_prod_spec2 = (spec2[idx2[i], 0] ** mz_power) * (spec2[idx2[i], 1] ** intensity_power)
         matching_pairs.append([idx1[i], idx2[i], power_prod_spec1 * power_prod_spec2])
     return matching_pairs

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -43,7 +43,7 @@ def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
         power_prod_spec1 = (spec1[idx, 0] ** mz_power) * (spec1[idx, 1] ** intensity_power)
         power_prod_spec2 = (spec2[idx2[i], 0] ** mz_power) * (spec2[idx2[i], 1] ** intensity_power)
         matching_pairs.append([idx1[i], idx2[i], power_prod_spec1 * power_prod_spec2])
-    return matching_pairs
+    return numpy.array(matching_pairs.copy())
 
 
 @numba.njit

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -46,7 +46,7 @@ def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
 
 
 @numba.njit
-def find_matches(spec1, spec2, tolerance, shift):
+def find_matches(spec1: numpy.ndarray, spec2: numpy.ndarray, tolerance: float, shift: float = 0) -> List[Tuple[int, int]]:
     """Faster search for matching peaks.
     Makes use of the fact that spec1 and spec2 contain ordered peak m/z (from
     low to high m/z).

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -5,25 +5,26 @@ from matchms.typing import SpectrumType
 
 
 @numba.njit
-def collect_peak_pairs(spec1, spec2, tolerance, shift=0,
-                       mz_power=0.0, intensity_power=1.0):
+def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
+                       tolerance: float, shift: float = 0, mz_power: float = 0.0,
+                       intensity_power: float = 1.0):
     # pylint: disable=too-many-arguments
     """Find matching pairs between two spectra.
 
     Args
     ----
-    spec1: numpy array
+    spec1:
         Spectrum peaks and intensities as numpy array.
-    spec2: numpy array
+    spec2:
         Spectrum peaks and intensities as numpy array.
-    tolerance : float
+    tolerance
         Peaks will be considered a match when <= tolerance appart.
-    shift : float, optional
+    shift
         Shift spectra peaks by shift. The default is 0.
-    mz_power: float, optional
+    mz_power:
         The power to raise mz to in the cosine function. The default is 0, in which
         case the peak intensity products will not depend on the m/z ratios.
-    intensity_power: float, optional
+    intensity_power:
         The power to raise intensity to in the cosine function. The default is 1.
 
     Returns
@@ -33,7 +34,7 @@ def collect_peak_pairs(spec1, spec2, tolerance, shift=0,
     """
     matching_pairs = []
 
-    for idx in range(len(spec1)):
+    for idx in range(spec1.shape[0]):
         intensity = spec1[idx, 1]
         mz = spec1[idx, 0]
         matches = numpy.where((numpy.abs(spec2[:, 0] - spec1[idx, 0] + shift) <= tolerance))[0]
@@ -43,8 +44,8 @@ def collect_peak_pairs(spec1, spec2, tolerance, shift=0,
             matching_pairs.append((idx, match, power_prod_spec1 * power_prod_spec2))
 
     if len(matching_pairs) > 0:
-        return np.array(matching_pairs)
-    return np.empty((0, 0))
+        return numpy.array(matching_pairs)
+    return numpy.empty((0, 0))
 
 
 def get_peaks_array(spectrum: SpectrumType) -> numpy.ndarray:
@@ -73,5 +74,5 @@ def score_best_matches(matching_pairs: numpy.ndarray, spec1: numpy.ndarray,
     spec1_power = spec1[:, 0] ** mz_power * spec1[:, 1] ** intensity_power
     spec2_power = spec2[:, 0] ** mz_power * spec2[:, 1] ** intensity_power
 
-    score = score/(np.sum(spec1_power ** 2) ** 0.5 * np.sum(spec2_power ** 2) ** 0.5)
+    score = score/(numpy.sum(spec1_power ** 2) ** 0.5 * numpy.sum(spec2_power ** 2) ** 0.5)
     return score, used_matches

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -54,9 +54,9 @@ def find_matches(spec1, spec2, tolerance, shift):
     Parameters
     ----------
     spec1:
-        Spectrum peaks and intensities as numpy array.
+        Spectrum peaks and intensities as numpy array. Peak mz values must be ordered.
     spec2:
-        Spectrum peaks and intensities as numpy array.
+        Spectrum peaks and intensities as numpy array. Peak mz values must be ordered.
     tolerance
         Peaks will be considered a match when <= tolerance appart.
     shift

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -59,6 +59,8 @@ def score_best_matches(matching_pairs: numpy.ndarray, spec1: numpy.ndarray,
                        intensity_power: float = 1.0) -> Tuple[float, int]:
     """Calculate cosine-like score by multiplying matches. Does require a sorted
     list of matching peaks (sorted by intensity product)."""
+    if matching_pairs.shape[0] == 0:
+        return 0.0, 0
     used1 = set()
     used2 = set()
     score = 0.0

--- a/tests/test_modified_cosine.py
+++ b/tests/test_modified_cosine.py
@@ -80,3 +80,22 @@ def test_modified_cosine_order_of_input_spectrums():
 
     assert score_1_2 == score_2_1, "Expected that the order of the arguments would not matter."
     assert n_matches_1_2 == n_matches_2_1, "Expected that the order of the arguments would not matter."
+
+
+def test_modified_cosine_with_mass_shift_5_no_matches_expected():
+    """Test modified cosine on two spectra with no expected matches."""
+    spectrum_1 = Spectrum(mz=numpy.array([100, 200, 300], dtype="float"),
+                          intensities=numpy.array([10, 10, 500], dtype="float"),
+                          metadata={"precursor_mz": 1000.0})
+
+    spectrum_2 = Spectrum(mz=numpy.array([120, 220, 320], dtype="float"),
+                          intensities=numpy.array([10, 10, 500], dtype="float"),
+                          metadata={"precursor_mz": 1005})
+
+    norm_spectrum_1 = normalize_intensities(spectrum_1)
+    norm_spectrum_2 = normalize_intensities(spectrum_2)
+    modified_cosine = ModifiedCosine(tolerance=1.0)
+    score, n_matches = modified_cosine.pair(norm_spectrum_1, norm_spectrum_2)
+
+    assert score == pytest.approx(0.0, 1e-5), "Expected different modified cosine score."
+    assert n_matches == 0, "Expected 0 matching peaks."

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -42,7 +42,7 @@ def test_collect_peak_pairs(shift, expected_pairs):
 
 @pytest.mark.parametrize("shift, matching_pairs", "expected_score",
                           [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
-                           (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2)])
+                           (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
 def test_score_best_matches_compiled(shift, matching_pairs, expected_score)
     """Test finding expected peak matches for given tolerance."""
     shift = -5.0
@@ -60,7 +60,7 @@ def test_score_best_matches_compiled(shift, matching_pairs, expected_score)
 
 @pytest.mark.parametrize("shift, matching_pairs", "expected_score",
                           [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
-                           (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2)])
+                           (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
 def test_score_best_matches(shift, matching_pairs, expected_score)
     """Test finding expected peak matches for given tolerance."""
     shift = -5.0

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -41,9 +41,9 @@ def test_collect_peak_pairs(shift, expected_pairs):
 
 
 @pytest.mark.parametrize("shift, matching_pairs", "expected_score",
-                          [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
-                           (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
-def test_score_best_matches_compiled(shift, matching_pairs, expected_score)
+                         [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
+def test_score_best_matches_compiled(shift, matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     shift = -5.0
     expected_pairs = [[2., 2., 1.], [3., 3., 1.]]
@@ -59,9 +59,9 @@ def test_score_best_matches_compiled(shift, matching_pairs, expected_score)
 
 
 @pytest.mark.parametrize("shift, matching_pairs", "expected_score",
-                          [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
-                           (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
-def test_score_best_matches(shift, matching_pairs, expected_score)
+                         [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
+def test_score_best_matches(shift, matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     shift = -5.0
     expected_pairs = [[2., 2., 1.], [3., 3., 1.]]

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -40,7 +40,7 @@ def test_collect_peak_pairs(shift, expected_pairs):
     assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
 
 
-@pytest.mark.parametrize("matching_pairs", "expected_score",
+@pytest.mark.parametrize("matching_pairs, expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
                           ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
 def test_score_best_matches_compiled(matching_pairs, expected_score):
@@ -56,7 +56,7 @@ def test_score_best_matches_compiled(matching_pairs, expected_score):
     assert matches == expected_score[1], "Expected different matches."
 
 
-@pytest.mark.parametrize("matching_pairs", "expected_score",
+@pytest.mark.parametrize("matching_pairs, expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
                           ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
 def test_score_best_matches(matching_pairs, expected_score):

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -6,11 +6,11 @@ from matchms.similarity.spectrum_similarity_functions import collect_peak_pairs
 from matchms.similarity.spectrum_similarity_functions import score_best_matches
 
 
-@pytest.mark.parametrize("shift, expected_pairs",
-                         [(0.0, [[2., 2., 1.], [3., 3., 1.]]),
-                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]]),
-                          (-20.0, [])])
-def test_collect_peak_pairs_compiled(shift, expected_pairs):
+@pytest.mark.parametrize("shift, expected_pairs, expected_matches",
+                         [(0.0, [[2., 2., 1.], [3., 3., 1.]], (2, 3)),
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (2, 3)),
+                          (-20.0, [], (0, 0))])
+def test_collect_peak_pairs_compiled(shift, expected_pairs, expected_matches):
     """Test finding expected peak matches for given tolerance."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
@@ -19,14 +19,14 @@ def test_collect_peak_pairs_compiled(shift, expected_pairs):
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=shift)
-    assert matching_pairs.shape == (2, 3), "Expected different number of matching peaks"
+    assert matching_pairs.shape == expected_matches, "Expected different number of matching peaks"
     assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
 
 
 @pytest.mark.parametrize("shift, expected_pairs",
-                         [(0.0, [[2., 2., 1.], [3., 3., 1.]]),
-                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]]),
-                          (-20.0, [])])
+                         [(0.0, [[2., 2., 1.], [3., 3., 1.]] (2, 3)),
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]] (2, 3)),
+                          (-20.0, [], (0, 0))])
 def test_collect_peak_pairs(shift, expected_pairs):
     """Test finding expected peak matches for tolerance=0.2 and given shift."""
     spec1 = numpy.array([[100, 200, 300, 500],
@@ -36,7 +36,7 @@ def test_collect_peak_pairs(shift, expected_pairs):
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift)
-    assert matching_pairs.shape == (2, 3), "Expected different number of matching peaks"
+    assert matching_pairs.shape == expected_matches, "Expected different number of matching peaks"
     assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
 
 

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -71,6 +71,6 @@ def test_score_best_matches(shift, matching_pairs, expected_score):
     spec2 = numpy.array([[105, 205.1, 300, 500.1],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
-    score, matches = .py_funcscore_best_matches(matching_pairs, spec1, spec2)
+    score, matches = score_best_matches.py_func(matching_pairs, spec1, spec2)
     assert score == pytest.approx(expected_score[0], 1e-8), "Expected different score"
     assert matches == expected_score[1], "Expected different matches."

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -17,7 +17,7 @@ def test_collect_peak_pairs_compiled(shift, expected_pairs, expected_matches):
     spec2 = numpy.array([[105, 205.1, 300, 500.1],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
-    matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=shift)
+    matching_pairs = numpy.array(collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=shift))
     assert matching_pairs.shape == expected_matches, "Expected different number of matching peaks"
     assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
 
@@ -33,7 +33,7 @@ def test_collect_peak_pairs(shift, expected_pairs, expected_matches):
     spec2 = numpy.array([[105, 205.1, 300, 500.1],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
-    matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift)
+    matching_pairs = numpy.array(collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift))
     assert matching_pairs.shape == expected_matches, "Expected different number of matching peaks"
     assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
 

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -42,8 +42,7 @@ def test_collect_peak_pairs(shift, expected_pairs):
 
 @pytest.mark.parametrize("matching_pairs, expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.990099009900, 2)),
-                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2)),
-                          ([], (0.0, 0))])
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2))])
 def test_score_best_matches_compiled(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     matching_pairs = numpy.array(matching_pairs)
@@ -60,8 +59,7 @@ def test_score_best_matches_compiled(matching_pairs, expected_score):
 
 @pytest.mark.parametrize("matching_pairs, expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.990099009900, 2)),
-                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2)),
-                          ([], (0.0, 0))])
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2))])
 def test_score_best_matches(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     matching_pairs = numpy.array(matching_pairs)

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -42,7 +42,7 @@ def test_collect_peak_pairs(shift, expected_pairs):
 
 @pytest.mark.parametrize("matching_pairs, expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.990099009900, 2)),
-                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2),
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2)),
                           ([], (0.0, 0))])
 def test_score_best_matches_compiled(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
@@ -60,7 +60,7 @@ def test_score_best_matches_compiled(matching_pairs, expected_score):
 
 @pytest.mark.parametrize("matching_pairs, expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.990099009900, 2)),
-                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2),
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2)),
                           ([], (0.0, 0))])
 def test_score_best_matches(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -21,7 +21,7 @@ def test_collect_peak_pairs_compiled(shift, expected_pairs):
 
     matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=shift)
     assert matching_pairs.shape == (2, 3), "Expected different number of matching peaks"
-    assert np.allclose(matching_pairs, np.array(expected_pairs), atol=1e-8), "Expected different values."
+    assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
 
 
 @pytest.mark.parametrize("shift, expected_pairs",
@@ -37,16 +37,14 @@ def test_collect_peak_pairs(shift, expected_pairs):
 
     matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift)
     assert matching_pairs.shape == (2, 3), "Expected different number of matching peaks"
-    assert np.allclose(matching_pairs, np.array(expected_pairs), atol=1e-8), "Expected different values."
+    assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
 
 
-@pytest.mark.parametrize("shift, matching_pairs", "expected_score",
-                         [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
-                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
+@pytest.mark.parametrize("matching_pairs", "expected_score",
+                         [([[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
 def test_score_best_matches_compiled(shift, matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
-    shift = -5.0
-    expected_pairs = [[2., 2., 1.], [3., 3., 1.]]
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
@@ -58,13 +56,11 @@ def test_score_best_matches_compiled(shift, matching_pairs, expected_score):
     assert matches == expected_score[1], "Expected different matches."
 
 
-@pytest.mark.parametrize("shift, matching_pairs", "expected_score",
-                         [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
-                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
+@pytest.mark.parametrize("matching_pairs", "expected_score",
+                         [([[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
 def test_score_best_matches(shift, matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
-    shift = -5.0
-    expected_pairs = [[2., 2., 1.], [3., 3., 1.]]
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -45,6 +45,7 @@ def test_collect_peak_pairs(shift, expected_pairs):
                           ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
 def test_score_best_matches_compiled(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
+    matching_pairs = numpy.array(matching_pairs)
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
@@ -61,6 +62,7 @@ def test_score_best_matches_compiled(matching_pairs, expected_score):
                           ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
 def test_score_best_matches(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
+    matching_pairs = numpy.array(matching_pairs)
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -42,7 +42,7 @@ def test_collect_peak_pairs(shift, expected_pairs, expected_matches):
 @pytest.mark.parametrize("numba_compiled", [True, False])
 def test_collect_peak_pairs_no_matches(numba_compiled):
     """Test function for no matching peaks."""
-    shift = -5.0
+    shift = -20.0
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
@@ -86,7 +86,7 @@ def test_find_matches_no_matches(numba_compiled):
         matches = find_matches(spec1, spec2, tolerance=0.2, shift=shift)
     else:
         matches = find_matches.py_func(spec1, spec2, tolerance=0.2, shift=shift)
-    assert matches is None, "Expected pairs to be None."
+    assert matches == [], "Expected empty list of matches."
 
 
 @pytest.mark.parametrize("matching_pairs, expected_score",

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -40,8 +40,8 @@ def test_collect_peak_pairs(shift, expected_pairs, expected_matches):
 
 @pytest.mark.parametrize("numba_compiled", [True, False])
 def test_collect_peak_pairs_no_matches(numba_compiled):
-    shift = -20.0
     """Test function for no matching peaks."""
+    shift = -20.0
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -3,6 +3,7 @@ pure Python version."""
 import numpy
 import pytest
 from matchms.similarity.spectrum_similarity_functions import collect_peak_pairs
+from matchms.similarity.spectrum_similarity_functions import score_best_matches
 
 
 @pytest.mark.parametrize("shift, expected_pairs",
@@ -10,6 +11,8 @@ from matchms.similarity.spectrum_similarity_functions import collect_peak_pairs
                           (-5.0, [(0, 0, 0.01), (1, 1, 0.01)])])
 def test_collect_peak_pairs_compiled(shift, expected_pairs):
     """Test finding expected peak matches for given tolerance."""
+    shift = 0.0
+    expected_pairs = [[2., 2., 1.], [3., 3., 1.]]
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
@@ -17,13 +20,13 @@ def test_collect_peak_pairs_compiled(shift, expected_pairs):
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=shift)
-    assert len(matching_pairs) == 2, "Expected different number of matching peaks"
-    assert matching_pairs == [pytest.approx(x, 1e-9) for x in expected_pairs], "Expected different pairs."
+    assert matching_pairs.shape == (2, 3), "Expected different number of matching peaks"
+    assert np.allclose(matching_pairs, np.array(expected_pairs), atol=1e-8), "Expected different values."
 
 
 @pytest.mark.parametrize("shift, expected_pairs",
-                         [(0.0, [(2, 2, 1.0), (3, 3, 1.0)]),
-                          (-5.0, [(0, 0, 0.01), (1, 1, 0.01)])])
+                         [(0.0, [[2., 2., 1.], [3., 3., 1.]]),
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]])])
 def test_collect_peak_pairs(shift, expected_pairs):
     """Test finding expected peak matches for tolerance=0.2 and given shift."""
     spec1 = numpy.array([[100, 200, 300, 500],
@@ -33,5 +36,41 @@ def test_collect_peak_pairs(shift, expected_pairs):
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift)
-    assert len(matching_pairs) == 2, "Expected different number of matching peaks"
-    assert matching_pairs == [pytest.approx(x, 1e-9) for x in expected_pairs], "Expected different pairs."
+    assert matching_pairs.shape == (2, 3), "Expected different number of matching peaks"
+    assert np.allclose(matching_pairs, np.array(expected_pairs), atol=1e-8), "Expected different values."
+
+
+@pytest.mark.parametrize("shift, matching_pairs", "expected_score",
+                          [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
+                           (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2)])
+def test_score_best_matches_compiled(shift, matching_pairs, expected_score)
+    """Test finding expected peak matches for given tolerance."""
+    shift = -5.0
+    expected_pairs = [[2., 2., 1.], [3., 3., 1.]]
+    spec1 = numpy.array([[100, 200, 300, 500],
+                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+
+    spec2 = numpy.array([[105, 205.1, 300, 500.1],
+                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+
+    score, matches = score_best_matches(matching_pairs, spec1, spec2)
+    assert score == pytest.approx(expected_score[0], 1e-8), "Expected different score"
+    assert matches == expected_score[1], "Expected different matches."
+
+
+@pytest.mark.parametrize("shift, matching_pairs", "expected_score",
+                          [(0.0, [[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
+                           (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2)])
+def test_score_best_matches(shift, matching_pairs, expected_score)
+    """Test finding expected peak matches for given tolerance."""
+    shift = -5.0
+    expected_pairs = [[2., 2., 1.], [3., 3., 1.]]
+    spec1 = numpy.array([[100, 200, 300, 500],
+                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+
+    spec2 = numpy.array([[105, 205.1, 300, 500.1],
+                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+
+    score, matches = .py_funcscore_best_matches(matching_pairs, spec1, spec2)
+    assert score == pytest.approx(expected_score[0], 1e-8), "Expected different score"
+    assert matches == expected_score[1], "Expected different matches."

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -23,11 +23,11 @@ def test_collect_peak_pairs_compiled(shift, expected_pairs, expected_matches):
     assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
 
 
-@pytest.mark.parametrize("shift, expected_pairs",
+@pytest.mark.parametrize("shift, expected_pairs, expected_matches",
                          [(0.0, [[2., 2., 1.], [3., 3., 1.]], (2, 3)),
                           (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (2, 3)),
                           (-20.0, [], (0, 0))])
-def test_collect_peak_pairs(shift, expected_pairs):
+def test_collect_peak_pairs(shift, expected_pairs, expected_matches):
     """Test finding expected peak matches for tolerance=0.2 and given shift."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -24,8 +24,8 @@ def test_collect_peak_pairs_compiled(shift, expected_pairs, expected_matches):
 
 
 @pytest.mark.parametrize("shift, expected_pairs",
-                         [(0.0, [[2., 2., 1.], [3., 3., 1.]] (2, 3)),
-                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]] (2, 3)),
+                         [(0.0, [[2., 2., 1.], [3., 3., 1.]], (2, 3)),
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (2, 3)),
                           (-20.0, [], (0, 0))])
 def test_collect_peak_pairs(shift, expected_pairs):
     """Test finding expected peak matches for tolerance=0.2 and given shift."""

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -41,8 +41,8 @@ def test_collect_peak_pairs(shift, expected_pairs):
 
 
 @pytest.mark.parametrize("matching_pairs, expected_score",
-                         [([[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
-                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
+                         [([[2., 2., 1.], [3., 3., 1.]], (0.990099009900, 2)),
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2))])
 def test_score_best_matches_compiled(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     matching_pairs = numpy.array(matching_pairs)
@@ -53,13 +53,13 @@ def test_score_best_matches_compiled(matching_pairs, expected_score):
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     score, matches = score_best_matches(matching_pairs, spec1, spec2)
-    assert score == pytest.approx(expected_score[0], 1e-8), "Expected different score"
+    assert score == pytest.approx(expected_score[0], 1e-6), "Expected different score"
     assert matches == expected_score[1], "Expected different matches."
 
 
 @pytest.mark.parametrize("matching_pairs, expected_score",
-                         [([[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
-                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
+                         [([[2., 2., 1.], [3., 3., 1.]], (0.990099009900, 2)),
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2))])
 def test_score_best_matches(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     matching_pairs = numpy.array(matching_pairs)
@@ -70,5 +70,5 @@ def test_score_best_matches(matching_pairs, expected_score):
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     score, matches = score_best_matches.py_func(matching_pairs, spec1, spec2)
-    assert score == pytest.approx(expected_score[0], 1e-8), "Expected different score"
+    assert score == pytest.approx(expected_score[0], 1e-6), "Expected different score"
     assert matches == expected_score[1], "Expected different matches."

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -8,8 +8,7 @@ from matchms.similarity.spectrum_similarity_functions import score_best_matches
 
 @pytest.mark.parametrize("shift, expected_pairs, expected_matches",
                          [(0.0, [[2., 2., 1.], [3., 3., 1.]], (2, 3)),
-                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (2, 3)),
-                          (-20.0, [], (0, 0))])
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (2, 3))])
 def test_collect_peak_pairs_compiled(shift, expected_pairs, expected_matches):
     """Test finding expected peak matches for given tolerance."""
     spec1 = numpy.array([[100, 200, 300, 500],
@@ -25,8 +24,7 @@ def test_collect_peak_pairs_compiled(shift, expected_pairs, expected_matches):
 
 @pytest.mark.parametrize("shift, expected_pairs, expected_matches",
                          [(0.0, [[2., 2., 1.], [3., 3., 1.]], (2, 3)),
-                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (2, 3)),
-                          (-20.0, [], (0, 0))])
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]], (2, 3))])
 def test_collect_peak_pairs(shift, expected_pairs, expected_matches):
     """Test finding expected peak matches for tolerance=0.2 and given shift."""
     spec1 = numpy.array([[100, 200, 300, 500],
@@ -38,6 +36,22 @@ def test_collect_peak_pairs(shift, expected_pairs, expected_matches):
     matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift)
     assert matching_pairs.shape == expected_matches, "Expected different number of matching peaks"
     assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
+
+
+@pytest.mark.parametrize("numba_compiled", [True, False])
+def test_collect_peak_pairs_no_matches(numba_compiled):
+    shift = -20.0
+    """Test function for no matching peaks."""
+    spec1 = numpy.array([[100, 200, 300, 500],
+                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+
+    spec2 = numpy.array([[105, 205.1, 300, 500.1],
+                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+    if numba_compiled:
+        matching_pairs = collect_peak_pairs(spec1, spec2, tolerance=0.2, shift=shift)
+    else:
+        matching_pairs = collect_peak_pairs.py_func(spec1, spec2, tolerance=0.2, shift=shift)
+    assert matching_pairs is None, "Expected pairs to be None."
 
 
 @pytest.mark.parametrize("matching_pairs, expected_score",

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -43,7 +43,7 @@ def test_collect_peak_pairs(shift, expected_pairs):
 @pytest.mark.parametrize("matching_pairs", "expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
                           ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
-def test_score_best_matches_compiled(shift, matching_pairs, expected_score):
+def test_score_best_matches_compiled(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
@@ -59,7 +59,7 @@ def test_score_best_matches_compiled(shift, matching_pairs, expected_score):
 @pytest.mark.parametrize("matching_pairs", "expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.9900990099, 2)),
                           ([[0., 0., 0.01], [1., 1., 0.01]], (0.0099009900, 2))])
-def test_score_best_matches(shift, matching_pairs, expected_score):
+def test_score_best_matches(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -7,12 +7,11 @@ from matchms.similarity.spectrum_similarity_functions import score_best_matches
 
 
 @pytest.mark.parametrize("shift, expected_pairs",
-                         [(0.0, [(2, 2, 1.0), (3, 3, 1.0)]),
-                          (-5.0, [(0, 0, 0.01), (1, 1, 0.01)])])
+                         [(0.0, [[2., 2., 1.], [3., 3., 1.]]),
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]]),
+                          (-20.0, [])])
 def test_collect_peak_pairs_compiled(shift, expected_pairs):
     """Test finding expected peak matches for given tolerance."""
-    shift = 0.0
-    expected_pairs = [[2., 2., 1.], [3., 3., 1.]]
     spec1 = numpy.array([[100, 200, 300, 500],
                          [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
@@ -26,7 +25,8 @@ def test_collect_peak_pairs_compiled(shift, expected_pairs):
 
 @pytest.mark.parametrize("shift, expected_pairs",
                          [(0.0, [[2., 2., 1.], [3., 3., 1.]]),
-                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]])])
+                          (-5.0, [[0., 0., 0.01], [1., 1., 0.01]]),
+                          (-20.0, [])])
 def test_collect_peak_pairs(shift, expected_pairs):
     """Test finding expected peak matches for tolerance=0.2 and given shift."""
     spec1 = numpy.array([[100, 200, 300, 500],
@@ -42,7 +42,8 @@ def test_collect_peak_pairs(shift, expected_pairs):
 
 @pytest.mark.parametrize("matching_pairs, expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.990099009900, 2)),
-                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2))])
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2),
+                          ([], (0.0, 0))])
 def test_score_best_matches_compiled(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     matching_pairs = numpy.array(matching_pairs)
@@ -59,7 +60,8 @@ def test_score_best_matches_compiled(matching_pairs, expected_score):
 
 @pytest.mark.parametrize("matching_pairs, expected_score",
                          [([[2., 2., 1.], [3., 3., 1.]], (0.990099009900, 2)),
-                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2))])
+                          ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2),
+                          ([], (0.0, 0))])
 def test_score_best_matches(matching_pairs, expected_score):
     """Test finding expected peak matches for given tolerance."""
     matching_pairs = numpy.array(matching_pairs)


### PR DESCRIPTION
- considerable performance gain by making better use of Numba and Numpy.
Main gain comes from a better search algorithm for matching peaks (``find_matches()`` using Numba and the fact that peaks are sorted).
For spectra with few peaks (<100) there is no huge difference, but the scaling changed quite drastically. Now it scales linear with the number of peaks, before it was polynomial. For instance for spectra with around 1000 peaks the new implementation is about 10x faster, for spectra with 2000 peaks about 20x faster.
- larger performance gain of ``CosineHungarian`` implementation due to faster implementation in scipy (>= 1.4.0) and the now better matching peak detection.