### PR TITLE
convert string charges to int during filtering

### DIFF
--- a/matchms/filtering/make_charge_scalar.py
+++ b/matchms/filtering/make_charge_scalar.py
@@ -12,4 +12,8 @@ def make_charge_scalar(spectrum_in: SpectrumType) -> SpectrumType:
     if isinstance(spectrum.get("charge", None), list):
         spectrum.set("charge", int(spectrum.get("charge")[0]))
 
+    # convert string charges to int
+    elif isinstance(spectrum.get("charge", None), str):
+        spectrum.set("charge", int(spectrum.get('charge')))
+
     return spectrum


### PR DESCRIPTION
Some json spectra contain string-formatted charges.  This pull request adds a filter for string-formatted charges to filtering.make_charge_scalar