### PR TITLE
handle duplicates test and pickydict version raise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - new spectral similarity score: `NeutralLossesCosine` which is based on matches between neutral losses of two spectra [#329](https://github.com/matchms/matchms/pull/329)
 
+### Changed
+
+- added new key conversion: "precursor_type" to "adduct" [#332](https://github.com/matchms/matchms/pull/332)
+
+### Fixed
+
+- handling of duplicate entries in spectrum files (e.g. as field and again in the comments field in msp files) by ugrade of pickydict to 0.4.0 [#332](https://github.com/matchms/matchms/pull/332)
+
 ## [0.14.0] - 2022-02-18
 
 This is the first of a few releases to work our way towards matchms 1.0.0, which also means that a few things in the API will likely change. Here the main change is that `Spectrum.metadata` is no longer a simple Python dictionary but became a `Metadata` object. In this context metadata field-names/keys will now be harmonized by default (e.g. "Precursor Mass" will become "precursor_mz). For list of conversions see [matchms key conversion table](https://github.com/matchms/matchms/blob/development/matchms/data/known_key_conversions.csv).

--- a/matchms/data/known_key_conversions.csv
+++ b/matchms/data/known_key_conversions.csv
@@ -3,6 +3,7 @@ precursor_mass,precursor_mz
 precursormass,precursor_mz
 precursormz,precursor_mz
 precursor,precursor_mz
+precursor_type,adduct
 precursorintensity,precursor_intensity
 precursor_charge,charge
 precursorcharge,charge

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "networkx",
         "numba >=0.47",
         "numpy",
-        "pickydict >= 0.3.0",
+        "pickydict >= 0.4.0",
         "pyteomics >=4.2",
         "requests",
         "scipy",

--- a/tests/test_spectra_collection.msp
+++ b/tests/test_spectra_collection.msp
@@ -1,0 +1,37 @@
+Name: 2-Hydroxychalcone
+Synon: $:00in-source
+DB#: VF-NPL-LTQ000001
+InChIKey: UDOOPSJCRMKSGL-ZHACJKMWSA-N
+Precursor_type: M-H
+Spectrum_type: MS2
+PrecursorMZ: 223.12845079826587
+Instrument_type: Linear Ion Trap
+Instrument: Thermo Finnigan LTQ
+Ion_mode: N
+Collision_energy: 35
+Formula: C15H12O2
+MW: 224
+ExactMass: 224.083729624
+Comments: "InChI=InChI=1S/C15H12O2/c16-14-9-5-4-8-13(14)10-11-15(17)12-6-2-1-3-7-12/h1-11,16H/b11-10+" "computed SMILES=O=C(C=CC=1C=CC=CC1O)C=2C=CC=CC2" "raw filename=120_100_iTree_NEG_08042014_10.raw" "author=Arpana Vaniya" "source introduction=direct infusion" "source voltage=3.50 kV" "capillary temperature=275 C" "ion source=ESI Ion Max" "computed spectral entropy=0.08743674675113056" "computed normalized entropy=0.12614456092932025" "computed mass accuracy=233.03695283966962" "computed mass error=0.05199717426586403" "SPLASH=splash10-0002-0900000000-6fd327c02607c02c0e42" "submitter=Arpana Vaniya (University of California, Davis)" "MoNA Rating=3.846153846153846"
+Num Peaks: 2
+177.06 1.763028
+195.05 100.000000
+
+
+Name: (2-AMINOETHYL)PHOSPHONATE
+Synon: $:00in-source
+DB#: CCMSLIB00000578169
+InChIKey: QQVDJLLNRSOCEL-UHFFFAOYSA-N
+Precursor_type: [M-H]-
+Spectrum_type: MS2
+PrecursorMZ: 124.016
+Instrument: Q-Exactive Plus
+Ion_mode: N
+Formula: C2H8NO3P
+MW: 125
+ExactMass: 125.02417974599999
+Comments: "cas number=2041-14-7" "pubmed id=339" "SMILES=O=P(O)(O)CCN" "computed SMILES=C(CP(=O)(O)O)N" "computed InChI=InChI=1S/C2H8NO3P/c3-1-2-7(4,5)6/h1-3H2,(H2,4,5,6)" "ion source=LC-ESI" "compound source=Commercial standard" "exact mass=125.024" "charge state=0" "source file=IROA_PLATE_neg_2_B.mzXML" "origin=GNPS-EMBL-MCF" "author=Alexandrov Theodore, pphapale, Prasad" "computed mass accuracy=7.287333892219113" "computed mass error=-9.037459999774455E-4" "SPLASH=splash10-00fr-5900000000-71241086c94c831eda97" "submitter=GNPS Team (University of California, San Diego)" "MoNA Rating=4.090909090909091"
+Num Peaks: 3
+55.649189 0.660602
+67.693985 0.748710
+72.791397 1.174059

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -177,6 +177,8 @@ def test_spectrum_clone(spectrum, default_filtering):
     [{"precursor_mz": 101.01}, True, {"precursor_mz": 101.01}],
     [{"precursormz": 101.01}, True, {"precursor_mz": 101.01}],
     [{"precursormz": 101.01}, False, {"precursor_mz": 101.01}],
+    [{"ExactMass": 105.055}, True, {"parent_mass": 105.055}],
+    [{"ExactMass": 105.055, "parent_mass": 107.077}, True, {"parent_mass": 107.077}],
     [{"charge": "2+"}, True, {"charge": 2}],
     [{"charge": -1}, True, {"charge": -1}],
     [{"charge": [-1, 0]}, True, {"charge": -1}],


### PR DESCRIPTION
- takes care of #330 
- added `precursor_type` to `adduct` conversion to conversion table