### PR TITLE
Made MSP export format compatible with MS-FINDER & MS-DIAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Update README.rst to fix fstring-quote python example [#226](https://github.com/matchms/matchms/pull/226)
+- Reordered written metadata in MSP export for compatability with MS-FINDER & MS-DIAL
 
 ## [0.9.0] - 2021-05-06
 

--- a/matchms/exporting/save_as_msp.py
+++ b/matchms/exporting/save_as_msp.py
@@ -52,13 +52,19 @@ def write_spectrum(spectrum: Spectrum, outfile: IO):
 
 
 def write_peaks(peaks: Spikes, outfile: IO):
+    outfile.write('NUM PEAKS: %d\n' % len(peaks))
     for mz, intensity in zip(peaks.mz, peaks.intensities):
         outfile.write('%s\t%s\n' % (str(mz), str(intensity)))
 
 
 def write_metadata(metadata: dict, outfile: IO):
     for key, value in metadata.items():
-        outfile.write('%s: %s\n' % (key.upper(), str(value)))
+        if not is_num_peaks(key):
+            outfile.write('%s: %s\n' % (key.upper(), str(value)))
+
+
+def is_num_peaks(key: str) -> bool:
+    return key.lower().startswith("num peaks")
 
 
 def ensure_list(spectra) -> List[Spectrum]:

--- a/tests/Hydrogen_chloride.msp
+++ b/tests/Hydrogen_chloride.msp
@@ -1,0 +1,11 @@
+NAME: Hydrogen chloride
+FORMULA: ClH
+MW: 36
+ID: 49
+NUM PEAKS: 4
+STDINCHI: InChI=1S/ClH/h1H
+SMILES: [H+].[Cl-]
+35.0	169.85
+36.0	999.0
+37.0	53.95
+38.0	323.71

--- a/tests/test_save_as_msp.py
+++ b/tests/test_save_as_msp.py
@@ -113,7 +113,15 @@ def test_num_peaks_last_metadata_field(filename, data):
     save_as_msp(data, filename)
 
     with open(filename, mode='r') as file:
-        lines = file.readlines()
-        
+        content = file.readlines()
+        for idx, line in enumerate(content):
+            if line.startswith('NUM PEAKS: '):
+                num_peaks = int(line.split()[2])
+                peaks = content[idx + 1: idx + num_peaks + 1]
+                for peak in peaks:
+                    mz, intensity = peak.split()
+                    mz = float(mz)
+                    intensity = float(intensity)
 
-    assert lines is not None
+                    assert isinstance(mz, float)
+                    assert isinstance(intensity, float)

--- a/tests/test_save_as_msp.py
+++ b/tests/test_save_as_msp.py
@@ -19,7 +19,7 @@ def spectrum():
                     intensities=numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
 
 
-@pytest.fixture(params=["rcx_gc-ei_ms_20201028_perylene.msp", "MoNA-export-GC-MS-first10.msp"])
+@pytest.fixture(params=["rcx_gc-ei_ms_20201028_perylene.msp", "MoNA-export-GC-MS-first10.msp", "Hydrogen_chloride.msp"])
 def data(request):
     module_root = os.path.join(os.path.dirname(__file__), "..")
     spectrums_file = os.path.join(module_root, "tests", request.param)
@@ -106,3 +106,14 @@ def save_and_reload_spectra(filename, spectra: List[Spectrum]):
     save_as_msp(spectra, filename)
     reloaded_spectra = list(load_from_msp(filename))
     return reloaded_spectra
+
+
+def test_num_peaks_last_metadata_field(filename, data):
+    """ Test to check whether the last line before the peaks is NUM PEAKS: ... """
+    save_as_msp(data, filename)
+
+    with open(filename, mode='r') as file:
+        lines = file.readlines()
+        
+
+    assert lines is not None


### PR DESCRIPTION
Changed the 'NUM PEAKS' metadata key as being the last one exported before the actual peak data.
This ensures that the peak data is loaded correctly in tools like MS-FINDER and MS-DIAL.

Fixes #229 