### PR TITLE
Fix string charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `make_charge_int()` to convert charge field to integer [#184](https://github.com/matchms/matchms/issues/184)
+
+### Changed
+
+- now deprecated: `make_charge_scalar()`, use `make_charge_int()` instead [#183](https://github.com/matchms/matchms/pull/183)
+
 ## [0.8.1] - 2021-02-19
 
 ### Fixed

--- a/matchms/filtering/__init__.py
+++ b/matchms/filtering/__init__.py
@@ -53,6 +53,7 @@ from .derive_smiles_from_inchi import derive_smiles_from_inchi
 from .harmonize_undefined_inchi import harmonize_undefined_inchi
 from .harmonize_undefined_inchikey import harmonize_undefined_inchikey
 from .harmonize_undefined_smiles import harmonize_undefined_smiles
+from .make_charge_int import make_charge_int
 from .make_charge_scalar import make_charge_scalar
 from .make_ionmode_lowercase import make_ionmode_lowercase
 from .normalize_intensities import normalize_intensities
@@ -88,6 +89,7 @@ __all__ = [
     "harmonize_undefined_inchi",
     "harmonize_undefined_inchikey",
     "harmonize_undefined_smiles",
+    "make_charge_int",
     "make_charge_scalar",
     "make_ionmode_lowercase",
     "normalize_intensities",

--- a/matchms/filtering/default_filters.py
+++ b/matchms/filtering/default_filters.py
@@ -6,7 +6,7 @@ from .correct_charge import correct_charge
 from .derive_adduct_from_name import derive_adduct_from_name
 from .derive_formula_from_name import derive_formula_from_name
 from .derive_ionmode import derive_ionmode
-from .make_charge_scalar import make_charge_scalar
+from .make_charge_int import make_charge_int
 from .make_ionmode_lowercase import make_ionmode_lowercase
 from .set_ionmode_na_when_missing import set_ionmode_na_when_missing
 
@@ -17,7 +17,7 @@ def default_filters(spectrum: SpectrumType) -> SpectrumType:
 
     Collection is
 
-    1. :meth:`~matchms.filtering.make_charge_scalar`
+    1. :meth:`~matchms.filtering.make_charge_int`
     2. :meth:`~matchms.filtering.make_ionmode_lowercase`
     3. :meth:`~matchms.filtering.set_ionmode_na_when_missing`
     4. :meth:`~matchms.filtering.add_compound_name`
@@ -29,7 +29,7 @@ def default_filters(spectrum: SpectrumType) -> SpectrumType:
     10. :meth:`~matchms.filtering.correct_charge`
 
     """
-    spectrum = make_charge_scalar(spectrum)
+    spectrum = make_charge_int(spectrum)
     spectrum = make_ionmode_lowercase(spectrum)
     spectrum = set_ionmode_na_when_missing(spectrum)
     spectrum = add_compound_name(spectrum)

--- a/matchms/filtering/make_charge_int.py
+++ b/matchms/filtering/make_charge_int.py
@@ -1,0 +1,23 @@
+from ..typing import SpectrumType
+
+
+def make_charge_int(spectrum_in: SpectrumType) -> SpectrumType:
+    """Convert charge field to integer (if possible)."""
+    if spectrum_in is None:
+        return None
+
+    spectrum = spectrum_in.clone()
+
+    # Avoid pyteomics ChargeList
+    if isinstance(spectrum.get("charge", None), list):
+        spectrum.set("charge", int(spectrum.get("charge")[0]))
+
+    # convert string charges to int
+    elif isinstance(spectrum.get("charge", None), str):
+        try:
+            charge_int = int(spectrum.get('charge'))
+            spectrum.set("charge", int(spectrum.get('charge')))
+        except ValueError:
+            print(f"Found charge ({spectrum.get('charge')}) cannot be converted to integer.")
+
+    return spectrum

--- a/matchms/filtering/make_charge_int.py
+++ b/matchms/filtering/make_charge_int.py
@@ -16,7 +16,7 @@ def make_charge_int(spectrum_in: SpectrumType) -> SpectrumType:
     if isinstance(spectrum.get("charge", None), str):
         try:
             charge_int = int(spectrum.get('charge'))
-            spectrum.set("charge", int(spectrum.get('charge')))
+            spectrum.set("charge", charge_int)
         except ValueError:
             print(f"Found charge ({spectrum.get('charge')}) cannot be converted to integer.")
 

--- a/matchms/filtering/make_charge_scalar.py
+++ b/matchms/filtering/make_charge_scalar.py
@@ -12,4 +12,8 @@ def make_charge_scalar(spectrum_in: SpectrumType) -> SpectrumType:
     if isinstance(spectrum.get("charge", None), list):
         spectrum.set("charge", int(spectrum.get("charge")[0]))
 
+    # convert string charges to int
+    elif isinstance(spectrum.get("charge", None), str):
+        spectrum.set("charge", int(spectrum.get('charge')))
+
     return spectrum

--- a/matchms/filtering/make_charge_scalar.py
+++ b/matchms/filtering/make_charge_scalar.py
@@ -13,7 +13,7 @@ def make_charge_scalar(spectrum_in: SpectrumType) -> SpectrumType:
         spectrum.set("charge", int(spectrum.get("charge")[0]))
 
     # convert string charges to int
-    elif isinstance(spectrum.get("charge", None), str):
+    if isinstance(spectrum.get("charge", None), str):
         spectrum.set("charge", int(spectrum.get('charge')))
 
     return spectrum

--- a/matchms/filtering/make_charge_scalar.py
+++ b/matchms/filtering/make_charge_scalar.py
@@ -1,19 +1,13 @@
+from deprecated.sphinx import deprecated
 from ..typing import SpectrumType
+from .make_charge_int import make_charge_int
 
 
+@deprecated(version='0.8.2', reason="Use expanded make_charge_int() instead.")
 def make_charge_scalar(spectrum_in: SpectrumType) -> SpectrumType:
-    """Convert charge field to scalar (if necessary)."""
-    if spectrum_in is None:
-        return None
+    """Convert charge field to scalar (if necessary).
 
-    spectrum = spectrum_in.clone()
+    Deprecated function, now replaced by make_charge_int().
+    """
 
-    # Avoid pyteomics ChargeList
-    if isinstance(spectrum.get("charge", None), list):
-        spectrum.set("charge", int(spectrum.get("charge")[0]))
-
-    # convert string charges to int
-    elif isinstance(spectrum.get("charge", None), str):
-        spectrum.set("charge", int(spectrum.get('charge')))
-
-    return spectrum
+    return make_charge_int(spectrum_in)

--- a/tests/test_make_charge_int.py
+++ b/tests/test_make_charge_int.py
@@ -1,0 +1,28 @@
+import numpy
+import pytest
+from matchms import Spectrum
+from matchms.filtering import make_charge_int
+
+
+@pytest.mark.parametrize("input_charge, corrected_charge", [('+1', 1),
+                                                            ('1', 1),
+                                                            (' 1 ', 1),
+                                                            ('-2', -2),
+                                                            ([-1, "stuff"], -1),
+                                                            (['-3'], -3),
+                                                            ('n/a', 'n/a')])
+def test_make_charge_int(input_charge, corrected_charge):
+    """Test if example inputs are correctly converted"""
+    spectrum_in = Spectrum(mz=numpy.array([100, 200.]),
+                           intensities=numpy.array([0.7, 0.1]),
+                           metadata={'charge': input_charge})
+
+    spectrum = make_charge_int(spectrum_in)
+    assert(spectrum.get("charge") == corrected_charge), "Expected different charge integer"
+
+
+def test_empty_spectrum():
+    spectrum_in = None
+    spectrum = make_charge_int(spectrum_in)
+
+    assert spectrum is None, "Expected different handling of None spectrum."

--- a/tests/test_make_charge_int.py
+++ b/tests/test_make_charge_int.py
@@ -10,6 +10,7 @@ from matchms.filtering import make_charge_int
                                                             ('-2', -2),
                                                             ([-1, "stuff"], -1),
                                                             (['-3'], -3),
+                                                            ('0', 0),
                                                             ('n/a', 'n/a')])
 def test_make_charge_int(input_charge, corrected_charge):
     """Test if example inputs are correctly converted"""

--- a/tests/test_make_charge_scalar.py
+++ b/tests/test_make_charge_scalar.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy
+import pytest
 from matchms import Spectrum
 from matchms.filtering import make_charge_scalar
 

--- a/tests/test_make_charge_scalar.py
+++ b/tests/test_make_charge_scalar.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy
 from matchms import Spectrum
 from matchms.filtering import make_charge_scalar
 

--- a/tests/test_make_charge_scalar.py
+++ b/tests/test_make_charge_scalar.py
@@ -10,8 +10,8 @@ from matchms.filtering import make_charge_scalar
                                                             ('-1', -1)])
 def test_make_charge_scalar(input_charge, corrected_charge):
     spectrum_in = Spectrum(mz=numpy.array([100, 200.]),
-                          intensities=numpy.array([0.7, 0.1]),
-                          metadata={'charge': input_charge})
+                           intensities=numpy.array([0.7, 0.1]),
+                           metadata={'charge': input_charge})
 
     spectrum = make_charge_scalar(spectrum_in)
     assert(spectrum.get("charge") == corrected_charge), "Expected different charge integer"

--- a/tests/test_make_charge_scalar.py
+++ b/tests/test_make_charge_scalar.py
@@ -1,0 +1,16 @@
+import pytest
+from matchms import Spectrum
+from matchms.filtering import make_charge_scalar
+
+
+@pytest.mark.parametrize("input_charge, corrected_charge", [('+1', 1),
+                                                            ('1', 1),
+                                                            (' 1 ', 1),
+                                                            ('-1', -1)])
+def test_make_charge_scalar(input_charge, corrected_charge):
+    spectrum_in = Spectrum(mz=numpy.array([100, 200.]),
+                          intensities=numpy.array([0.7, 0.1]),
+                          metadata={'charge': input_charge})
+
+    spectrum = make_charge_scalar(spectrum_in)
+    assert(spectrum.get("charge") == corrected_charge), "Expected different charge integer"

--- a/tests/test_make_charge_scalar.py
+++ b/tests/test_make_charge_scalar.py
@@ -8,7 +8,7 @@ from matchms.filtering import make_charge_scalar
                                                             ('1', 1),
                                                             (' 1 ', 1),
                                                             ('-1', -1),
-                                                            ([-1, stuff], -1)])
+                                                            ([-1, "stuff"], -1)])
 def test_make_charge_scalar(input_charge, corrected_charge):
     """Test if example inputs are correctly converted"""
     spectrum_in = Spectrum(mz=numpy.array([100, 200.]),

--- a/tests/test_make_charge_scalar.py
+++ b/tests/test_make_charge_scalar.py
@@ -7,11 +7,20 @@ from matchms.filtering import make_charge_scalar
 @pytest.mark.parametrize("input_charge, corrected_charge", [('+1', 1),
                                                             ('1', 1),
                                                             (' 1 ', 1),
-                                                            ('-1', -1)])
+                                                            ('-1', -1),
+                                                            ([-1, stuff], -1)])
 def test_make_charge_scalar(input_charge, corrected_charge):
+    """Test if example inputs are correctly converted"""
     spectrum_in = Spectrum(mz=numpy.array([100, 200.]),
                            intensities=numpy.array([0.7, 0.1]),
                            metadata={'charge': input_charge})
 
     spectrum = make_charge_scalar(spectrum_in)
     assert(spectrum.get("charge") == corrected_charge), "Expected different charge integer"
+
+
+def test_empty_spectrum():
+    spectrum_in = None
+    spectrum = make_charge_scalar(spectrum_in)
+
+    assert spectrum is None, "Expected different handling of None spectrum."


### PR DESCRIPTION
Based on PR from fork, done by @davidwhealey
Original message:

Some json spectra contain string-formatted charges. This pull request adds a filter for string-formatted charges to filtering.make_charge_scalar

- For more detailed discussion I opened #184.
- I added a unit test
- Give rights to @davidwhealey
- Switch to `make_charge_int()`, now marked as deprecated: `make_charge_scalar()`