### PR TITLE
Support importing MGF from file-like object

### DIFF
--- a/matchms/importing/load_from_mgf.py
+++ b/matchms/importing/load_from_mgf.py
@@ -1,30 +1,30 @@
-from io import BytesIO
-from typing import Generator, Union
+from typing import Generator, Union, TextIO
 import numpy
 from pyteomics.mgf import MGF
 from ..Spectrum import Spectrum
 
 
-def load_from_mgf(source: Union[str, BytesIO]) -> Generator[Spectrum, None, None]:
+def load_from_mgf(source: Union[str, TextIO]) -> Generator[Spectrum, None, None]:
     """Load spectrum(s) from mgf file.
 
-    source param accepts both a path to a mgf file or a bytesIO object from a preloaded MGF file
+    source param accepts both a path to a mgf file or a file-like object from a preloaded MGF file
 
-    Example:
+    Examples:
 
     .. code-block:: python
 
         from matchms.importing import load_from_mgf
 
         file_mgf = "pesticides.mgf"
-        spectrums = list(load_from_mgf(file_mgf))
+        spectra_from_path = list(load_from_mgf(file_mgf))
+
+        // or you can read the file in your application
+        with open(file_mgf, 'r') as spectra_file:
+            spectra_from_file = list(load_from_mgf(spectra_file))
 
     """
 
-
-    mgf = MGF(source, convert_arrays=1)
-
-    for pyteomics_spectrum in mgf:
+    for pyteomics_spectrum in MGF(source, convert_arrays=1):
 
         metadata = pyteomics_spectrum.get("params", None)
         mz = pyteomics_spectrum["m/z array"]

--- a/matchms/importing/load_from_mgf.py
+++ b/matchms/importing/load_from_mgf.py
@@ -1,11 +1,14 @@
-from typing import Generator
+from io import BytesIO
+from typing import Generator, Union
 import numpy
 from pyteomics.mgf import MGF
 from ..Spectrum import Spectrum
 
 
-def load_from_mgf(filename: str) -> Generator[Spectrum, None, None]:
+def load_from_mgf(source: Union[str, BytesIO]) -> Generator[Spectrum, None, None]:
     """Load spectrum(s) from mgf file.
+
+    source param accepts both a path to a mgf file or a bytesIO object from a preloaded MGF file
 
     Example:
 
@@ -18,7 +21,10 @@ def load_from_mgf(filename: str) -> Generator[Spectrum, None, None]:
 
     """
 
-    for pyteomics_spectrum in MGF(filename, convert_arrays=1):
+
+    mgf = MGF(source, convert_arrays=1)
+
+    for pyteomics_spectrum in mgf:
 
         metadata = pyteomics_spectrum.get("params", None)
         mz = pyteomics_spectrum["m/z array"]

--- a/matchms/importing/load_from_mgf.py
+++ b/matchms/importing/load_from_mgf.py
@@ -18,7 +18,7 @@ def load_from_mgf(source: Union[str, TextIO]) -> Generator[Spectrum, None, None]
         file_mgf = "pesticides.mgf"
         spectra_from_path = list(load_from_mgf(file_mgf))
 
-        // or you can read the file in your application
+        # Or you can read the file in your application
         with open(file_mgf, 'r') as spectra_file:
             spectra_from_file = list(load_from_mgf(spectra_file))
 

--- a/tests/test_load_from_mgf.py
+++ b/tests/test_load_from_mgf.py
@@ -1,24 +1,26 @@
 import os
-from io import BytesIO
 
+from matchms import Spectrum
 from matchms.importing import load_from_mgf
 
 
-def test_load_from_mgf():
+def test_load_from_mgf_using_filepath():
     module_root = os.path.join(os.path.dirname(__file__), "..")
     spectra_file = os.path.join(module_root, "tests", "pesticides.mgf")
 
-    spectra = load_from_mgf(spectra_file)
+    spectra = list(load_from_mgf(spectra_file))
 
-    assert len(list(spectra)) > 0
+    assert len(spectra) > 0
+    assert isinstance(spectra[0], Spectrum)
 
 
-def test_load_from_mgf_file_like_obj():
+def test_load_from_mgf_using_file():
     module_root = os.path.join(os.path.dirname(__file__), "..")
-    spectra_file = os.path.join(module_root, "tests", "pesticides.mgf")
+    spectra_filepath = os.path.join(module_root, "tests", "pesticides.mgf")
 
-    with open(spectra_file, 'rb') as spectra_bytes:
-        buf = BytesIO(spectra_bytes.read())
-        spectra = load_from_mgf(spectra_bytes)
+    with open(spectra_filepath, 'r') as spectra_file:
+        spectra = list(load_from_mgf(spectra_file))
 
-        assert len(list(spectra)) > 0
+        assert len(spectra) > 0
+        assert isinstance(spectra[0], Spectrum)
+

--- a/tests/test_load_from_mgf.py
+++ b/tests/test_load_from_mgf.py
@@ -1,0 +1,24 @@
+import os
+from io import BytesIO
+
+from matchms.importing import load_from_mgf
+
+
+def test_load_from_mgf():
+    module_root = os.path.join(os.path.dirname(__file__), "..")
+    spectra_file = os.path.join(module_root, "tests", "pesticides.mgf")
+
+    spectra = load_from_mgf(spectra_file)
+
+    assert len(list(spectra)) > 0
+
+
+def test_load_from_mgf_file_like_obj():
+    module_root = os.path.join(os.path.dirname(__file__), "..")
+    spectra_file = os.path.join(module_root, "tests", "pesticides.mgf")
+
+    with open(spectra_file, 'rb') as spectra_bytes:
+        buf = BytesIO(spectra_bytes.read())
+        spectra = load_from_mgf(spectra_bytes)
+
+        assert len(list(spectra)) > 0


### PR DESCRIPTION
* Added tests for both import by file path and file-like object
* Changed type annotations and docstring to indicate support

Turns out pyteomics already supported receiving a file-like (TextIO for instance) object as input for creating the MGF object. So I just changed the docs and added tests to make it clear that we support it.