### PR TITLE
proposed filtering modifications

### DIFF
--- a/matchms/filtering/reduce_to_number_of_peaks.py
+++ b/matchms/filtering/reduce_to_number_of_peaks.py
@@ -26,6 +26,8 @@ def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 1, n_
     """
     def _set_maximum_number_of_peaks_to_keep():
         parent_mass = spectrum.get("parent_mass", None)
+        if parent_mass is None:
+            parent_mass = spectrum.get("mz_precursor", None)
         if parent_mass and ratio_desired:
             n_desired_by_mass = int(ceil(ratio_desired * parent_mass))
             return min(max(n_required, n_desired_by_mass), n_max)


### PR DESCRIPTION
Hi,

I was trying to train a spec2vec model using some preprocessing steps.

My mgf does not include an adduct charge or parent_mass field, but it includes an a PEPMASS field and therefore I can use add_mz_precursor to fill the mz_precusor field. The reduce_to_number_of_peaks function is not working however as the resulting spectrum does not have a parent_mass field.

Looking at the implementation I don t see a reason why this filter can't work with a mz_precusor only, I therefore propose to include it.

I hope it makes sense,

Alexis
