### PR TITLE
Remove deprecation warning about np.bool

### DIFF
--- a/matchms/similarity/ParentMassMatch.py
+++ b/matchms/similarity/ParentMassMatch.py
@@ -52,7 +52,7 @@ class ParentMassMatch(BaseSimilarity):
     # Set key characteristics as class attributes
     is_commutative = True
     # Set output data type, e.g.  "float" or [("score", "float"), ("matches", "int")]
-    score_datatype = numpy.bool
+    score_datatype = bool
 
     def __init__(self, tolerance: float = 0.1):
         """

--- a/matchms/similarity/PrecursorMzMatch.py
+++ b/matchms/similarity/PrecursorMzMatch.py
@@ -53,7 +53,7 @@ class PrecursorMzMatch(BaseSimilarity):
     """
     # Set key characteristics as class attributes
     is_commutative = True
-    score_datatype = numpy.bool
+    score_datatype = bool
 
     def __init__(self, tolerance: float = 0.1, tolerance_type: str = "Dalton"):
         """


### PR DESCRIPTION
# This is to remove the following warning in our test suite:

matchms/similarity/ParentMassMatch.py:55
matchms/similarity/ParentMassMatch.py:55: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    score_datatype = numpy.bool

matchms/similarity/PrecursorMzMatch.py:56
matchms/similarity/PrecursorMzMatch.py:56: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    score_datatype = numpy.bool


# Pytest test report: (so I guess it is safe for merge)
===================== 373 passed, 16 skipped, 32 warnings in 6.96s =====================
