### PR TITLE
Updated test cases and reduced smiles & inchi regexp strictness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- metadata filtering: made prefilter check for SMILES and InChI more lenient, eventually resulting in longer runtimes but more accurate checks [#337](https://github.com/matchms/matchms/pull/337)
+
 ## [0.15.0] - 2022-03-09
 
 Added neutral losses similarity score (cosine-type score) and a few small fixes.

--- a/matchms/metadata_utils.py
+++ b/matchms/metadata_utils.py
@@ -96,7 +96,7 @@ def is_valid_inchi(inchi: str) -> bool:
     if inchi is None:
         return False
     inchi = inchi.strip('"')
-    regexp = r"(InChI=1|1)(S\/|\/)[0-9a-zA-Z\.]{2,}\/[ch]{1}[0-9]"
+    regexp = r"(InChI=1|1)(S\/|\/)[0-9a-zA-Z\.]{2,}"
     if not re.search(regexp, inchi):
         return False
     # Proper chemical test
@@ -123,7 +123,7 @@ def is_valid_smiles(smiles: str) -> bool:
     if smiles is None:
         return False
 
-    regexp = r"^([^J][0-9ABCOHNMSPIFKiergalcons@+\-\[\]\(\)\\\/%=#$,.~&!]{3,})$"
+    regexp = r"^([^J][0-9ABCOHNMSPIFKiergalcons@+\-\[\]\(\)\\\/%=#$,.~&!]*)$"
     if not re.match(regexp, smiles):
         return False
 

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -72,54 +72,47 @@ def test_is_valid_inchikey_none_input():
     assert not is_valid_inchikey(None), "Expected None entry to give False."
 
 
-def test_is_valid_inchi():
-    """Test if strings are correctly classified."""
+
+
+@pytest.mark.parametrize("inchi, expected", [
+    ["InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)", True],
+    ['"InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)"', True],
+    ["InChI=1S/Ne", True],
+    ["InChI=1S/C14H9Cl5/c15-11-5-1-9(2-6-11)13(14(17,18)19)10-3-7-12(16)8-4-10/h1-8,13H", True],
+    ["1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)", False],
+    ["InChI=1S/C2H7N3/c152(3)4/h1H3,(H4,3,4,5)", False],
+    ["InChI=C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)", False],
+    ["InChI=1S/C2H7N3/c1-5-2(3)", False]
+])
+def test_is_valid_inchi(inchi, expected):
     pytest.importorskip("rdkit")
-
-    inchi_true = [
-        "InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-        '"InChI=1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)"'
-    ]
-    inchi_false = [
-        "1S/C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-        "InChI=1S/C2H7N3/c152(3)4/h1H3,(H4,3,4,5)",
-        "InChI=C2H7N3/c1-5-2(3)4/h1H3,(H4,3,4,5)",
-        "InChI=1S/C2H7N3/c1-5-2(3)"
-    ]
-
-    for inchi in inchi_true:
-        assert is_valid_inchi(inchi), "Expected inchi is True."
-    for inchi in inchi_false:
-        assert not is_valid_inchi(inchi), "Expected inchi is False."
+    assert is_valid_inchi(inchi) == expected
 
 
 def test_is_valid_inchi_none_input():
     """Test None entry."""
     pytest.importorskip("rdkit")
-
     assert not is_valid_inchi(None), "Expected None entry to give False."
 
 
-def test_is_valid_smiles():
-    """Test if strings are correctly classified."""
+@pytest.mark.parametrize("smiles, expected", [
+    [r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O", True],
+    [r"CN1N(C(=O)C=C1C)c1ccccc1", True],
+    [r"COC(=O)C1=CN=CC=N1", True],
+    [r"C", True],
+    [r"CF", True],
+    [r"C#C", True],
+    [r"C1=CC(=CC=C1C(C2=CC=C(C=C2)Cl)C(Cl)(Cl)Cl)Cl", True],
+    [r"[18FH]", True],
+    [r"F", True],
+    [r"CN1N(C(=O)C=C1C)c1cccccx1", False],
+    [r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O", False],
+    [r"COC(=O[)]C1=CN=CC=N1", False],
+    [r"1S/C2H7N3/c1-5-2(3)4", False]
+])
+def test_is_valid_smiles(smiles, expected):
     pytest.importorskip("rdkit")
-
-    smiles_true = [
-        r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+]([O-])=O",
-        r"CN1N(C(=O)C=C1C)c1ccccc1",
-        r"COC(=O)C1=CN=CC=N1"
-    ]
-    smiles_false = [
-        r"CN1N(C(=O)C=C1C)c1cccccx1",
-        r"CN1COCN(CC2=CN=C(Cl)S2)\C1=N\[N+++]([O-])=O",
-        r"COC(=O[)]C1=CN=CC=N1",
-        r"1S/C2H7N3/c1-5-2(3)4"
-    ]
-
-    for smiles in smiles_true:
-        assert is_valid_smiles(smiles), "Expected smiles is True."
-    for smiles in smiles_false:
-        assert not is_valid_smiles(smiles), "Expected smiles is False."
+    assert is_valid_smiles(smiles) == expected
 
 
 def test_is_valid_smiles_none_input():


### PR DESCRIPTION
Close #334 
Close #335 

I reduced the regexp filters to detect wrong InChI and Smiles to a more lenient behaviour to accept small smiles such as `C` or `CF` which are valid and exist in certain databases.