### PR TITLE
New network formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Spectrum` objects now also have `.mz` and `.intensities` properties [#339](https://github.com/matchms/matchms/pull/339)
+- `SimilarityNetwork`: similarity-network graphs can now be exported to [cyjs](http://manual.cytoscape.org/en/stable/index.html),
+[gexf](http://gexf.net/schema.html), [gml](https://web.archive.org/web/20190207140002/http://www.fim.uni-passau.de/index.php?id=17297&L=1),
+and node-link JSON formats [#349](https://github.com/matchms/matchms/pull/349)
 
 ### Changed
 - metadata filtering: made prefilter check for SMILES and InChI more lenient, eventually resulting in longer runtimes but more accurate checks [#337](https://github.com/matchms/matchms/pull/337)

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -7,7 +7,7 @@ from .networking_functions import get_top_hits
 
 
 class SimilarityNetwork:
-    """Create a spectal network from spectrum similarities.
+    """Create a spectral network from spectrum similarities.
 
     For example
 
@@ -55,7 +55,7 @@ class SimilarityNetwork:
         Parameters
         ----------
         identifier_key
-            Metadata key for unique intentifier for each spectrum in scores.
+            Metadata key for unique identifier for each spectrum in scores.
             Will also be used for the naming the network nodes. Default is 'spectrum_id'.
         top_n
             Consider edge between spectrumA and spectrumB if score falls into
@@ -69,7 +69,7 @@ class SimilarityNetwork:
             Important side note: The max_links restriction is strict which means that
             if scores around max_links are equal still only max_links will be added
             which can results in some random variations (sorting spectra with equal
-            scores restuls in a random order of such elements).
+            scores results in a random order of such elements).
         score_cutoff
             Threshold for given similarities. Edges/Links will only be made for
             similarities > score_cutoff. Default = 0.7.

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -163,7 +163,19 @@ class SimilarityNetwork:
         format
             Format of file to write to. Supported formats are: "cyjs", "gexf", "gml", "graphml", "json"
         """
-        pass
+        writer = {"cyjs": self._export_to_cyjs,
+                  "gexf": nx.write_gexf,
+                  "gml": nx.write_gml,
+                  "graphml": self.export_to_graphml,
+                  "json": self._export_to_json}
+
+        assert format in writer, "Format not supported.\n" \
+                                 "Please use one of supported formats: 'cyjs', 'gexf', 'gml', 'graphml', 'json'"
+
+        if not self.graph:
+            raise ValueError("No network found. Make sure to first run .create_network() step")
+
+        writer[format](filename)
 
     def export_to_graphml(self, filename: str):
         """Save the network as .graphml file.
@@ -174,6 +186,10 @@ class SimilarityNetwork:
             Specify filename for exporting the graph.
 
         """
-        if not self.graph:
-            raise ValueError("No network found. Make sure to first run .create_network() step")
         nx.write_graphml_lxml(self.graph, filename)
+
+    def _export_to_cyjs(self, filename: str):
+        pass
+
+    def _export_to_json(self, filename: str):
+        pass

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -168,7 +168,7 @@ class SimilarityNetwork:
                   "gexf": nx.write_gexf,
                   "gml": nx.write_gml,
                   "graphml": self.export_to_graphml,
-                  "json": self._export_to_json}
+                  "json": self._export_to_node_link_json}
 
         assert format in writer, "Format not supported.\n" \
                                  "Please use one of supported formats: 'cyjs', 'gexf', 'gml', 'graphml', 'json'"
@@ -190,7 +190,7 @@ class SimilarityNetwork:
         nx.write_graphml_lxml(self.graph, filename)
 
     def _export_to_cyjs(self, filename: str):
-        """Save the network as .cyjs file.
+        """Save the network in cyjs format.
 
         Parameters
         ----------
@@ -199,6 +199,18 @@ class SimilarityNetwork:
 
         """
         graph = nx.cytoscape_data(self.graph)
+        return self._export_to_json(graph, filename)
+
+    def _export_to_node_link_json(self, filename: str):
+        """Save the network in node-link format.
+
+        Parameters
+        ----------
+        filename
+            Specify filename for exporting the graph.
+
+        """
+        graph = nx.node_link_data(self.graph)
         return self._export_to_json(graph, filename)
 
     @staticmethod

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -152,6 +152,19 @@ class SimilarityNetwork:
             msnet.remove_nodes_from(list(nx.isolates(msnet)))
         self.graph = msnet
 
+    def export_to_file(self, filename: str, format: str = "graphml"):
+        """
+        Save the network to a file with chosen format.
+
+        Parameters
+        ----------
+        filename
+            Path to file to write to.
+        format
+            Format of file to write to. Supported formats are: "cyjs", "gexf", "gml", "graphml", "json"
+        """
+        pass
+
     def export_to_graphml(self, filename: str):
         """Save the network as .graphml file.
 

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -153,7 +153,7 @@ class SimilarityNetwork:
             msnet.remove_nodes_from(list(nx.isolates(msnet)))
         self.graph = msnet
 
-    def export_to_file(self, filename: str, format: str = "graphml"):
+    def export_to_file(self, filename: str, graph_format: str = "graphml"):
         """
         Save the network to a file with chosen format.
 
@@ -161,25 +161,26 @@ class SimilarityNetwork:
         ----------
         filename
             Path to file to write to.
-        format
-            Format of file to write to. Supported formats are: "cyjs", "gexf", "gml", "graphml", "json"
+        graph_format
+            Format, in which to store the network graph. Supported formats are: "cyjs", "gexf", "gml", "graphml", "json".
+            Default is "graphml".
         """
         if not self.graph:
             raise ValueError("No network found. Make sure to first run .create_network() step")
 
-        writer = self._generate_writer(format)
+        writer = self._generate_writer(graph_format)
         writer(filename)
 
-    def _generate_writer(self, format: str):
+    def _generate_writer(self, graph_format: str):
         writer = {"cyjs": self._export_to_cyjs,
                   "gexf": self._export_to_gexf,
                   "gml": self._export_to_gml,
                   "graphml": self.export_to_graphml,
                   "json": self._export_to_node_link_json}
 
-        assert format in writer, "Format not supported.\n" \
-                                 "Please use one of supported formats: 'cyjs', 'gexf', 'gml', 'graphml', 'json'"
-        return writer[format]
+        assert graph_format in writer, "Format not supported.\n" \
+                                       "Please use one of supported formats: 'cyjs', 'gexf', 'gml', 'graphml', 'json'"
+        return writer[graph_format]
 
     def export_to_graphml(self, filename: str):
         """Save the network as .graphml file.

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -195,15 +195,15 @@ class SimilarityNetwork:
     def _export_to_cyjs(self, filename: str):
         """Save the network in cyjs format."""
         graph = nx.cytoscape_data(self.graph)
-        return self._export_to_json(graph, filename)
+        return self._write_to_json(graph, filename)
 
     def _export_to_node_link_json(self, filename: str):
         """Save the network in node-link format."""
         graph = nx.node_link_data(self.graph)
-        return self._export_to_json(graph, filename)
+        return self._write_to_json(graph, filename)
 
     @staticmethod
-    def _export_to_json(graph: dict, filename: str):
+    def _write_to_json(graph: dict, filename: str):
         """Save the network as JSON file.
 
         Parameters

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -164,6 +164,13 @@ class SimilarityNetwork:
         format
             Format of file to write to. Supported formats are: "cyjs", "gexf", "gml", "graphml", "json"
         """
+        if not self.graph:
+            raise ValueError("No network found. Make sure to first run .create_network() step")
+
+        writer = self._generate_writer(format)
+        writer(filename)
+
+    def _generate_writer(self, format: str):
         writer = {"cyjs": self._export_to_cyjs,
                   "gexf": self._export_to_gexf,
                   "gml": self._export_to_gml,
@@ -172,11 +179,7 @@ class SimilarityNetwork:
 
         assert format in writer, "Format not supported.\n" \
                                  "Please use one of supported formats: 'cyjs', 'gexf', 'gml', 'graphml', 'json'"
-
-        if not self.graph:
-            raise ValueError("No network found. Make sure to first run .create_network() step")
-
-        writer[format](filename)
+        return writer[format]
 
     def export_to_graphml(self, filename: str):
         """Save the network as .graphml file.

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -190,26 +190,12 @@ class SimilarityNetwork:
         nx.write_graphml_lxml(self.graph, filename)
 
     def _export_to_cyjs(self, filename: str):
-        """Save the network in cyjs format.
-
-        Parameters
-        ----------
-        filename
-            Specify filename for exporting the graph.
-
-        """
+        """Save the network in cyjs format."""
         graph = nx.cytoscape_data(self.graph)
         return self._export_to_json(graph, filename)
 
     def _export_to_node_link_json(self, filename: str):
-        """Save the network in node-link format.
-
-        Parameters
-        ----------
-        filename
-            Specify filename for exporting the graph.
-
-        """
+        """Save the network in node-link format."""
         graph = nx.node_link_data(self.graph)
         return self._export_to_json(graph, filename)
 
@@ -229,23 +215,9 @@ class SimilarityNetwork:
             json.dump(graph, file)
 
     def _export_to_gexf(self, filename: str):
-        """Save the network as .gexf file.
-
-        Parameters
-        ----------
-        filename
-            Specify filename for exporting the graph.
-
-        """
+        """Save the network as .gexf file."""
         nx.write_gexf(self.graph, filename)
 
     def _export_to_gml(self, filename: str):
-        """Save the network as .gml file.
-
-        Parameters
-        ----------
-        filename
-            Specify filename for exporting the graph.
-
-        """
+        """Save the network as .gml file."""
         nx.write_gml(self.graph, filename)

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -215,7 +215,7 @@ class SimilarityNetwork:
             Specify filename for exporting the graph.
 
         """
-        with open(filename, "w") as file:
+        with open(filename, "w", encoding="utf-8") as file:
             json.dump(graph, file)
 
     def _export_to_gexf(self, filename: str):

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -1,3 +1,4 @@
+import json
 from typing import Optional
 import networkx as nx
 import numpy
@@ -189,7 +190,28 @@ class SimilarityNetwork:
         nx.write_graphml_lxml(self.graph, filename)
 
     def _export_to_cyjs(self, filename: str):
-        pass
+        """Save the network as .cyjs file.
 
-    def _export_to_json(self, filename: str):
-        pass
+        Parameters
+        ----------
+        filename
+            Specify filename for exporting the graph.
+
+        """
+        graph = nx.cytoscape_data(self.graph)
+        return self._export_to_json(graph, filename)
+
+    @staticmethod
+    def _export_to_json(graph: dict, filename: str):
+        """Save the network as JSON file.
+
+        Parameters
+        ----------
+        graph
+            JSON-dictionary type graph to save.
+        filename
+            Specify filename for exporting the graph.
+
+        """
+        with open(filename, "w") as file:
+            json.dump(graph, file)

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -165,8 +165,8 @@ class SimilarityNetwork:
             Format of file to write to. Supported formats are: "cyjs", "gexf", "gml", "graphml", "json"
         """
         writer = {"cyjs": self._export_to_cyjs,
-                  "gexf": nx.write_gexf,
-                  "gml": nx.write_gml,
+                  "gexf": self._export_to_gexf,
+                  "gml": self._export_to_gml,
                   "graphml": self.export_to_graphml,
                   "json": self._export_to_node_link_json}
 
@@ -227,3 +227,25 @@ class SimilarityNetwork:
         """
         with open(filename, "w") as file:
             json.dump(graph, file)
+
+    def _export_to_gexf(self, filename: str):
+        """Save the network as .gexf file.
+
+        Parameters
+        ----------
+        filename
+            Specify filename for exporting the graph.
+
+        """
+        nx.write_gexf(self.graph, filename)
+
+    def _export_to_gml(self, filename: str):
+        """Save the network as .gml file.
+
+        Parameters
+        ----------
+        filename
+            Specify filename for exporting the graph.
+
+        """
+        nx.write_gml(self.graph, filename)

--- a/tests/test_SimilarityNetwork.py
+++ b/tests/test_SimilarityNetwork.py
@@ -8,13 +8,13 @@ from matchms.similarity import FingerprintSimilarity, ModifiedCosine
 
 
 @pytest.fixture(params=["cyjs", "gexf", "gml", "graphml", "json"])
-def file_format(request):
+def graph_format(request):
     yield request.param
 
 
 @pytest.fixture()
-def filename(file_format):
-    filename = f"test.{file_format}"
+def filename(graph_format):
+    filename = f"test.{graph_format}"
     with tempfile.TemporaryDirectory() as temp_dir:
         filepath = os.path.join(temp_dir, filename)
         yield filepath
@@ -133,13 +133,13 @@ def test_create_network_symmetric_modified_cosine():
     assert len(edges_list) == 28, "Expected different number of edges"
 
 
-def test_create_network_export_to_file(filename, file_format):
+def test_create_network_export_to_file(filename, graph_format):
     """Test creating a graph file from a symmetric Scores object using ModifiedCosine"""
     cutoff = 0.7
     scores = create_dummy_scores_symmetric_modified_cosine()
     msnet = SimilarityNetwork(score_cutoff=cutoff)
     msnet.create_network(scores)
-    msnet.export_to_file(filename, file_format)
+    msnet.export_to_file(filename, graph_format)
 
     assert os.path.isfile(filename), "network file not found"
 

--- a/tests/test_SimilarityNetwork.py
+++ b/tests/test_SimilarityNetwork.py
@@ -7,11 +7,17 @@ from matchms.networking import SimilarityNetwork
 from matchms.similarity import FingerprintSimilarity, ModifiedCosine
 
 
-@pytest.fixture
-def filename():
+@pytest.fixture(params=["cyjs", "gexf", "gml", "graphml", "json"])
+def file_format(request):
+    yield request.param
+
+
+@pytest.fixture()
+def filename(file_format):
+    filename = f"test.{file_format}"
     with tempfile.TemporaryDirectory() as temp_dir:
-        filename = os.path.join(temp_dir, "test.graphml")
-        yield filename
+        filepath = os.path.join(temp_dir, filename)
+        yield filepath
 
 
 def create_dummy_spectrums():
@@ -127,15 +133,15 @@ def test_create_network_symmetric_modified_cosine():
     assert len(edges_list) == 28, "Expected different number of edges"
 
 
-def test_create_network_export_to_graphml(filename):
-    """Test creating a graph from a symmetric Scores object using ModifiedCosine"""
+def test_create_network_export_to_file(filename, file_format):
+    """Test creating a graph file from a symmetric Scores object using ModifiedCosine"""
     cutoff = 0.7
     scores = create_dummy_scores_symmetric_modified_cosine()
     msnet = SimilarityNetwork(score_cutoff=cutoff)
     msnet.create_network(scores)
-    msnet.export_to_graphml(filename)
+    msnet.export_to_file(filename, file_format)
 
-    assert os.path.isfile(filename), "graphml file not found"
+    assert os.path.isfile(filename), "network file not found"
 
 
 def test_create_network_symmetric_higher_cutoff():


### PR DESCRIPTION
Merge of PR from @maximskorik 

Original PR comment was:
* Extended `SimilarityNetwork` class to be able to write network graphs in `cyjs`, `gexf`, `gml`, and `JSON` formats
   - these formats appear to be the most robust and commonly used. Let me know if I missed any.
   - `JSON` data is represented via **node-link** format, which seems to be more suitable for molecular network visualization than **adjacency** or **tree-like** formats (two other json formats available at [NetworkX](https://networkx.org/documentation/stable/reference/readwrite/json_graph.html))
* `export_to_graphml` is still available as a public method, and `graphml` is a default format in `export_to_file` method
* Updated tests to include new file extensions

**Testing**
* I also generated a `.cyjs` file from [dummy spectra](https://github.com/matchms/matchms/blob/e780a91f9dfb7ba975f0e8e2732f800ee122163f/tests/test_SimilarityNetwork.py#L17) network and was able to visualize the graph in Galaxy Cytoscape plugin
---
Closes #341 