### PR TITLE
Fix derive parent_mass, when charge = 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Correctly handle charge=0 entries in `add_parent_mass` filter [#236](https://github.com/matchms/matchms/pull/236)
+- Reordered written metadata in MSP export for compatability with MS-FINDER & MS-DIAL [#230](https://github.com/matchms/matchms/pull/230)
 - Update README.rst to fix fstring-quote python example [#226](https://github.com/matchms/matchms/pull/226)
-- Reordered written metadata in MSP export for compatability with MS-FINDER & MS-DIAL
 
 ## [0.9.0] - 2021-05-06
 

--- a/matchms/filtering/add_parent_mass.py
+++ b/matchms/filtering/add_parent_mass.py
@@ -46,7 +46,7 @@ def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True
             correction_mass = adducts_dict[adduct]["correction_mass"]
             parent_mass = precursor_mz * multiplier - correction_mass
 
-        if parent_mass is None and charge is not None:
+        if parent_mass is None and charge is not None and charge != 0:
             # Otherwise assume adduct of shape [M+xH] or [M-xH]
             protons_mass = PROTON_MASS * charge
             precursor_mass = precursor_mz * abs(charge)

--- a/tests/test_add_parent_mass.py
+++ b/tests/test_add_parent_mass.py
@@ -5,7 +5,7 @@ from matchms.filtering import add_parent_mass
 
 
 def test_add_parent_mass_pepmass_no_precursormz(capsys):
-    """Test if correct expection is returned."""
+    """Test if correct exception is returned."""
     mz = numpy.array([], dtype='float')
     intensities = numpy.array([], dtype='float')
     metadata = {"pepmass": (444.0, 10),
@@ -21,7 +21,7 @@ def test_add_parent_mass_pepmass_no_precursormz(capsys):
 
 
 def test_add_parent_mass_no_precursormz(capsys):
-    """Test if correct expection is returned."""
+    """Test if correct exception is returned."""
     mz = numpy.array([], dtype='float')
     intensities = numpy.array([], dtype='float')
     metadata = {"charge": -1}
@@ -33,6 +33,22 @@ def test_add_parent_mass_no_precursormz(capsys):
 
     assert spectrum.get("parent_mass") is None, "Expected no parent mass"
     assert "Missing precursor m/z to derive parent mass." in capsys.readouterr().out
+
+
+def test_add_parent_mass_precursormz_zero_charge(capsys):
+    """Test if correct exception is returned."""
+    mz = numpy.array([], dtype='float')
+    intensities = numpy.array([], dtype='float')
+    metadata = {"precursor_mz": 444.0,
+                "charge": 0}
+    spectrum_in = Spectrum(mz=mz,
+                           intensities=intensities,
+                           metadata=metadata)
+
+    spectrum = add_parent_mass(spectrum_in)
+
+    assert spectrum.get("parent_mass") is None, "Expected no parent mass"
+    assert "Not sufficient spectrum metadata to derive parent mass." in capsys.readouterr().out
 
 
 def test_add_parent_mass_precursormz(capsys):


### PR DESCRIPTION
When the charge is set at None in the metadata and no ioncharge is given. The charge will be set to 0.
In add parent_mass the charge is used to derive the parent mass from the precursor_mz and the charge. If the charge is set to 0, this results in a parent mass of 0.0, which is unexpected behavior. 
This pull request adds a quick fix, since it will now print the warning "Not sufficient spectrum metadata to derive parent mass." if charge = 0. 

Alternative might be automatically using a charge of 1, when the charge is set to 0.