### PR TITLE
Filter square_root_intensities

### DIFF
--- a/matchms/filtering/__init__.py
+++ b/matchms/filtering/__init__.py
@@ -69,6 +69,7 @@ from .select_by_mz import select_by_mz
 from .select_by_relative_intensity import select_by_relative_intensity
 from .set_ionmode_na_when_missing import set_ionmode_na_when_missing
 from .SpeciesString import SpeciesString
+from .square_root_intensities import square_root_intensities
 
 
 __all__ = [
@@ -104,5 +105,6 @@ __all__ = [
     "select_by_mz",
     "select_by_relative_intensity",
     "set_ionmode_na_when_missing",
-    "SpeciesString"
+    "SpeciesString",
+    "square_root_intensities"
 ]

--- a/matchms/filtering/_intenstiy_manager.py
+++ b/matchms/filtering/_intenstiy_manager.py
@@ -1,0 +1,43 @@
+import numpy
+from matchms.typing import SpectrumType
+from ..Spikes import Spikes
+
+
+class IntensityManagerBase:
+    """Base class to replace intensities of a spectrum.
+    This base class is designed to be extended by modyfing the ._get_new_intensities() method."""
+
+    spectrum = None
+
+    def __init__(self, spectrum_in: SpectrumType):
+
+        if spectrum_in is not None:
+            self.spectrum = spectrum_in.clone()
+
+    def replace_intensities(self) -> SpectrumType:
+        """Replace intensities of an MS/MS spectrum with their square-root."""
+
+        spectrum = self.spectrum
+
+        if spectrum is None:
+            return None
+
+        if len(spectrum.peaks) == 0:
+            return spectrum
+
+        self._replace_spectrum_attribute("peaks")
+        if spectrum.losses is not None and len(spectrum.losses) > 0:
+            self._replace_spectrum_attribute("losses")
+
+        return spectrum
+
+    def _replace_spectrum_attribute(self, attr_name: str) -> None:
+        mz, intensities = getattr(self.spectrum, attr_name)
+        new_intensities = self._get_new_intensities(intensities)
+        setattr(self.spectrum, attr_name, Spikes(mz=mz, intensities=new_intensities))
+
+    def _get_new_intensities(self, intensities: numpy.ndarray) -> numpy.ndarray:
+        """This method perform the actual computation on intensities.
+        Change this method when extend this class."""
+
+        return intensities

--- a/matchms/filtering/normalize_intensities.py
+++ b/matchms/filtering/normalize_intensities.py
@@ -1,30 +1,31 @@
 import numpy
 from matchms.typing import SpectrumType
-from ..Spikes import Spikes
+from ._intenstiy_manager import IntensityManagerBase
+
+
+class IntensityManagerNormalize(IntensityManagerBase):
+    """Class to manage remplacement of a spectrum instensity to its normalized intensity."""
+
+    max_intensity = None
+
+    def __init__(self, *args, **kwargs):
+        """Set max intensity."""
+
+        super().__init__(*args, **kwargs)
+        if (self.spectrum is not None) and (len(self.spectrum.peaks) > 0):
+            self.max_intensity = numpy.max(self.spectrum.peaks.intensities)
+
+    def _get_new_intensities(self, intensities: numpy.ndarray) -> numpy.ndarray:
+        """Normalize intensities."""
+
+        if self.max_intensity is None:
+            return intensities
+        return intensities / self.max_intensity
 
 
 def normalize_intensities(spectrum_in: SpectrumType) -> SpectrumType:
     """Normalize intensities of peaks (and losses) to unit height."""
 
-    if spectrum_in is None:
-        return None
+    manager = IntensityManagerNormalize(spectrum_in)
 
-    spectrum = spectrum_in.clone()
-
-    if len(spectrum.peaks) == 0:
-        return spectrum
-
-    max_intensity = numpy.max(spectrum.peaks.intensities)
-
-    # Normalize peak intensities
-    mz, intensities = spectrum.peaks
-    normalized_intensities = intensities / max_intensity
-    spectrum.peaks = Spikes(mz=mz, intensities=normalized_intensities)
-
-    # Normalize loss intensities
-    if spectrum.losses is not None and len(spectrum.losses) > 0:
-        mz, intensities = spectrum.losses
-        normalized_intensities = intensities / max_intensity
-        spectrum.losses = Spikes(mz=mz, intensities=normalized_intensities)
-
-    return spectrum
+    return manager.replace_intensities()

--- a/matchms/filtering/square_root_intensities.py
+++ b/matchms/filtering/square_root_intensities.py
@@ -1,0 +1,19 @@
+import numpy
+from matchms.typing import SpectrumType
+from ._intenstiy_manager import IntensityManagerBase
+
+
+class IntensityManagerSquareRoot(IntensityManagerBase):
+    """Class to manage remplacement of a spectrum instensity to its square root intensity."""
+
+    def _get_new_intensities(self, intensities: numpy.ndarray) -> numpy.ndarray:
+        return numpy.sqrt(intensities)
+
+
+def square_root_intensities(spectrum_in: SpectrumType) -> SpectrumType:
+    """Replace intensities of an MS/MS spectrum with their square-root
+    to minimize/maximize effects of high/low intensity peaks"""
+
+    manager = IntensityManagerSquareRoot(spectrum_in)
+
+    return manager.replace_intensities()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import numpy
+import pytest
+from matchms import Spectrum
+from matchms.filtering import add_losses
+
+
+@pytest.fixture
+def mz():
+    return numpy.array([10, 20, 30, 40], dtype='float')
+
+
+@pytest.fixture
+def intensities():
+    return numpy.array([0, 1, 10, 100], dtype='float')
+
+
+@pytest.fixture
+def spectrum_without_losses(mz, intensities):
+    return Spectrum(mz=mz, intensities=intensities)
+
+
+@pytest.fixture
+def spectrum_with_losses(mz, intensities):
+    spectrum = Spectrum(mz=mz, intensities=intensities, metadata={"precursor_mz": 45.0})
+    return add_losses(spectrum)
+
+
+@pytest.fixture
+def spectrum_without_peaks():
+    mz = numpy.array([], dtype='float')
+    intensities = numpy.array([], dtype='float')
+    return Spectrum(mz=mz, intensities=intensities)

--- a/tests/test_normalize_intensities.py
+++ b/tests/test_normalize_intensities.py
@@ -1,48 +1,37 @@
 import numpy
-from matchms import Spectrum
-from matchms.filtering import add_losses
 from matchms.filtering import normalize_intensities
 
 
-def test_normalize_intensities():
-    """Test if peak intensities are normalized correctly."""
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
-    spectrum_in = Spectrum(mz=mz, intensities=intensities)
+def test_square_root_intensities(spectrum_without_losses, mz, intensities):
+    """Test if peak intensities are square root correctly."""
 
-    spectrum = normalize_intensities(spectrum_in)
+    spectrum = normalize_intensities(spectrum_without_losses)
 
     assert max(spectrum.peaks.intensities) == 1.0, "Expected the spectrum to be scaled to 1.0."
     assert numpy.array_equal(spectrum.peaks.intensities, intensities/100), "Expected different intensities"
     assert numpy.array_equal(spectrum.peaks.mz, mz), "Expected different peak mz."
 
 
-def test_normalize_intensities_losses_present():
-    """Test if also losses (if present) are normalized correctly."""
-    mz = numpy.array([10, 20, 30, 40], dtype='float')
-    intensities = numpy.array([0, 1, 10, 100], dtype='float')
-    spectrum_in = Spectrum(mz=mz, intensities=intensities,
-                           metadata={"precursor_mz": 45.0})
+def test_square_root_intensities_losses_present(spectrum_with_losses, mz, intensities):
+    """Test if also losses (if present) are square root correctly."""
 
-    spectrum = add_losses(spectrum_in)
-    spectrum = normalize_intensities(spectrum)
+    spectrum = normalize_intensities(spectrum_with_losses)
+
     expected_loss_intensities = numpy.array([1., 0.1, 0.01, 0.], dtype='float')
 
     assert max(spectrum.peaks.intensities) == 1.0, "Expected the spectrum to be scaled to 1.0."
     assert numpy.array_equal(spectrum.peaks.intensities, intensities/100), "Expected different intensities"
     assert max(spectrum.losses.intensities) == 1.0, "Expected the losses to be scaled to 1.0."
-    assert numpy.all(spectrum.losses.intensities == expected_loss_intensities), "Expected different loss intensities"
+    assert numpy.array_equal(spectrum.losses.intensities, expected_loss_intensities), "Expected different loss intensities"
+    assert numpy.array_equal(spectrum.peaks.mz, mz), "Expected different peak mz."
 
 
-def test_normalize_intensities_empty_peaks():
+def test_normalize_intensities_empty_peaks(spectrum_without_peaks):
     """Test running filter with empty peaks spectrum."""
-    mz = numpy.array([], dtype='float')
-    intensities = numpy.array([], dtype='float')
-    spectrum_in = Spectrum(mz=mz, intensities=intensities)
 
-    spectrum = normalize_intensities(spectrum_in)
+    spectrum = normalize_intensities(spectrum_without_peaks)
 
-    assert spectrum == spectrum_in, "Spectrum should remain unchanged."
+    assert spectrum == spectrum_without_peaks, "Spectrum should remain unchanged."
 
 
 def test_normalize_intensities_empty_spectrum():

--- a/tests/test_square_root_intensities.py
+++ b/tests/test_square_root_intensities.py
@@ -1,0 +1,41 @@
+import numpy
+from matchms.filtering import square_root_intensities
+
+
+def test_square_root_intensities(spectrum_without_losses, mz, intensities):
+    """Test if peak intensities are normalized correctly."""
+
+    spectrum = square_root_intensities(spectrum_without_losses)
+
+    expected_intensities = numpy.sqrt(intensities)
+
+    assert numpy.array_equal(spectrum.peaks.intensities, expected_intensities), "Expected different intensities"
+    assert numpy.array_equal(spectrum.peaks.mz, mz), "Expected different peak mz."
+
+
+def test_square_root_intensities_losses_present(spectrum_with_losses, mz, intensities):
+    """Test if also losses (if present) are normalized correctly."""
+
+    spectrum = square_root_intensities(spectrum_with_losses)
+
+    expected_intensities = numpy.sqrt(intensities)
+    expected_loss_intensities = numpy.sqrt(spectrum_with_losses.losses.intensities)
+
+    assert numpy.array_equal(spectrum.peaks.intensities, expected_intensities), "Expected different intensities"
+    assert numpy.array_equal(spectrum.losses.intensities, expected_loss_intensities), "Expected different loss intensities"
+    assert numpy.array_equal(spectrum.peaks.mz, mz), "Expected different peak mz."
+
+
+def test_square_root_intensities_empty_peaks(spectrum_without_peaks):
+    """Test running filter with empty peaks spectrum."""
+
+    spectrum = square_root_intensities(spectrum_without_peaks)
+
+    assert spectrum == spectrum_without_peaks, "Spectrum should remain unchanged."
+
+
+def test_square_root_intensities_empty_spectrum():
+    """Test running filter with spectrum == None."""
+    spectrum = square_root_intensities(None)
+
+    assert spectrum is None, "Expected spectrum to be None."


### PR DESCRIPTION
I propose this filter to replace spectrum intensities by their square root value.

This square root filtering is used in MetGem, and I guess GNPS, prior to normalization and cosine similarity score. This will allow to have cosine score closer to those other tools by using Matchms. 

I've factorized some code from normalized_intensities filter, including pytest fixtures.

Can it also contribute to https://github.com/matchms/matchms/issues/209#issuecomment-801717729 ?
