### PR TITLE
Derive parent mass from mz precursor if charge is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Code linting triggered by pylint update [#257](https://github.com/matchms/matchms/pull/257)
+- Refactored `add_parent_mass()` filter can now also handle missing charge entries (if ionmode is known) [#252](https://github.com/matchms/matchms/pull/252)
 
 ## [0.9.2] - 2021-07-20
 

--- a/matchms/filtering/add_parent_mass.py
+++ b/matchms/filtering/add_parent_mass.py
@@ -32,36 +32,38 @@ def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True
     spectrum = spectrum_in.clone()
     adducts_dict = load_adducts_dict()
 
-    if spectrum.get("parent_mass", None) is None or overwrite_existing_entry:
-        parent_mass = None
-        charge = spectrum.get("charge")
-        adduct = clean_adduct(spectrum.get("adduct"))
-        precursor_mz = spectrum.get("precursor_mz", None)
-        if precursor_mz is None:
-            print("Missing precursor m/z to derive parent mass.")
-            return spectrum
+    if spectrum.get("parent_mass", None) and not overwrite_existing_entry:
+        return spectrum
 
-        if estimate_from_adduct and adduct in adducts_dict:
-            multiplier = adducts_dict[adduct]["mass_multiplier"]
-            correction_mass = adducts_dict[adduct]["correction_mass"]
-            parent_mass = precursor_mz * multiplier - correction_mass
+    parent_mass = None
+    charge = spectrum.get("charge")
+    adduct = clean_adduct(spectrum.get("adduct"))
+    precursor_mz = spectrum.get("precursor_mz", None)
+    if precursor_mz is None:
+        print("Missing precursor m/z to derive parent mass.")
+        return spectrum
 
-        if parent_mass is None and charge is not None and charge != 0:
-            # Otherwise assume adduct of shape [M+xH] or [M-xH]
+    if estimate_from_adduct and (adduct in adducts_dict):
+        multiplier = adducts_dict[adduct]["mass_multiplier"]
+        correction_mass = adducts_dict[adduct]["correction_mass"]
+        parent_mass = precursor_mz * multiplier - correction_mass
+
+    if parent_mass is None:
+        # Handle missing charge if ionmode is given
+        ionmode = spectrum.get('ionmode')
+        if (charge in[None, 0]) and ionmode in ["positive", "negative"]:
+            charge = 1 if ionmode == "positive" else -1
+            print(f"Missing charge entry, but {ionmode} ionmode detected. " \
+                  "Consider prior run of `correct_charge()` filter.")
+
+        if charge not in [None, 0]:
+            # Assume adduct of shape [M+xH] or [M-xH]
             protons_mass = PROTON_MASS * charge
             precursor_mass = precursor_mz * abs(charge)
             parent_mass = precursor_mass - protons_mass
-        
-        if parent_mass is None:
-            # If charge and adduct is not given the ionmode is checked to assume a charge of -1 or +1
-            # Alternatively, you can run derive_ion mode followed by correct charge, before running add_parent_mass to use the metadata to set the ionmode and charge. 
-            if spectrum.get('ionmode') == "positive":
-               parent_mass = precursor_mz - PROTON_MASS
-            if spectrum.get('ionmode') == "negative":
-                parent_mass = precursor_mz + PROTON_MASS
-        
-        if parent_mass is None:
-            print("Not sufficient spectrum metadata to derive parent mass.")
-        else:
-            spectrum.set("parent_mass", float(parent_mass))
+
+    if parent_mass is None:
+        print("Not sufficient spectrum metadata to derive parent mass.")
+    else:
+        spectrum.set("parent_mass", float(parent_mass))
     return spectrum

--- a/matchms/filtering/add_parent_mass.py
+++ b/matchms/filtering/add_parent_mass.py
@@ -60,5 +60,8 @@ def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True
             if spectrum.get('ionmode') == "negative":
                 parent_mass = precursor_mz + PROTON_MASS
         
-        spectrum.set("parent_mass", float(parent_mass))
+        if parent_mass is None:
+            print("Not sufficient spectrum metadata to derive parent mass.")
+        else:
+            spectrum.set("parent_mass", float(parent_mass))
     return spectrum

--- a/matchms/filtering/add_parent_mass.py
+++ b/matchms/filtering/add_parent_mass.py
@@ -55,7 +55,7 @@ def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True
         if parent_mass is None:
             print("Warning: charge is unknown, so assumed to be 1")
             precursor_mass = precursor_mz
-            parent_mass = precursor_mass - PROTONS_MASS
+            parent_mass = precursor_mass - PROTON_MASS
         
         spectrum.set("parent_mass", float(parent_mass))
     return spectrum

--- a/matchms/filtering/add_parent_mass.py
+++ b/matchms/filtering/add_parent_mass.py
@@ -53,9 +53,12 @@ def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True
             parent_mass = precursor_mass - protons_mass
         
         if parent_mass is None:
-            print("Warning: charge is unknown, so assumed to be 1")
-            precursor_mass = precursor_mz
-            parent_mass = precursor_mass - PROTON_MASS
+            # If charge and adduct is not given the ionmode is checked to assume a charge of -1 or +1
+            # Alternatively, you can run derive_ion mode followed by correct charge, before running add_parent_mass to use the metadata to set the ionmode and charge. 
+            if spectrum.get('ionmode') == "positive":
+               parent_mass = precursor_mz - PROTON_MASS
+            if spectrum.get('ionmode') == "negative":
+                parent_mass = precursor_mz + PROTON_MASS
         
         spectrum.set("parent_mass", float(parent_mass))
     return spectrum

--- a/matchms/filtering/add_parent_mass.py
+++ b/matchms/filtering/add_parent_mass.py
@@ -51,9 +51,11 @@ def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True
             protons_mass = PROTON_MASS * charge
             precursor_mass = precursor_mz * abs(charge)
             parent_mass = precursor_mass - protons_mass
-
+        
         if parent_mass is None:
-            print("Not sufficient spectrum metadata to derive parent mass.")
-        else:
-            spectrum.set("parent_mass", float(parent_mass))
+            print("Warning: charge is unknown, so assumed to be 1")
+            precursor_mass = precursor_mz
+            parent_mass = precursor_mass - PROTONS_MASS
+        
+        spectrum.set("parent_mass", float(parent_mass))
     return spectrum

--- a/matchms/filtering/add_parent_mass.py
+++ b/matchms/filtering/add_parent_mass.py
@@ -51,9 +51,9 @@ def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True
     if parent_mass is None:
         # Handle missing charge if ionmode is given
         ionmode = spectrum.get('ionmode')
-        if (charge in[None, 0]) and ionmode in ["positive", "negative"]:
+        if (charge in [None, 0]) and ionmode in ["positive", "negative"]:
             charge = 1 if ionmode == "positive" else -1
-            print(f"Missing charge entry, but {ionmode} ionmode detected. " \
+            print(f"Missing charge entry, but {ionmode} ionmode detected. "
                   "Consider prior run of `correct_charge()` filter.")
 
         if charge not in [None, 0]:

--- a/matchms/filtering/add_parent_mass.py
+++ b/matchms/filtering/add_parent_mass.py
@@ -30,11 +30,11 @@ def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True
         return (charge is not None) and (charge != 0)
 
     def guess_charge_from_ionmode(spectrum):
-        ionmode = spectrum.get('ionmode')
-        if ionmode == "positive":
+        if spectrum.get('ionmode') == "positive":
             return 1
-        if ionmode == "negative":
+        if spectrum.get('ionmode') == "negative":
             return -1
+        return 0
 
     if spectrum_in is None:
         return None

--- a/matchms/filtering/add_parent_mass.py
+++ b/matchms/filtering/add_parent_mass.py
@@ -81,4 +81,7 @@ def _get_charge(spectrum):
         print("Missing charge entry, but negative ionmode detected. "
               "Consider prior run of `correct_charge()` filter.")
         return -1
+
+    print("Missing charge and ionmode entries. "
+          "Consider prior run of `derive_ionmode()` and `correct_charge()` filters.")
     return 0

--- a/tests/test_add_parent_mass.py
+++ b/tests/test_add_parent_mass.py
@@ -91,7 +91,9 @@ def test_add_parent_mass_using_adduct(adduct, expected):
     assert isinstance(spectrum.get("parent_mass"), float), "Expected parent mass to be float."
 
 
-def test_add_parent_mass_overwrite():
+@pytest.mark.parametrize("overwrite, expected", [(True, 442.992724),
+                                                 (False, 443.0)])
+def test_add_parent_mass_overwrite(overwrite, expected):
     """Test if parent mass is replaced by newly calculated value."""
     mz = numpy.array([], dtype='float')
     intensities = numpy.array([], dtype='float')
@@ -103,9 +105,9 @@ def test_add_parent_mass_overwrite():
                            intensities=intensities,
                            metadata=metadata)
 
-    spectrum = add_parent_mass(spectrum_in, overwrite_existing_entry=True)
+    spectrum = add_parent_mass(spectrum_in, overwrite_existing_entry=overwrite)
 
-    assert numpy.allclose(spectrum.get("parent_mass"), 442.992724, atol=1e-4), \
+    assert numpy.allclose(spectrum.get("parent_mass"), expected, atol=1e-4), \
         "Expected parent mass to be replaced by new value."
 
 

--- a/tests/test_add_parent_mass.py
+++ b/tests/test_add_parent_mass.py
@@ -2,6 +2,7 @@ import numpy
 import pytest
 from matchms import Spectrum
 from matchms.filtering import add_parent_mass
+from matchms.constants import PROTON_MASS
 
 
 def test_add_parent_mass_pepmass_no_precursormz(capsys):
@@ -128,3 +129,18 @@ def test_empty_spectrum():
     spectrum = add_parent_mass(spectrum_in)
 
     assert spectrum is None, "Expected different handling of None spectrum."
+    
+
+def test_use_ionmode():
+    """Test when there is no charge given, that the ionmode is used to derive parent mass."""
+    mz = numpy.array([], dtype='float')
+    intensities = numpy.array([], dtype='float')
+    metadata = {"precursor_mz": 444.0, "ionmode": "positive"}
+    spectrum_in = Spectrum(mz=mz,
+                           intensities=intensities,
+                           metadata=metadata)
+
+    spectrum = add_parent_mass(spectrum_in)
+
+    assert spectrum.get("parent_mass") == 444.0 - PROTON_MASS, "Expected a different parent_mass"
+  

--- a/tests/test_add_parent_mass.py
+++ b/tests/test_add_parent_mass.py
@@ -131,7 +131,7 @@ def test_empty_spectrum():
     assert spectrum is None, "Expected different handling of None spectrum."
     
 
-def test_use_ionmode():
+def test_use_positive_ionmode():
     """Test when there is no charge given, that the ionmode is used to derive parent mass."""
     mz = numpy.array([], dtype='float')
     intensities = numpy.array([], dtype='float')
@@ -143,4 +143,18 @@ def test_use_ionmode():
     spectrum = add_parent_mass(spectrum_in)
 
     assert spectrum.get("parent_mass") == 444.0 - PROTON_MASS, "Expected a different parent_mass"
+    
+    
+def test_use_negative_ionmode():
+    """Test when there is no charge given, that the ionmode is used to derive parent mass."""
+    mz = numpy.array([], dtype='float')
+    intensities = numpy.array([], dtype='float')
+    metadata = {"precursor_mz": 444.0, "ionmode": "negative"}
+    spectrum_in = Spectrum(mz=mz,
+                           intensities=intensities,
+                           metadata=metadata)
+
+    spectrum = add_parent_mass(spectrum_in)
+
+    assert spectrum.get("parent_mass") == 444.0 + PROTON_MASS, "Expected a different parent_mass"
   

--- a/tests/test_add_parent_mass.py
+++ b/tests/test_add_parent_mass.py
@@ -129,7 +129,7 @@ def test_empty_spectrum():
     spectrum = add_parent_mass(spectrum_in)
 
     assert spectrum is None, "Expected different handling of None spectrum."
-    
+
 
 def test_use_positive_ionmode():
     """Test when there is no charge given, that the ionmode is used to derive parent mass."""
@@ -143,8 +143,8 @@ def test_use_positive_ionmode():
     spectrum = add_parent_mass(spectrum_in)
 
     assert spectrum.get("parent_mass") == 444.0 - PROTON_MASS, "Expected a different parent_mass"
-    
-    
+
+
 def test_use_negative_ionmode():
     """Test when there is no charge given, that the ionmode is used to derive parent mass."""
     mz = numpy.array([], dtype='float')
@@ -157,4 +157,4 @@ def test_use_negative_ionmode():
     spectrum = add_parent_mass(spectrum_in)
 
     assert spectrum.get("parent_mass") == 444.0 + PROTON_MASS, "Expected a different parent_mass"
-  
+

--- a/tests/test_add_parent_mass.py
+++ b/tests/test_add_parent_mass.py
@@ -1,8 +1,8 @@
 import numpy
 import pytest
 from matchms import Spectrum
-from matchms.filtering import add_parent_mass
 from matchms.constants import PROTON_MASS
+from matchms.filtering import add_parent_mass
 
 
 def test_add_parent_mass_pepmass_no_precursormz(capsys):
@@ -142,7 +142,8 @@ def test_use_positive_ionmode():
 
     spectrum = add_parent_mass(spectrum_in)
 
-    assert spectrum.get("parent_mass") == 444.0 - PROTON_MASS, "Expected a different parent_mass"
+    assert spectrum.get("parent_mass") == (444.0 - PROTON_MASS), \
+        "Expected a different parent_mass"
 
 
 def test_use_negative_ionmode():
@@ -156,5 +157,5 @@ def test_use_negative_ionmode():
 
     spectrum = add_parent_mass(spectrum_in)
 
-    assert spectrum.get("parent_mass") == 444.0 + PROTON_MASS, "Expected a different parent_mass"
-
+    assert spectrum.get("parent_mass") == (444.0 + PROTON_MASS), \
+        "Expected a different parent_mass"

--- a/tests/test_add_parent_mass.py
+++ b/tests/test_add_parent_mass.py
@@ -133,31 +133,19 @@ def test_empty_spectrum():
     assert spectrum is None, "Expected different handling of None spectrum."
 
 
-def test_use_positive_ionmode():
-    """Test when there is no charge given, that the ionmode is used to derive parent mass."""
+@pytest.mark.parametrize("ionmode, expected", [("positive", 444.0 - PROTON_MASS),
+                                               ("negative", 444.0 + PROTON_MASS)])
+def test_use_of_ionmode(ionmode, expected):
+    """Test when there is no charge given, than the ionmode
+    is used to derive parent mass."""
     mz = numpy.array([], dtype='float')
     intensities = numpy.array([], dtype='float')
-    metadata = {"precursor_mz": 444.0, "ionmode": "positive"}
+    metadata = {"precursor_mz": 444.0, "ionmode": ionmode}
     spectrum_in = Spectrum(mz=mz,
                            intensities=intensities,
                            metadata=metadata)
 
     spectrum = add_parent_mass(spectrum_in)
 
-    assert spectrum.get("parent_mass") == (444.0 - PROTON_MASS), \
-        "Expected a different parent_mass"
-
-
-def test_use_negative_ionmode():
-    """Test when there is no charge given, that the ionmode is used to derive parent mass."""
-    mz = numpy.array([], dtype='float')
-    intensities = numpy.array([], dtype='float')
-    metadata = {"precursor_mz": 444.0, "ionmode": "negative"}
-    spectrum_in = Spectrum(mz=mz,
-                           intensities=intensities,
-                           metadata=metadata)
-
-    spectrum = add_parent_mass(spectrum_in)
-
-    assert spectrum.get("parent_mass") == (444.0 + PROTON_MASS), \
+    assert spectrum.get("parent_mass") == expected, \
         "Expected a different parent_mass"


### PR DESCRIPTION
See #242, for additional discussion on this topic. 

Matchms already has the function add_parent_mass, however this will not add a parent mass if the charge is not specified.
Since in most cases people do not work with multiply charged MS-MS spectra.
I think it would be a good suggestion to still derive the parent mass from the mz_precursor, if the charge is not specified.
So apply the following workflow: Use charge if available, else assume charge == 1.

When creating this pull request, I noticed that the charge also changes if the PROTON_MASS is added or removed. Since, using negative mode is actually getting more common, this would give issues in this case. Do you maybe know of some other info field of information that can be used to differ between positive and negative mode?

I think it will be important to change this, since in all 3 case study datasets I used, the charge (and parent mass) was not given. So I assume that this will be a very common problem for people that want to use matchms. 

If there is no good solution maybe add a comment in the printed message when parent mass cannot be derived to run 
spectrums = [s.set("parent_mass", s.get("precursor_mz")) for s in spectrums] to set the parent mass (or alternatively the charge). 
