### PR TITLE
Changed find_matches function to only take m/z values

### DIFF
--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -33,7 +33,7 @@ def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
     matching_pairs : numpy array
         Array of found matching peaks.
     """
-    matches = find_matches(spec1, spec2, tolerance, shift)
+    matches = find_matches(spec1[:, 0], spec2[:, 0], tolerance, shift)
     idx1 = [x[0] for x in matches]
     idx2 = [x[1] for x in matches]
     if len(idx1) == 0:
@@ -47,7 +47,7 @@ def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
 
 
 @numba.njit
-def find_matches(spec1: numpy.ndarray, spec2: numpy.ndarray,
+def find_matches(spec1_mz: numpy.ndarray, spec2_mz: numpy.ndarray,
                  tolerance: float, shift: float = 0) -> List[Tuple[int, int]]:
     """Faster search for matching peaks.
     Makes use of the fact that spec1 and spec2 contain ordered peak m/z (from
@@ -55,10 +55,10 @@ def find_matches(spec1: numpy.ndarray, spec2: numpy.ndarray,
 
     Parameters
     ----------
-    spec1:
-        Spectrum peaks and intensities as numpy array. Peak mz values must be ordered.
-    spec2:
-        Spectrum peaks and intensities as numpy array. Peak mz values must be ordered.
+    spec1_mz:
+        Spectrum peak m/z values as numpy array. Peak mz values must be ordered.
+    spec2_mz:
+        Spectrum peak m/z values as numpy array. Peak mz values must be ordered.
     tolerance
         Peaks will be considered a match when <= tolerance appart.
     shift
@@ -72,12 +72,12 @@ def find_matches(spec1: numpy.ndarray, spec2: numpy.ndarray,
     """
     lowest_idx = 0
     matches = []
-    for peak1_idx in range(spec1.shape[0]):
-        mz = spec1[peak1_idx, 0]
+    for peak1_idx in range(spec1_mz.shape[0]):
+        mz = spec1_mz[peak1_idx]
         low_bound = mz - tolerance
         high_bound = mz + tolerance
-        for peak2_idx in range(lowest_idx, spec2.shape[0]):
-            mz2 = spec2[peak2_idx, 0] + shift
+        for peak2_idx in range(lowest_idx, spec2_mz.shape[0]):
+            mz2 = spec2_mz[peak2_idx] + shift
             if mz2 > high_bound:
                 break
             if mz2 < low_bound:

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -59,17 +59,15 @@ def test_collect_peak_pairs_no_matches(numba_compiled):
 def test_find_matches_shifted(numba_compiled):
     """Test finding matches with shifted peaks."""
     shift = -5.0
-    spec1 = numpy.array([[100, 200, 300, 500],
-                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+    spec1_mz = numpy.array([100, 200, 300, 500], dtype="float")
 
-    spec2 = numpy.array([[105, 205.1, 300, 304.99, 500.1],
-                         [0.1, 0.1, 1.0, 0.8, 1.0]], dtype="float").T
+    spec2_mz = numpy.array([105, 205.1, 300, 304.99, 500.1], dtype="float")
 
     expected_matches = [(0, 0), (1, 1), (2, 3)]
     if numba_compiled:
-        matches = find_matches(spec1, spec2, tolerance=0.2, shift=shift)
+        matches = find_matches(spec1_mz, spec2_mz, tolerance=0.2, shift=shift)
     else:
-        matches = find_matches.py_func(spec1, spec2, tolerance=0.2, shift=shift)
+        matches = find_matches.py_func(spec1_mz, spec2_mz, tolerance=0.2, shift=shift)
     assert expected_matches == matches, "Expected different matches."
 
 
@@ -77,15 +75,13 @@ def test_find_matches_shifted(numba_compiled):
 def test_find_matches_no_matches(numba_compiled):
     """Test function for no matching peaks."""
     shift = -20.0
-    spec1 = numpy.array([[100, 200, 300, 500],
-                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+    spec1_mz = numpy.array([100, 200, 300, 500], dtype="float")
 
-    spec2 = numpy.array([[105, 205.1, 300, 500.1],
-                         [0.1, 0.1, 1.0, 1.0]], dtype="float").T
+    spec2_mz = numpy.array([105, 205.1, 300, 500.1], dtype="float")
     if numba_compiled:
-        matches = find_matches(spec1, spec2, tolerance=0.2, shift=shift)
+        matches = find_matches(spec1_mz, spec2_mz, tolerance=0.2, shift=shift)
     else:
-        matches = find_matches.py_func(spec1, spec2, tolerance=0.2, shift=shift)
+        matches = find_matches.py_func(spec1_mz, spec2_mz, tolerance=0.2, shift=shift)
     assert matches == [], "Expected empty list of matches."
 
 


### PR DESCRIPTION
Renamed parameters to be only m/z values from spectra. Changed handling to expect 1d arrays.

Adapted test cases to work with new format and renamed corresponding variables.

Fixes #208