### PR TITLE
Update Spectrum.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Spectrum` objects now also have `.mz` and `.intensities` properties [#339](https://github.com/matchms/matchms/pull/339)
+
 ### Changed
 - metadata filtering: made prefilter check for SMILES and InChI more lenient, eventually resulting in longer runtimes but more accurate checks [#337](https://github.com/matchms/matchms/pull/337)
 

--- a/matchms/Spectrum.py
+++ b/matchms/Spectrum.py
@@ -194,6 +194,14 @@ class Spectrum:
         return self
 
     @property
+    def mz(self):
+        return self.peaks.mz
+
+    @property
+    def intensities(self):
+        return self.peaks.intensities
+
+    @property
     def metadata(self):
         return self._metadata.data.copy()
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
                             "prospector[with_pyroma]",
                             "pytest",
                             "pytest-cov",
-                            "sphinx>=3.0.0,!=3.2.0,!=3.5.0,<4.0.0",
+                            "sphinx>=4.0.0",
                             "sphinx_rtd_theme",
                             "sphinxcontrib-apidoc",
                             "testfixtures",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9"
     ],
-    test_suite="tests",
     python_requires='>=3.7',
     install_requires=[
         "deprecated",

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -57,6 +57,10 @@ def test_spectrum_getters_return_copies():
 def test_spectrum_getters(spectrum: Spectrum):
     assert np.all(spectrum.mz == spectrum.peaks.mz)
     assert np.all(spectrum.intensities == spectrum.peaks.intensities)
+    # Test if true copy
+    mz = spectrum.mz
+    mz[0] = 1111
+    assert np.allclose(spectrum.peaks.mz[0], 100.00003)
 
 
 @pytest.mark.parametrize("input_dict, expected_dict", [

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -54,6 +54,11 @@ def test_spectrum_getters_return_copies():
     assert spectrum.metadata == {'testdata': 1}, "Expected metadata to remain unchanged"
 
 
+def test_spectrum_getters(spectrum: Spectrum):
+    assert np.all(spectrum.mz == spectrum.peaks.mz)
+    assert np.all(spectrum.intensities == spectrum.peaks.intensities)
+
+
 @pytest.mark.parametrize("input_dict, expected_dict", [
     [{"precursor mass": 400.768, "Some Key": "Whatever.", "NEW\tSTUFF": "XYZ"},
      {"precursor_mz": 400.768, "some_key": "Whatever.", "new_stuff": "XYZ"}],


### PR DESCRIPTION
Add `.mz` and `.intensities` properties to `Spectrum` to make it more intuitive to access the "peaks". 

`spectrum.mz` returns `spectrum.peaks.mz`