### PR TITLE
Update isort

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -40,7 +40,7 @@ jobs:
         run: prospector -o grouped -o pylint:pylint-report.txt
       - name: Check whether import statements are used consistently
         shell: bash -l {0}
-        run: isort --check-only --diff --conda-env matchms-dev
+        run: isort --check-only --diff --conda-env matchms-dev --recursive
       - name: SonarCloud Scan
         if: github.repository == 'matchms/matchms'
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -39,8 +39,7 @@ jobs:
         shell: bash -l {0}
         run: prospector -o grouped -o pylint:pylint-report.txt
       - name: Check whether import statements are used consistently
-        shell: bash -l {0}
-        run: isort --check-only --diff --conda-env matchms-dev --recursive
+        run: isort . --check-only --diff
       - name: SonarCloud Scan
         if: github.repository == 'matchms/matchms'
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -40,7 +40,7 @@ jobs:
         run: prospector -o grouped -o pylint:pylint-report.txt
       - name: Check whether import statements are used consistently
         shell: bash -l {0}
-        run: isort --check-only --diff --conda-env matchms-dev --recursive --lines-after-imports 2 --force-single-line --no-lines-before FUTURE --no-lines-before STDLIB --no-lines-before THIRDPARTY --no-lines-before FIRSTPARTY --no-lines-before LOCALFOLDER matchms/ tests/ integration-tests/
+        run: isort --check-only --diff --conda-env matchms-dev
       - name: SonarCloud Scan
         if: github.repository == 'matchms/matchms'
         uses: sonarsource/sonarcloud-github-action@master

--- a/integration-tests/test_user_workflow.py
+++ b/integration-tests/test_user_workflow.py
@@ -2,12 +2,10 @@ import os
 import numpy
 import pytest
 from matchms import calculate_scores
-from matchms.filtering import add_parent_mass
-from matchms.filtering import default_filters
-from matchms.filtering import normalize_intensities
-from matchms.filtering import require_minimum_number_of_peaks
-from matchms.filtering import select_by_mz
-from matchms.filtering import select_by_relative_intensity
+from matchms.filtering import (add_parent_mass, default_filters,
+                               normalize_intensities,
+                               require_minimum_number_of_peaks, select_by_mz,
+                               select_by_relative_intensity)
 from matchms.importing import load_from_mgf
 from matchms.similarity import CosineGreedy
 

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 import numpy
 from deprecated.sphinx import deprecated
 from matchms.similarity.BaseSimilarity import BaseSimilarity
-from matchms.typing import QueriesType
-from matchms.typing import ReferencesType
+from matchms.typing import QueriesType, ReferencesType
 
 
 class Scores:

--- a/matchms/Spectrum.py
+++ b/matchms/Spectrum.py
@@ -1,15 +1,13 @@
 from typing import Optional
 import matplotlib.pyplot as plt
 import numpy as np
-from matchms.plotting.spectrum_plots import plot_spectra_mirror
-from matchms.plotting.spectrum_plots import plot_spectrum
+from matchms.plotting.spectrum_plots import plot_spectra_mirror, plot_spectrum
 from .filtering.add_precursor_mz import _add_precursor_mz_metadata
 from .filtering.add_retention import _add_retention
 from .filtering.interpret_pepmass import _interpret_pepmass_metadata
 from .filtering.make_charge_int import _convert_charge_to_int
 from .Fragments import Fragments
-from .hashing import metadata_hash
-from .hashing import spectrum_hash
+from .hashing import metadata_hash, spectrum_hash
 from .Metadata import Metadata
 
 

--- a/matchms/__init__.py
+++ b/matchms/__init__.py
@@ -1,14 +1,8 @@
-from . import exporting
-from . import filtering
-from . import importing
-from . import networking
-from . import plotting
-from . import similarity
+from . import exporting, filtering, importing, networking, plotting, similarity
 from .__version__ import __version__
 from .calculate_scores import calculate_scores
 from .Fragments import Fragments
-from .logging_functions import _init_logger
-from .logging_functions import set_matchms_logger_level
+from .logging_functions import _init_logger, set_matchms_logger_level
 from .Metadata import Metadata
 from .Scores import Scores
 from .Spectrum import Spectrum

--- a/matchms/calculate_scores.py
+++ b/matchms/calculate_scores.py
@@ -1,7 +1,6 @@
 from .Scores import Scores
 from .similarity.BaseSimilarity import BaseSimilarity
-from .typing import QueriesType
-from .typing import ReferencesType
+from .typing import QueriesType, ReferencesType
 
 
 def calculate_scores(references: ReferencesType, queries: QueriesType,

--- a/matchms/exporting/save_as_msp.py
+++ b/matchms/exporting/save_as_msp.py
@@ -1,9 +1,6 @@
 import logging
 import os
-from typing import IO
-from typing import Dict
-from typing import List
-from typing import Union
+from typing import IO, Dict, List, Union
 from ..Fragments import Fragments
 from ..Spectrum import Spectrum
 

--- a/matchms/filtering/__init__.py
+++ b/matchms/filtering/__init__.py
@@ -41,8 +41,7 @@ from .add_fingerprint import add_fingerprint
 from .add_losses import add_losses
 from .add_parent_mass import add_parent_mass
 from .add_precursor_mz import add_precursor_mz
-from .add_retention import add_retention_index
-from .add_retention import add_retention_time
+from .add_retention import add_retention_index, add_retention_time
 from .clean_compound_name import clean_compound_name
 from .correct_charge import correct_charge
 from .default_filters import default_filters
@@ -56,8 +55,7 @@ from .harmonize_undefined_inchi import harmonize_undefined_inchi
 from .harmonize_undefined_inchikey import harmonize_undefined_inchikey
 from .harmonize_undefined_smiles import harmonize_undefined_smiles
 from .interpret_pepmass import interpret_pepmass
-from .load_adducts import load_adducts_dict
-from .load_adducts import load_known_adduct_conversions
+from .load_adducts import load_adducts_dict, load_known_adduct_conversions
 from .make_charge_int import make_charge_int
 from .make_charge_scalar import make_charge_scalar
 from .make_ionmode_lowercase import make_ionmode_lowercase

--- a/matchms/filtering/add_fingerprint.py
+++ b/matchms/filtering/add_fingerprint.py
@@ -1,7 +1,7 @@
 import logging
 import numpy
-from ..metadata_utils import derive_fingerprint_from_inchi
-from ..metadata_utils import derive_fingerprint_from_smiles
+from ..metadata_utils import (derive_fingerprint_from_inchi,
+                              derive_fingerprint_from_smiles)
 from ..typing import SpectrumType
 
 

--- a/matchms/filtering/add_retention.py
+++ b/matchms/filtering/add_retention.py
@@ -1,9 +1,6 @@
 import logging
-from typing import Any
-from typing import List
-from typing import Optional
-from matchms.utils import filter_none
-from matchms.utils import get_common_keys
+from typing import Any, List, Optional
+from matchms.utils import filter_none, get_common_keys
 from ..typing import SpectrumType
 
 

--- a/matchms/filtering/derive_adduct_from_name.py
+++ b/matchms/filtering/derive_adduct_from_name.py
@@ -1,6 +1,5 @@
 import logging
-from ..metadata_utils import clean_adduct
-from ..metadata_utils import looks_like_adduct
+from ..metadata_utils import clean_adduct, looks_like_adduct
 from ..typing import SpectrumType
 
 

--- a/matchms/filtering/derive_inchi_from_smiles.py
+++ b/matchms/filtering/derive_inchi_from_smiles.py
@@ -1,7 +1,6 @@
 import logging
-from ..metadata_utils import convert_smiles_to_inchi
-from ..metadata_utils import is_valid_inchi
-from ..metadata_utils import is_valid_smiles
+from ..metadata_utils import (convert_smiles_to_inchi, is_valid_inchi,
+                              is_valid_smiles)
 from ..typing import SpectrumType
 
 

--- a/matchms/filtering/derive_inchikey_from_inchi.py
+++ b/matchms/filtering/derive_inchikey_from_inchi.py
@@ -1,7 +1,6 @@
 import logging
-from ..metadata_utils import convert_inchi_to_inchikey
-from ..metadata_utils import is_valid_inchi
-from ..metadata_utils import is_valid_inchikey
+from ..metadata_utils import (convert_inchi_to_inchikey, is_valid_inchi,
+                              is_valid_inchikey)
 from ..typing import SpectrumType
 
 

--- a/matchms/filtering/derive_smiles_from_inchi.py
+++ b/matchms/filtering/derive_smiles_from_inchi.py
@@ -1,7 +1,6 @@
 import logging
-from ..metadata_utils import convert_inchi_to_smiles
-from ..metadata_utils import is_valid_inchi
-from ..metadata_utils import is_valid_smiles
+from ..metadata_utils import (convert_inchi_to_smiles, is_valid_inchi,
+                              is_valid_smiles)
 from ..typing import SpectrumType
 
 

--- a/matchms/importing/load_from_json.py
+++ b/matchms/importing/load_from_json.py
@@ -1,8 +1,7 @@
 import ast
 import json
 import logging
-from typing import List
-from typing import Union
+from typing import List, Union
 import numpy
 from ..Spectrum import Spectrum
 

--- a/matchms/importing/load_from_mgf.py
+++ b/matchms/importing/load_from_mgf.py
@@ -1,6 +1,4 @@
-from typing import Generator
-from typing import TextIO
-from typing import Union
+from typing import Generator, TextIO, Union
 import numpy
 from pyteomics.mgf import MGF
 from ..Spectrum import Spectrum

--- a/matchms/importing/load_from_msp.py
+++ b/matchms/importing/load_from_msp.py
@@ -1,7 +1,5 @@
 import re
-from typing import Generator
-from typing import Iterator
-from typing import Tuple
+from typing import Generator, Iterator, Tuple
 import numpy
 from ..Spectrum import Spectrum
 

--- a/matchms/importing/parsing_utils.py
+++ b/matchms/importing/parsing_utils.py
@@ -1,7 +1,6 @@
 """Helper functions for parsing metadata.
 """
-from typing import Any
-from typing import Union
+from typing import Any, Union
 
 
 def find_by_key(data: Union[list, dict], target: str) -> Any:

--- a/matchms/metadata_utils.py
+++ b/matchms/metadata_utils.py
@@ -1,8 +1,8 @@
 import re
 from typing import Optional
 import numpy
-from matchms.filtering.load_adducts import load_adducts_dict
-from matchms.filtering.load_adducts import load_known_adduct_conversions
+from matchms.filtering.load_adducts import (load_adducts_dict,
+                                            load_known_adduct_conversions)
 
 
 try:  # rdkit is not included in pip package

--- a/matchms/plotting/__init__.py
+++ b/matchms/plotting/__init__.py
@@ -64,9 +64,8 @@ Finally, it is also possible to plot many spectra at once using `plot_spectra_ar
    Compare many spectra visually using an array plot.
 
 """
-from .spectrum_plots import plot_spectra_array
-from .spectrum_plots import plot_spectra_mirror
-from .spectrum_plots import plot_spectrum
+from .spectrum_plots import (plot_spectra_array, plot_spectra_mirror,
+                             plot_spectrum)
 
 
 __all__ = [

--- a/matchms/plotting/spectrum_plots.py
+++ b/matchms/plotting/spectrum_plots.py
@@ -1,5 +1,4 @@
-from typing import Optional
-from typing import Union
+from typing import Optional, Union
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import numpy as np

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -2,8 +2,8 @@ from typing import Tuple
 import numpy
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
-from .spectrum_similarity_functions import collect_peak_pairs
-from .spectrum_similarity_functions import score_best_matches
+from .spectrum_similarity_functions import (collect_peak_pairs,
+                                            score_best_matches)
 
 
 class CosineGreedy(BaseSimilarity):

--- a/matchms/similarity/FingerprintSimilarity.py
+++ b/matchms/similarity/FingerprintSimilarity.py
@@ -1,14 +1,13 @@
-from typing import List
-from typing import Union
+from typing import List, Union
 import numpy
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
-from .vector_similarity_functions import cosine_similarity
-from .vector_similarity_functions import cosine_similarity_matrix
-from .vector_similarity_functions import dice_similarity
-from .vector_similarity_functions import dice_similarity_matrix
-from .vector_similarity_functions import jaccard_index
-from .vector_similarity_functions import jaccard_similarity_matrix
+from .vector_similarity_functions import (cosine_similarity,
+                                          cosine_similarity_matrix,
+                                          dice_similarity,
+                                          dice_similarity_matrix,
+                                          jaccard_index,
+                                          jaccard_similarity_matrix)
 
 
 class FingerprintSimilarity(BaseSimilarity):

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -4,8 +4,8 @@ import numpy
 from matchms.filtering.add_precursor_mz import _convert_precursor_mz
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
-from .spectrum_similarity_functions import collect_peak_pairs
-from .spectrum_similarity_functions import score_best_matches
+from .spectrum_similarity_functions import (collect_peak_pairs,
+                                            score_best_matches)
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -1,5 +1,4 @@
-from typing import List
-from typing import Tuple
+from typing import List, Tuple
 import numba
 import numpy
 

--- a/matchms/typing.py
+++ b/matchms/typing.py
@@ -1,7 +1,4 @@
-from typing import List
-from typing import NewType
-from typing import Tuple
-from typing import Union
+from typing import List, NewType, Tuple, Union
 import numpy
 
 

--- a/matchms/utils.py
+++ b/matchms/utils.py
@@ -1,8 +1,7 @@
 import csv
 import os
 from functools import lru_cache
-from typing import Iterable
-from typing import List
+from typing import Iterable, List
 
 
 def get_first_common_element(first: Iterable[str], second: Iterable[str]) -> str:

--- a/readthedocs/conf.py
+++ b/readthedocs/conf.py
@@ -12,10 +12,13 @@
 #
 import os
 import sys
+
+
 d = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, os.path.join(d, ".."))
 
 import matchms
+
 
 # -- Project information -----------------------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,9 @@ description-file = README.rst
 test = pytest
 
 [tool:isort]
-lines_after_imports = 2
-force_single_line = 1
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 no_lines_before = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+lines_after_imports = 2
 known_first_party = matchms
 skip = readthedocs/conf.py
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import os
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     ],
     extras_require={"dev": ["bump2version",
                             "decorator",
-                            "isort>=4.2.5,<5",
+                            "isort>=5.1.0",
                             "pylint<2.12",
                             "prospector[with_pyroma]",
                             "pytest",

--- a/tests/test_ParentmassMatch.py
+++ b/tests/test_ParentmassMatch.py
@@ -1,10 +1,9 @@
 import numpy
 import pytest
 from matchms.similarity import ParentMassMatch
-from matchms.similarity.ParentMassMatch import parentmass_scores
-from matchms.similarity.ParentMassMatch import parentmass_scores_symmetric
-from .builder_Spectrum import SpectrumBuilder
-from .builder_Spectrum import spectra_factory
+from matchms.similarity.ParentMassMatch import (parentmass_scores,
+                                                parentmass_scores_symmetric)
+from .builder_Spectrum import SpectrumBuilder, spectra_factory
 
 
 @pytest.mark.parametrize('parent_mass, tolerance, expected', [

--- a/tests/test_PrecursormzMatch.py
+++ b/tests/test_PrecursormzMatch.py
@@ -1,13 +1,10 @@
 import numpy
 import pytest
 from matchms.similarity import PrecursorMzMatch
-from matchms.similarity.PrecursorMzMatch import precursormz_scores
-from matchms.similarity.PrecursorMzMatch import precursormz_scores_ppm
-from matchms.similarity.PrecursorMzMatch import precursormz_scores_symmetric
-from matchms.similarity.PrecursorMzMatch import \
-    precursormz_scores_symmetric_ppm
-from .builder_Spectrum import SpectrumBuilder
-from .builder_Spectrum import spectra_factory
+from matchms.similarity.PrecursorMzMatch import (
+    precursormz_scores, precursormz_scores_ppm, precursormz_scores_symmetric,
+    precursormz_scores_symmetric_ppm)
+from .builder_Spectrum import SpectrumBuilder, spectra_factory
 
 
 @pytest.mark.parametrize('precursor_mz, tolerance, tolerance_type, expected', [

--- a/tests/test_SimilarityNetwork.py
+++ b/tests/test_SimilarityNetwork.py
@@ -2,11 +2,9 @@ import os
 import tempfile
 import numpy as np
 import pytest
-from matchms import Spectrum
-from matchms import calculate_scores
+from matchms import Spectrum, calculate_scores
 from matchms.networking import SimilarityNetwork
-from matchms.similarity import FingerprintSimilarity
-from matchms.similarity import ModifiedCosine
+from matchms.similarity import FingerprintSimilarity, ModifiedCosine
 
 
 @pytest.fixture

--- a/tests/test_add_fingerprint.py
+++ b/tests/test_add_fingerprint.py
@@ -2,8 +2,8 @@ import numpy
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import add_fingerprint
-from matchms.logging_functions import reset_matchms_logger
-from matchms.logging_functions import set_matchms_logger_level
+from matchms.logging_functions import (reset_matchms_logger,
+                                       set_matchms_logger_level)
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_add_precursor_mz.py
+++ b/tests/test_add_precursor_mz.py
@@ -1,8 +1,8 @@
 import numpy
 import pytest
 from matchms.filtering import add_precursor_mz
-from matchms.logging_functions import reset_matchms_logger
-from matchms.logging_functions import set_matchms_logger_level
+from matchms.logging_functions import (reset_matchms_logger,
+                                       set_matchms_logger_level)
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_add_retention.py
+++ b/tests/test_add_retention.py
@@ -1,6 +1,5 @@
 import pytest
-from matchms.filtering import add_retention_index
-from matchms.filtering import add_retention_time
+from matchms.filtering import add_retention_index, add_retention_time
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_derive_adduct_from_name.py
+++ b/tests/test_derive_adduct_from_name.py
@@ -1,8 +1,8 @@
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import derive_adduct_from_name
-from matchms.logging_functions import reset_matchms_logger
-from matchms.logging_functions import set_matchms_logger_level
+from matchms.logging_functions import (reset_matchms_logger,
+                                       set_matchms_logger_level)
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_derive_inchi_from_inchikey.py
+++ b/tests/test_derive_inchi_from_inchikey.py
@@ -1,8 +1,8 @@
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import derive_inchikey_from_inchi
-from matchms.logging_functions import reset_matchms_logger
-from matchms.logging_functions import set_matchms_logger_level
+from matchms.logging_functions import (reset_matchms_logger,
+                                       set_matchms_logger_level)
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_derive_smiles_from_inchi.py
+++ b/tests/test_derive_smiles_from_inchi.py
@@ -1,8 +1,8 @@
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import derive_smiles_from_inchi
-from matchms.logging_functions import reset_matchms_logger
-from matchms.logging_functions import set_matchms_logger_level
+from matchms.logging_functions import (reset_matchms_logger,
+                                       set_matchms_logger_level)
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_fingerprint_similarity.py
+++ b/tests/test_fingerprint_similarity.py
@@ -1,7 +1,6 @@
 import numpy
 import pytest
-from matchms import Spectrum
-from matchms import calculate_scores
+from matchms import Spectrum, calculate_scores
 from matchms.similarity import FingerprintSimilarity
 
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,8 +1,7 @@
 import numpy
 import pytest
 from matchms import Spectrum
-from matchms.hashing import metadata_hash
-from matchms.hashing import spectrum_hash
+from matchms.hashing import metadata_hash, spectrum_hash
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_load_adducts.py
+++ b/tests/test_load_adducts.py
@@ -1,6 +1,5 @@
 import numpy
-from matchms.filtering import load_adducts_dict
-from matchms.filtering import load_known_adduct_conversions
+from matchms.filtering import load_adducts_dict, load_known_adduct_conversions
 from matchms.filtering.load_adducts import _convert_and_fill_dict
 
 

--- a/tests/test_load_from_usi.py
+++ b/tests/test_load_from_usi.py
@@ -1,5 +1,4 @@
-from unittest.mock import Mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 import numpy as np
 from matchms.importing import load_from_usi
 from .builder_Spectrum import SpectrumBuilder

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
-from matchms.logging_functions import add_logging_to_file
-from matchms.logging_functions import reset_matchms_logger
-from matchms.logging_functions import set_matchms_logger_level
+from matchms.logging_functions import (add_logging_to_file,
+                                       reset_matchms_logger,
+                                       set_matchms_logger_level)
 
 
 def test_initial_logging(caplog, capsys):

--- a/tests/test_metadata_match.py
+++ b/tests/test_metadata_match.py
@@ -1,9 +1,8 @@
 import numpy as np
 import pytest
 from matchms import calculate_scores
-from matchms.similarity.MetadataMatch import MetadataMatch
-from matchms.similarity.MetadataMatch import entries_scores
-from matchms.similarity.MetadataMatch import entries_scores_symmetric
+from matchms.similarity.MetadataMatch import (MetadataMatch, entries_scores,
+                                              entries_scores_symmetric)
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -6,14 +6,12 @@ from unittest import mock
 import numpy
 import pytest
 import matchms.metadata_utils
-from matchms.metadata_utils import clean_adduct
-from matchms.metadata_utils import derive_fingerprint_from_inchi
-from matchms.metadata_utils import derive_fingerprint_from_smiles
-from matchms.metadata_utils import is_valid_inchi
-from matchms.metadata_utils import is_valid_inchikey
-from matchms.metadata_utils import is_valid_smiles
-from matchms.metadata_utils import looks_like_adduct
-from matchms.metadata_utils import mol_converter
+from matchms.metadata_utils import (clean_adduct,
+                                    derive_fingerprint_from_inchi,
+                                    derive_fingerprint_from_smiles,
+                                    is_valid_inchi, is_valid_inchikey,
+                                    is_valid_smiles, looks_like_adduct,
+                                    mol_converter)
 
 
 def test_mol_converter_smiles_to_inchi():

--- a/tests/test_normalize_intensities.py
+++ b/tests/test_normalize_intensities.py
@@ -1,7 +1,6 @@
 import numpy
 import pytest
-from matchms.filtering import add_losses
-from matchms.filtering import normalize_intensities
+from matchms.filtering import add_losses, normalize_intensities
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_reduce_to_number_of_peaks.py
+++ b/tests/test_reduce_to_number_of_peaks.py
@@ -2,8 +2,8 @@ import numpy
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import reduce_to_number_of_peaks
-from matchms.logging_functions import reset_matchms_logger
-from matchms.logging_functions import set_matchms_logger_level
+from matchms.logging_functions import (reset_matchms_logger,
+                                       set_matchms_logger_level)
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_require_precursor_below_mz.py
+++ b/tests/test_require_precursor_below_mz.py
@@ -2,8 +2,8 @@ import numpy
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import require_precursor_below_mz
-from matchms.logging_functions import reset_matchms_logger
-from matchms.logging_functions import set_matchms_logger_level
+from matchms.logging_functions import (reset_matchms_logger,
+                                       set_matchms_logger_level)
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_require_precursor_mz.py
+++ b/tests/test_require_precursor_mz.py
@@ -2,8 +2,8 @@ import numpy
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering.require_precursor_mz import require_precursor_mz
-from matchms.logging_functions import reset_matchms_logger
-from matchms.logging_functions import set_matchms_logger_level
+from matchms.logging_functions import (reset_matchms_logger,
+                                       set_matchms_logger_level)
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -1,9 +1,7 @@
 import numpy
 import pytest
-from matchms import Scores
-from matchms import calculate_scores
-from matchms.similarity import CosineGreedy
-from matchms.similarity import IntersectMz
+from matchms import Scores, calculate_scores
+from matchms.similarity import CosineGreedy, IntersectMz
 from matchms.similarity.BaseSimilarity import BaseSimilarity
 from .builder_Spectrum import SpectrumBuilder
 

--- a/tests/test_spectrum_peak_comments.py
+++ b/tests/test_spectrum_peak_comments.py
@@ -1,6 +1,5 @@
 import numpy
-from matchms import Fragments
-from matchms import Spectrum
+from matchms import Fragments, Spectrum
 from matchms.filtering import normalize_intensities
 
 

--- a/tests/test_spectrum_plots.py
+++ b/tests/test_spectrum_plots.py
@@ -1,8 +1,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 from matchms import Spectrum
-from matchms.plotting import plot_spectra_array
-from matchms.plotting import plot_spectrum
+from matchms.plotting import plot_spectra_array, plot_spectrum
 
 
 def _assert_fig_ok(fig, n_plots, dpi, height):

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -2,9 +2,8 @@
 pure Python version."""
 import numpy
 import pytest
-from matchms.similarity.spectrum_similarity_functions import collect_peak_pairs
-from matchms.similarity.spectrum_similarity_functions import find_matches
-from matchms.similarity.spectrum_similarity_functions import score_best_matches
+from matchms.similarity.spectrum_similarity_functions import (
+    collect_peak_pairs, find_matches, score_best_matches)
 
 
 @pytest.mark.parametrize("shift, expected_pairs, expected_matches",

--- a/tests/test_vector_similarity_functions.py
+++ b/tests/test_vector_similarity_functions.py
@@ -2,15 +2,9 @@
 and fully python-based versions of functions."""
 import numpy
 import pytest
-from matchms.similarity.vector_similarity_functions import cosine_similarity
-from matchms.similarity.vector_similarity_functions import \
-    cosine_similarity_matrix
-from matchms.similarity.vector_similarity_functions import dice_similarity
-from matchms.similarity.vector_similarity_functions import \
-    dice_similarity_matrix
-from matchms.similarity.vector_similarity_functions import jaccard_index
-from matchms.similarity.vector_similarity_functions import \
-    jaccard_similarity_matrix
+from matchms.similarity.vector_similarity_functions import (
+    cosine_similarity, cosine_similarity_matrix, dice_similarity,
+    dice_similarity_matrix, jaccard_index, jaccard_similarity_matrix)
 
 
 def test_cosine_similarity_compiled():


### PR DESCRIPTION
Move from isort 4 to version 5 and update all imports by running `isort .`
(checks can be done by running `isort --check-only --diff .`.