### PR TITLE
Install sphinxcontrib.apidoc on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,5 @@ python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - dev


### PR DESCRIPTION
The build on readthedocs is failing with 
```
Extension error:
Could not import extension sphinxcontrib.apidoc (exception: No module named 'sphinxcontrib.apidoc')
```

This PR installs the develop dependencies during readthedocs build.


I configured this branch to be [build](https://readthedocs.org/projects/matchms/builds/15022214/) at readthedocs and it is green. See https://matchms.readthedocs.io/en/rtd-apidoc/ ,

After PR is merged/closed this PR branch should be removed on https://readthedocs.org/projects/matchms/versions/