### PR TITLE
Add export/import for Scores objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Scores`: added functionality for writing and reading `Scores` objects to/from disk as JSON and Pickle files [#353](https://github.com/matchms/matchms/pull/353)
+
 ## [0.16.0] - 2022-06-12
 
 ### Added

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -217,7 +217,7 @@ class Scores:
                             self._scores[references_idx_sorted, selected_idx].copy()))
         return list(zip(self.references, self._scores[:, selected_idx].copy()))
 
-    def export_to_json(self, filename: str):
+    def to_json(self, filename: str):
         """Export the scores to a file.
 
         Parameters
@@ -228,7 +228,7 @@ class Scores:
         with open(filename, "w", encoding="utf-8") as f:
             json.dump(self, f, cls=ScoresJSONEncoder)
 
-    def export_to_pickle(self, filename: str):
+    def to_pickle(self, filename: str):
         """Export the scores to a file.
 
         Parameters

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -199,6 +199,30 @@ class Scores:
                             self._scores[references_idx_sorted, selected_idx].copy()))
         return list(zip(self.references, self._scores[:, selected_idx].copy()))
 
+    @classmethod
+    def import_from_file(cls, file_path: str) -> Scores:
+        """Import scores from a file.
+
+        Parameters
+        ----------
+        file_path
+            Path to the scores file.
+        """
+        raise NotImplementedError("Import from file is not implemented yet.")
+
+    def export_to_file(self, filename: str, file_format: str = "json"):
+        """Export the scores to a file.
+
+        Parameters
+        ----------
+        filename
+            Path to file to write to
+        file_format
+            File format to write to.
+            Default is "json".
+        """
+        raise NotImplementedError("Not implemented yet.")
+
     @property
     def scores(self) -> numpy.ndarray:
         """Scores as numpy array

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -223,7 +223,7 @@ class Scores:
         file_path
             Path to the scores file.
         """
-        return ScoresBuilder.from_json(file_path).build()
+        return ScoresBuilder().from_json(file_path).build()
 
     def export_to_file(self, filename: str, file_format: str = "json"):
         """Export the scores to a file.

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -81,6 +81,17 @@ class Scores:
         self._scores = numpy.empty([self.n_rows, self.n_cols], dtype="object")
         self._index = 0
 
+    def __eq__(self, other):
+        if isinstance(other, Scores):
+            return self._scores == other._scores and\
+                self.similarity_function == other.similarity_function and\
+                self.is_symmetric == other.is_symmetric and\
+                self.n_rows == other.n_rows and\
+                self.n_cols == other.n_cols and\
+                self.references == other.references and\
+                self.queries == other.queries
+        return False
+
     def __iter__(self):
         return self
 

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -230,7 +230,11 @@ class Scores:
 
     @classmethod
     def import_from_pickle(cls, file_path: str) -> Scores:
-        """Import scores from a pickle file."""
+        """Import scores from a pickle file.
+
+        WARNING: Pickle files are not secure and may execute malicious code. Make sure that you are importing a pickle
+        file from a trusted source.
+        """
         with open(file_path, "rb") as f:
             return pickle.load(f)
 

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -218,7 +218,7 @@ class Scores:
         return list(zip(self.references, self._scores[:, selected_idx].copy()))
 
     def to_json(self, filename: str):
-        """Export the scores to a file.
+        """Export :py:class:`~matchms.Scores.Scores` to a JSON file.
 
         Parameters
         ----------
@@ -229,7 +229,7 @@ class Scores:
             json.dump(self, f, cls=ScoresJSONEncoder)
 
     def to_pickle(self, filename: str):
-        """Export the scores to a file.
+        """Export :py:class:`~matchms.Scores.Scores` to a Pickle file.
 
         Parameters
         ----------

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -257,6 +257,15 @@ class Scores:
         else:
             raise ValueError(f"File format '{file_format}' is not supported.")
 
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of scores."""
+        return {"__Scores__": True,
+                "similarity_function": self._encode_similarity_function(self.similarity_function),
+                "is_symmetric": self.is_symmetric,
+                "references": [reference.to_dict() for reference in self.references],
+                "queries": [query.to_dict() for query in self.queries] if not self.is_symmetric else None,
+                "scores": self.scores.tolist()}
+
     @property
     def scores(self) -> numpy.ndarray:
         """Scores as numpy array

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -5,6 +5,7 @@ from deprecated.sphinx import deprecated
 from matchms.importing.load_from_json import scores_json_decoder
 from matchms.exporting.save_as_json import ScoresJSONEncoder
 from matchms.similarity.BaseSimilarity import BaseSimilarity
+from matchms.similarity import _get_similarity_function_by_name
 from matchms.typing import QueriesType, ReferencesType
 
 
@@ -310,11 +311,18 @@ class ScoresBuilder:
         self._validate_json_input(scores_dict)
 
         self.is_symmetric = scores_dict['is_symmetric']
-        self.similarity_function = scores_dict['similarity_function']
+        self.similarity_function = self._construct_similarity_function(scores_dict['similarity_function'])
         self.references = scores_dict['references']
         self.queries = scores_dict['queries'] if not self.is_symmetric else self.references
 
         return self
+
+    def _construct_similarity_function(similarity_function_dict: dict) -> BaseSimilarity:
+        """
+        Constructs similarity function from its serialized representation
+        """
+        similarity_function_class = _get_similarity_function_by_name(similarity_function_dict.pop("name"))
+        return similarity_function_class(**similarity_function_dict)
 
     @staticmethod
     def _validate_json_input(scores_dict: dict):

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -286,15 +286,18 @@ class ScoresBuilder:
         self.queries = None
         self.similarity_function = None
         self.is_symmetric = None
+        self.scores = None
 
     def build(self) -> Scores:
         """
         Builds scores object
         """
-        return Scores(references=self.references,
-                      queries=self.queries,
-                      similarity_function=self.similarity_function,
-                      is_symmetric=self.is_symmetric)
+        scores = Scores(references=self.references,
+                        queries=self.queries,
+                        similarity_function=self.similarity_function,
+                        is_symmetric=self.is_symmetric)
+        scores._scores = self.scores
+        return scores
 
     def from_json(self, file_path: str):
         """
@@ -314,6 +317,7 @@ class ScoresBuilder:
         self.similarity_function = self._construct_similarity_function(scores_dict['similarity_function'])
         self.references = scores_dict['references']
         self.queries = scores_dict['queries'] if not self.is_symmetric else self.references
+        self.scores = scores_dict['scores']
 
         return self
 

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 import json
+import pickle
 import numpy
 import numpy.lib.recfunctions
 from deprecated.sphinx import deprecated
-from matchms.importing.load_from_json import scores_json_decoder
 from matchms.exporting.save_as_json import ScoresJSONEncoder
-from matchms.similarity.BaseSimilarity import BaseSimilarity
+from matchms.importing.load_from_json import scores_json_decoder
 from matchms.similarity import _get_similarity_function_by_name
+from matchms.similarity.BaseSimilarity import BaseSimilarity
 from matchms.typing import QueriesType, ReferencesType
-import pickle
 
 
 class Scores:

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -57,6 +57,7 @@ class Scores:
         Cosine score between spectrum2 and spectrum3 is 0.14 with 1 matched peaks
         Cosine score between spectrum2 and spectrum4 is 0.61 with 1 matched peaks
     """
+
     def __init__(self, references: ReferencesType, queries: QueriesType,
                  similarity_function: BaseSimilarity, is_symmetric: bool = False):
         """
@@ -90,12 +91,12 @@ class Scores:
     def __eq__(self, other):
         if isinstance(other, Scores):
             return numpy.array_equal(self._scores, other._scores) and \
-                self.similarity_function.__class__ == other.similarity_function.__class__ and \
-                self.is_symmetric == other.is_symmetric and \
-                self.n_rows == other.n_rows and \
-                self.n_cols == other.n_cols and \
-                numpy.array_equal(self.references, other.references) and \
-                numpy.array_equal(self.queries, other.queries)
+                   self.similarity_function.__class__ == other.similarity_function.__class__ and \
+                   self.is_symmetric == other.is_symmetric and \
+                   self.n_rows == other.n_rows and \
+                   self.n_cols == other.n_cols and \
+                   numpy.array_equal(self.references, other.references) and \
+                   numpy.array_equal(self.queries, other.queries)
         return NotImplemented
 
     def __iter__(self):
@@ -118,13 +119,13 @@ class Scores:
 
     @staticmethod
     def _validate_input_arguments(references, queries, similarity_function):
-        assert isinstance(references, (list, tuple, numpy.ndarray)),\
+        assert isinstance(references, (list, tuple, numpy.ndarray)), \
             "Expected input argument 'references' to be list or tuple or numpy.ndarray."
 
-        assert isinstance(queries, (list, tuple, numpy.ndarray)),\
+        assert isinstance(queries, (list, tuple, numpy.ndarray)), \
             "Expected input argument 'queries' to be list or tuple or numpy.ndarray."
 
-        assert isinstance(similarity_function, BaseSimilarity),\
+        assert isinstance(similarity_function, BaseSimilarity), \
             "Expected input argument 'similarity_function' to have BaseSimilarity as super-class."
 
     @deprecated(version='0.6.0', reason="Calculate scores via calculate_scores() function.")
@@ -308,7 +309,7 @@ class ScoresBuilder:
                         queries=self.queries,
                         similarity_function=self.similarity_function,
                         is_symmetric=self.is_symmetric)
-        scores._scores = self.scores
+        scores._scores = self.scores  # pylint: disable=protected-access
         return scores
 
     def from_json(self, file_path: str):

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -279,7 +279,7 @@ class Scores:
 
 class ScoresBuilder:
     """
-    Builds scores object from its serialized representation
+    Builder class for :class:`~matchms.Scores`.
     """
 
     def __init__(self):
@@ -291,7 +291,7 @@ class ScoresBuilder:
 
     def build(self) -> Scores:
         """
-        Builds scores object
+        Build scores object
         """
         scores = Scores(references=self.references,
                         queries=self.queries,
@@ -324,7 +324,7 @@ class ScoresBuilder:
 
     def _restructure_scores(self, scores: dict) -> numpy.ndarray:
         """
-        Restructure scores from nested list to a numpy array. If scores were stored as a matrix of tuples, restores
+        Restructure scores from a nested list to a numpy array. If scores were stored as an array of tuples, restores
         their original form.
         """
         scores = numpy.array(scores)
@@ -337,7 +337,7 @@ class ScoresBuilder:
     @staticmethod
     def _construct_similarity_function(similarity_function_dict: dict) -> BaseSimilarity:
         """
-        Constructs similarity function from its serialized representation
+        Construct similarity function from its serialized form.
         """
         similarity_function_class = _get_similarity_function_by_name(similarity_function_dict.pop("__Similarity__"))
         return similarity_function_class(**similarity_function_dict)
@@ -345,6 +345,6 @@ class ScoresBuilder:
     @staticmethod
     def _validate_json_input(scores_dict: dict):
         if {"__Scores__", "similarity_function", "is_symmetric", "references", "queries", "scores"} != scores_dict.keys():
-            raise ValueError("Scores JSON file does not match against the schema.\n\
+            raise ValueError("Scores JSON file does not match the expected schema.\n\
                              Make sure the file contains the following keys:\n\
                              ['__Scores__', 'similarity_function', 'is_symmetric', 'references', 'queries', 'scores']")

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -260,7 +260,7 @@ class Scores:
     def to_dict(self) -> dict:
         """Return a dictionary representation of scores."""
         return {"__Scores__": True,
-                "similarity_function": self._encode_similarity_function(self.similarity_function),
+                "similarity_function": self.similarity_function.to_dict(),
                 "is_symmetric": self.is_symmetric,
                 "references": [reference.to_dict() for reference in self.references],
                 "queries": [query.to_dict() for query in self.queries] if not self.is_symmetric else None,

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -8,6 +8,7 @@ from matchms.exporting.save_as_json import ScoresJSONEncoder
 from matchms.similarity.BaseSimilarity import BaseSimilarity
 from matchms.similarity import _get_similarity_function_by_name
 from matchms.typing import QueriesType, ReferencesType
+import pickle
 
 
 class Scores:
@@ -226,6 +227,12 @@ class Scores:
         """
         return ScoresBuilder().from_json(file_path).build()
 
+    @classmethod
+    def import_from_pickle(cls, file_path: str) -> Scores:
+        """Import scores from a pickle file."""
+        with open(file_path, 'rb') as f:
+            return pickle.load(f)
+
     def export_to_file(self, filename: str, file_format: str = "json"):
         """Export the scores to a file.
 
@@ -234,12 +241,16 @@ class Scores:
         filename
             Path to file to write to
         file_format
-            File format to write to.
-            Default is "json".
+            File format to write to. Supported formats are: "json", "pkl". Default is "json".
         """
-        with open(filename, "w") as f:
-            if file_format == "json":
+        if file_format == "json":
+            with open(filename, "w", encoding="utf-8") as f:
                 json.dump(self, f, cls=ScoresJSONEncoder)
+        elif file_format == "pkl":
+            with open(filename, "wb") as f:
+                pickle.dump(self, f)
+        else:
+            raise ValueError(f"File format '{file_format}' is not supported.")
 
     @property
     def scores(self) -> numpy.ndarray:

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+import json
 import numpy
 from deprecated.sphinx import deprecated
+from matchms.exporting.save_as_json import ScoresJSONEncoder
 from matchms.similarity.BaseSimilarity import BaseSimilarity
 from matchms.typing import QueriesType, ReferencesType
 
@@ -232,7 +234,9 @@ class Scores:
             File format to write to.
             Default is "json".
         """
-        raise NotImplementedError("Not implemented yet.")
+        with open(filename, "w") as f:
+            if file_format == "json":
+                json.dump(self, f, cls=ScoresJSONEncoder)
 
     @property
     def scores(self) -> numpy.ndarray:

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -222,21 +222,7 @@ class Scores:
         file_path
             Path to the scores file.
         """
-        with open(file_path, 'rb') as f:
-            scores_dict = json.load(f, object_hook=scores_json_decoder)
-
-        if scores_dict["is_symmetric"] and scores_dict["queries"] is None:
-            scores_dict["queries"] = scores_dict["references"]
-
-        cls._validate_json_input(scores_dict)
-
-        scores = cls(references=numpy.array(scores_dict['references']),
-                     queries=numpy.array(scores_dict['queries']),
-                     similarity_function=BaseSimilarity(),
-                     is_symmetric=scores_dict['is_symmetric'])
-        scores._scores = scores_dict['scores']
-
-        return scores
+        return ScoresBuilder.from_json(file_path)
 
     def export_to_file(self, filename: str, file_format: str = "json"):
         """Export the scores to a file.
@@ -288,9 +274,32 @@ class Scores:
         """
         return self._scores.copy()
 
+
+class ScoresBuilder:
+    """
+    Builds scores object from its serialized representation
+    """
+
+    def __init__(self):
+        pass
+
+    def from_json(self, file_path: str) -> Scores:
+        """
+        Import scores object from a JSON file.
+
+        Parameters
+        ----------
+        file_path
+            Path to the scores file.
+        """
+        with open(file_path, 'rb') as f:
+            scores_dict = json.load(f, object_hook=scores_json_decoder)
+
+        self._validate_json_input(scores_dict)
+
     @staticmethod
     def _validate_json_input(scores_dict: dict):
         if {"__Scores__", "similarity_function", "is_symmetric", "references", "queries", "scores"} != scores_dict.keys():
             raise ValueError("Scores JSON file does not match against the schema.\n\
-                             Make sure JSON file contains the following keys:\n\
+                             Make sure the file contains the following keys:\n\
                              ['__Scores__', 'similarity_function', 'is_symmetric', 'references', 'queries', 'scores']")

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -317,6 +317,7 @@ class ScoresBuilder:
 
         return self
 
+    @staticmethod
     def _construct_similarity_function(similarity_function_dict: dict) -> BaseSimilarity:
         """
         Constructs similarity function from its serialized representation

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -217,27 +217,6 @@ class Scores:
                             self._scores[references_idx_sorted, selected_idx].copy()))
         return list(zip(self.references, self._scores[:, selected_idx].copy()))
 
-    @classmethod
-    def import_from_json(cls, file_path: str) -> Scores:
-        """Import scores from a JSON file.
-
-        Parameters
-        ----------
-        file_path
-            Path to the scores file.
-        """
-        return ScoresBuilder().from_json(file_path).build()
-
-    @classmethod
-    def import_from_pickle(cls, file_path: str) -> Scores:
-        """Import scores from a pickle file.
-
-        WARNING: Pickle files are not secure and may execute malicious code. Make sure that you are importing a pickle
-        file from a trusted source.
-        """
-        with open(file_path, "rb") as f:
-            return pickle.load(f)
-
     def export_to_file(self, filename: str, file_format: str = "json"):
         """Export the scores to a file.
 

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -222,7 +222,7 @@ class Scores:
         file_path
             Path to the scores file.
         """
-        return ScoresBuilder.from_json(file_path)
+        return ScoresBuilder.from_json(file_path).build()
 
     def export_to_file(self, filename: str, file_format: str = "json"):
         """Export the scores to a file.
@@ -281,11 +281,23 @@ class ScoresBuilder:
     """
 
     def __init__(self):
-        pass
+        self.references = None
+        self.queries = None
+        self.similarity_function = None
+        self.is_symmetric = None
 
-    def from_json(self, file_path: str) -> Scores:
+    def build(self) -> Scores:
         """
-        Import scores object from a JSON file.
+        Builds scores object
+        """
+        return Scores(references=self.references,
+                      queries=self.queries,
+                      similarity_function=self.similarity_function,
+                      is_symmetric=self.is_symmetric)
+
+    def from_json(self, file_path: str):
+        """
+        Import scores data from a JSON file.
 
         Parameters
         ----------
@@ -296,6 +308,13 @@ class ScoresBuilder:
             scores_dict = json.load(f, object_hook=scores_json_decoder)
 
         self._validate_json_input(scores_dict)
+
+        self.is_symmetric = scores_dict['is_symmetric']
+        self.similarity_function = scores_dict['similarity_function']
+        self.references = scores_dict['references']
+        self.queries = scores_dict['queries'] if not self.is_symmetric else self.references
+
+        return self
 
     @staticmethod
     def _validate_json_input(scores_dict: dict):

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -230,7 +230,7 @@ class Scores:
     @classmethod
     def import_from_pickle(cls, file_path: str) -> Scores:
         """Import scores from a pickle file."""
-        with open(file_path, 'rb') as f:
+        with open(file_path, "rb") as f:
             return pickle.load(f)
 
     def export_to_file(self, filename: str, file_format: str = "json"):
@@ -320,16 +320,16 @@ class ScoresBuilder:
         file_path
             Path to the scores file.
         """
-        with open(file_path, 'rb') as f:
+        with open(file_path, "rb") as f:
             scores_dict = json.load(f, object_hook=scores_json_decoder)
 
         self._validate_json_input(scores_dict)
 
-        self.is_symmetric = scores_dict['is_symmetric']
-        self.similarity_function = self._construct_similarity_function(scores_dict['similarity_function'])
-        self.references = scores_dict['references']
-        self.queries = scores_dict['queries'] if not self.is_symmetric else self.references
-        self.scores = self._restructure_scores(scores_dict['scores'])
+        self.is_symmetric = scores_dict["is_symmetric"]
+        self.similarity_function = self._construct_similarity_function(scores_dict["similarity_function"])
+        self.references = scores_dict["references"]
+        self.queries = scores_dict["queries"] if not self.is_symmetric else self.references
+        self.scores = self._restructure_scores(scores_dict["scores"])
 
         return self
 

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -222,10 +222,10 @@ class Scores:
         file_path
             Path to the scores file.
         """
-        with open(file_path, 'r') as f:
+        with open(file_path, 'rb') as f:
             scores_dict = json.load(f, object_hook=scores_json_decoder)
 
-        raise NotImplementedError("Import from file is not implemented yet.")
+        return scores_dict
 
     def export_to_file(self, filename: str, file_format: str = "json"):
         """Export the scores to a file.

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import json
 import numpy
 from deprecated.sphinx import deprecated
+from matchms.importing.load_from_json import scores_json_decoder
 from matchms.exporting.save_as_json import ScoresJSONEncoder
 from matchms.similarity.BaseSimilarity import BaseSimilarity
 from matchms.typing import QueriesType, ReferencesType
@@ -213,14 +214,17 @@ class Scores:
         return list(zip(self.references, self._scores[:, selected_idx].copy()))
 
     @classmethod
-    def import_from_file(cls, file_path: str) -> Scores:
-        """Import scores from a file.
+    def import_from_json(cls, file_path: str) -> Scores:
+        """Import scores from a JSON file.
 
         Parameters
         ----------
         file_path
             Path to the scores file.
         """
+        with open(file_path, 'r') as f:
+            scores_dict = json.load(f, object_hook=scores_json_decoder)
+
         raise NotImplementedError("Import from file is not implemented yet.")
 
     def export_to_file(self, filename: str, file_format: str = "json"):

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -88,14 +88,14 @@ class Scores:
 
     def __eq__(self, other):
         if isinstance(other, Scores):
-            return self._scores == other._scores and\
-                self.similarity_function == other.similarity_function and\
-                self.is_symmetric == other.is_symmetric and\
-                self.n_rows == other.n_rows and\
-                self.n_cols == other.n_cols and\
-                self.references == other.references and\
-                self.queries == other.queries
-        return False
+            return numpy.array_equal(self._scores, other._scores) and \
+                self.similarity_function.__class__ == other.similarity_function.__class__ and \
+                self.is_symmetric == other.is_symmetric and \
+                self.n_rows == other.n_rows and \
+                self.n_cols == other.n_cols and \
+                numpy.array_equal(self.references, other.references) and \
+                numpy.array_equal(self.queries, other.queries)
+        return NotImplemented
 
     def __iter__(self):
         return self

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -322,7 +322,7 @@ class ScoresBuilder:
         """
         Constructs similarity function from its serialized representation
         """
-        similarity_function_class = _get_similarity_function_by_name(similarity_function_dict.pop("name"))
+        similarity_function_class = _get_similarity_function_by_name(similarity_function_dict.pop("__Similarity__"))
         return similarity_function_class(**similarity_function_dict)
 
     @staticmethod

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -6,7 +6,7 @@ import numpy.lib.recfunctions
 from deprecated.sphinx import deprecated
 from matchms.exporting.save_as_json import ScoresJSONEncoder
 from matchms.importing.load_from_json import scores_json_decoder
-from matchms.similarity import _get_similarity_function_by_name
+from matchms.similarity import get_similarity_function_by_name
 from matchms.similarity.BaseSimilarity import BaseSimilarity
 from matchms.typing import QueriesType, ReferencesType
 
@@ -351,7 +351,7 @@ class ScoresBuilder:
         """
         Construct similarity function from its serialized form.
         """
-        similarity_function_class = _get_similarity_function_by_name(similarity_function_dict.pop("__Similarity__"))
+        similarity_function_class = get_similarity_function_by_name(similarity_function_dict.pop("__Similarity__"))
         return similarity_function_class(**similarity_function_dict)
 
     @staticmethod

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -217,24 +217,27 @@ class Scores:
                             self._scores[references_idx_sorted, selected_idx].copy()))
         return list(zip(self.references, self._scores[:, selected_idx].copy()))
 
-    def export_to_file(self, filename: str, file_format: str = "json"):
+    def export_to_json(self, filename: str):
         """Export the scores to a file.
 
         Parameters
         ----------
         filename
             Path to file to write to
-        file_format
-            File format to write to. Supported formats are: "json", "pkl". Default is "json".
         """
-        if file_format == "json":
-            with open(filename, "w", encoding="utf-8") as f:
-                json.dump(self, f, cls=ScoresJSONEncoder)
-        elif file_format == "pkl":
-            with open(filename, "wb") as f:
-                pickle.dump(self, f)
-        else:
-            raise ValueError(f"File format '{file_format}' is not supported.")
+        with open(filename, "w", encoding="utf-8") as f:
+            json.dump(self, f, cls=ScoresJSONEncoder)
+
+    def export_to_pickle(self, filename: str):
+        """Export the scores to a file.
+
+        Parameters
+        ----------
+        filename
+            Path to file to write to
+        """
+        with open(filename, "wb") as f:
+            pickle.dump(self, f)
 
     def to_dict(self) -> dict:
         """Return a dictionary representation of scores."""

--- a/matchms/Spectrum.py
+++ b/matchms/Spectrum.py
@@ -196,7 +196,7 @@ class Spectrum:
     def to_dict(self) -> dict:
         """Return a dictionary representation of a spectrum."""
         peaks_list = np.vstack((self.peaks.mz, self.peaks.intensities)).T.tolist()
-        spectrum_dict = {key: self.metadata[key] for key in self.metadata}
+        spectrum_dict = dict(self.metadata.items())
         spectrum_dict["peaks_json"] = peaks_list
         if "fingerprint" in spectrum_dict:
             spectrum_dict["fingerprint"] = spectrum_dict["fingerprint"].tolist()

--- a/matchms/Spectrum.py
+++ b/matchms/Spectrum.py
@@ -193,6 +193,13 @@ class Spectrum:
         self._metadata.set(key, value)
         return self
 
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of a spectrum."""
+        peaks_list = np.vstack((self.peaks.mz, self.peaks.intensities)).T.tolist()
+        spectrum_dict = {key: self.metadata[key] for key in self.metadata}
+        spectrum_dict["peaks_json"] = peaks_list
+        return spectrum_dict
+
     @property
     def mz(self):
         return self.peaks.mz

--- a/matchms/Spectrum.py
+++ b/matchms/Spectrum.py
@@ -198,6 +198,8 @@ class Spectrum:
         peaks_list = np.vstack((self.peaks.mz, self.peaks.intensities)).T.tolist()
         spectrum_dict = {key: self.metadata[key] for key in self.metadata}
         spectrum_dict["peaks_json"] = peaks_list
+        if "fingerprint" in spectrum_dict:
+            spectrum_dict["fingerprint"] = spectrum_dict["fingerprint"].tolist()
         return spectrum_dict
 
     @property

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -65,11 +65,13 @@ class SpectrumJSONEncoder(json.JSONEncoder):
 class ScoresJSONEncoder(json.JSONEncoder):
     def default(self, o):
         """JSON Encoder which can encode a :py:class:`~matchms.Scores.Scores` object"""
+        class_name = o.__class__.__name__
         # do isinstance(o, Scores) without importing matchms.Scores
-        if o.__class__.__name__ == "Scores":
+        if class_name == "Scores":
             scores = copy.deepcopy(o)
 
-            scores_dict = {"similarity_function": str(scores.similarity_function.__class__.__name__),
+            scores_dict = {"__Scores__": True,
+                           "similarity_function": str(scores.similarity_function.__class__.__name__),
                            "is_symmetric": scores.is_symmetric,
                            "references": [_convert_spectrum_into_dict(reference) for reference in scores.references],
                            "queries": [_convert_spectrum_into_dict(query) for query in scores.queries] if scores.is_symmetric else None,

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from typing import List
 import numpy
@@ -43,16 +44,36 @@ def save_as_json(spectrums: List[Spectrum], filename: str):
         json.dump(spectrums, fout, cls=SpectrumJSONEncoder)
 
 
+def _convert_spectrum_into_dict(spectrum: Spectrum):
+    """Convert matchms.Spectrum() into dictionaries"""
+    peaks_list = numpy.vstack((spectrum.peaks.mz, spectrum.peaks.intensities)).T.tolist()
+    spectrum_dict = {key: spectrum.metadata[key] for key in spectrum.metadata}
+    spectrum_dict["peaks_json"] = peaks_list
+    return spectrum_dict
+
+
 class SpectrumJSONEncoder(json.JSONEncoder):
     # See https://github.com/PyCQA/pylint/issues/414 for reference
     def default(self, o):
         """JSON Encoder which can encode a :py:class:`~matchms.Spectrum.Spectrum` object"""
         if isinstance(o, Spectrum):
             spec = o.clone()
-            peaks_list = numpy.vstack((spec.peaks.mz, spec.peaks.intensities)).T.tolist()
+            return _convert_spectrum_into_dict(spec)
+        return json.JSONEncoder.default(self, o)
 
-            # Convert matchms.Spectrum() into dictionaries
-            spectrum_dict = {key: spec.metadata[key] for key in spec.metadata}
-            spectrum_dict["peaks_json"] = peaks_list
-            return spectrum_dict
+
+class ScoresJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        """JSON Encoder which can encode a :py:class:`~matchms.Scores.Scores` object"""
+        # do isinstance(o, Scores) without importing matchms.Scores
+        if o.__class__.__name__ == "Scores":
+            scores = copy.deepcopy(o)
+
+            scores_dict = {"similarity_function": str(scores.similarity_function.__class__.__name__),
+                           "is_symmetric": scores.is_symmetric,
+                           "references": [_convert_spectrum_into_dict(reference) for reference in scores.references],
+                           "queries": [_convert_spectrum_into_dict(query) for query in scores.queries] if scores.is_symmetric else None,
+                           "scores": scores.scores.tolist()}
+
+            return scores_dict
         return json.JSONEncoder.default(self, o)

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -60,18 +60,5 @@ class ScoresJSONEncoder(json.JSONEncoder):
         # do isinstance(o, Scores) without importing matchms.Scores
         if class_name == "Scores":
             scores = copy.deepcopy(o)
-
-            scores_dict = {"__Scores__": True,
-                           "similarity_function": self._encode_similarity_function(scores.similarity_function),
-                           "is_symmetric": scores.is_symmetric,
-                           "references": [reference.to_dict() for reference in scores.references],
-                           "queries": [query.to_dict() for query in scores.queries] if not scores.is_symmetric else None,
-                           "scores": scores.scores.tolist()}
-
-            return scores_dict
+            return scores.to_dict()
         return json.JSONEncoder.default(self, o)
-
-    @staticmethod
-    def _encode_similarity_function(similarity_function) -> dict:
-        similarity_function_dict = {"__Similarity__": similarity_function.__class__.__name__, **similarity_function.__dict__}
-        return similarity_function_dict

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -1,7 +1,6 @@
 import copy
 import json
 from typing import List
-import numpy
 from ..Spectrum import Spectrum
 
 
@@ -44,21 +43,13 @@ def save_as_json(spectrums: List[Spectrum], filename: str):
         json.dump(spectrums, fout, cls=SpectrumJSONEncoder)
 
 
-def _convert_spectrum_into_dict(spectrum: Spectrum):
-    """Convert :py:class:`~matchms.Spectrum.Spectrum` into a dictionary"""
-    peaks_list = numpy.vstack((spectrum.peaks.mz, spectrum.peaks.intensities)).T.tolist()
-    spectrum_dict = {key: spectrum.metadata[key] for key in spectrum.metadata}
-    spectrum_dict["peaks_json"] = peaks_list
-    return spectrum_dict
-
-
 class SpectrumJSONEncoder(json.JSONEncoder):
     # See https://github.com/PyCQA/pylint/issues/414 for reference
     def default(self, o):
         """JSON Encoder which can encode a :py:class:`~matchms.Spectrum.Spectrum` object"""
         if isinstance(o, Spectrum):
             spec = o.clone()
-            return _convert_spectrum_into_dict(spec)
+            return spec.to_dict()
         return json.JSONEncoder.default(self, o)
 
 
@@ -73,8 +64,8 @@ class ScoresJSONEncoder(json.JSONEncoder):
             scores_dict = {"__Scores__": True,
                            "similarity_function": self._encode_similarity_function(scores.similarity_function),
                            "is_symmetric": scores.is_symmetric,
-                           "references": [_convert_spectrum_into_dict(reference) for reference in scores.references],
-                           "queries": [_convert_spectrum_into_dict(query) for query in scores.queries] if not scores.is_symmetric else None,
+                           "references": [reference.to_dict() for reference in scores.references],
+                           "queries": [query.to_dict() for query in scores.queries] if not scores.is_symmetric else None,
                            "scores": scores.scores.tolist()}
 
             return scores_dict

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -45,7 +45,7 @@ def save_as_json(spectrums: List[Spectrum], filename: str):
 
 
 def _convert_spectrum_into_dict(spectrum: Spectrum):
-    """Convert matchms.Spectrum() into dictionaries"""
+    """Convert :py:class:`~matchms.Spectrum.Spectrum` into a dictionary"""
     peaks_list = numpy.vstack((spectrum.peaks.mz, spectrum.peaks.intensities)).T.tolist()
     spectrum_dict = {key: spectrum.metadata[key] for key in spectrum.metadata}
     spectrum_dict["peaks_json"] = peaks_list

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -40,7 +40,7 @@ def save_as_json(spectrums: List[Spectrum], filename: str):
         spectrums = [spectrums]
 
     # Write to json file
-    with open(filename, 'w', encoding="utf-8") as fout:
+    with open(filename, "w", encoding="utf-8") as fout:
         json.dump(spectrums, fout, cls=SpectrumJSONEncoder)
 
 

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -71,7 +71,7 @@ class ScoresJSONEncoder(json.JSONEncoder):
             scores = copy.deepcopy(o)
 
             scores_dict = {"__Scores__": True,
-                           "similarity_function": str(scores.similarity_function.__class__.__name__),
+                           "similarity_function": self._encode_similarity_function(scores.similarity_function),
                            "is_symmetric": scores.is_symmetric,
                            "references": [_convert_spectrum_into_dict(reference) for reference in scores.references],
                            "queries": [_convert_spectrum_into_dict(query) for query in scores.queries] if not scores.is_symmetric else None,
@@ -79,3 +79,8 @@ class ScoresJSONEncoder(json.JSONEncoder):
 
             return scores_dict
         return json.JSONEncoder.default(self, o)
+
+    @staticmethod
+    def _encode_similarity_function(similarity_function) -> dict:
+        similarity_function_dict = {"__Similarity__": similarity_function.__class__.__name__, **similarity_function.__dict__}
+        return similarity_function_dict

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -74,7 +74,7 @@ class ScoresJSONEncoder(json.JSONEncoder):
                            "similarity_function": str(scores.similarity_function.__class__.__name__),
                            "is_symmetric": scores.is_symmetric,
                            "references": [_convert_spectrum_into_dict(reference) for reference in scores.references],
-                           "queries": [_convert_spectrum_into_dict(query) for query in scores.queries] if scores.is_symmetric else None,
+                           "queries": [_convert_spectrum_into_dict(query) for query in scores.queries] if not scores.is_symmetric else None,
                            "scores": scores.scores.tolist()}
 
             return scores_dict

--- a/matchms/importing/__init__.py
+++ b/matchms/importing/__init__.py
@@ -22,6 +22,7 @@ from .load_from_mzxml import load_from_mzxml
 from .load_from_usi import load_from_usi
 from .load_scores import scores_from_json, scores_from_pickle
 
+
 __all__ = [
     "load_from_json",
     "load_from_mgf",

--- a/matchms/importing/__init__.py
+++ b/matchms/importing/__init__.py
@@ -32,4 +32,3 @@ __all__ = [
     "scores_from_json",
     "scores_from_pickle",
 ]
-

--- a/matchms/importing/__init__.py
+++ b/matchms/importing/__init__.py
@@ -20,7 +20,7 @@ from .load_from_msp import load_from_msp
 from .load_from_mzml import load_from_mzml
 from .load_from_mzxml import load_from_mzxml
 from .load_from_usi import load_from_usi
-
+from .load_scores import scores_from_json, scores_from_pickle
 
 __all__ = [
     "load_from_json",
@@ -29,4 +29,7 @@ __all__ = [
     "load_from_mzml",
     "load_from_mzxml",
     "load_from_usi",
+    "scores_from_json",
+    "scores_from_pickle",
 ]
+

--- a/matchms/importing/load_from_json.py
+++ b/matchms/importing/load_from_json.py
@@ -115,6 +115,6 @@ def dict2spectrum(spectrum_dict: dict,
 
 
 def scores_json_decoder(dct):
-    if not "__Scores__" in dct:
+    if "__Scores__" not in dct and "__Similarity__" not in dct:
         return dict2spectrum(dct, metadata_harmonization=False)
     return dct

--- a/matchms/importing/load_from_json.py
+++ b/matchms/importing/load_from_json.py
@@ -115,6 +115,9 @@ def dict2spectrum(spectrum_dict: dict,
 
 
 def scores_json_decoder(dct):
+    """
+    Object_hook function to convert JSON dictionary with :py:class:`~matchms.Score.Score` object into a python dictionary.
+    """
     if "__Scores__" not in dct and "__Similarity__" not in dct:
         return dict2spectrum(dct, metadata_harmonization=False)
     return dct

--- a/matchms/importing/load_from_json.py
+++ b/matchms/importing/load_from_json.py
@@ -112,3 +112,7 @@ def dict2spectrum(spectrum_dict: dict,
                         metadata_harmonization=metadata_harmonization)
     logger.info("Empty spectrum found (no peaks in 'peaks_json'). Will not be imported.")
     return None
+
+
+def scores_json_decoder(dct):
+    pass

--- a/matchms/importing/load_from_json.py
+++ b/matchms/importing/load_from_json.py
@@ -115,4 +115,6 @@ def dict2spectrum(spectrum_dict: dict,
 
 
 def scores_json_decoder(dct):
-    pass
+    if not "__Scores__" in dct:
+        return dict2spectrum(dct, metadata_harmonization=False)
+    return dct

--- a/matchms/importing/load_scores.py
+++ b/matchms/importing/load_scores.py
@@ -1,0 +1,31 @@
+import pickle
+
+from matchms.Scores import ScoresBuilder
+
+
+def scores_from_json(file_path):
+    """
+    Load :py:class:`~matchms.Score.Score` object from a json file.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to json file containing scores.
+    """
+    return ScoresBuilder().from_json(file_path).build()
+
+
+def scores_from_pickle(file_path):
+    """
+    Load :py:class:`~matchms.Score.Score` object from a pickle file.
+
+    WARNING: Pickle files are not secure and may execute malicious code. Make sure that you are importing a pickle
+        file from a trusted source.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to pickle file containing scores.
+    """
+    with open(file_path, "rb") as f:
+        return pickle.load(f)

--- a/matchms/importing/load_scores.py
+++ b/matchms/importing/load_scores.py
@@ -1,5 +1,4 @@
 import pickle
-
 from matchms.Scores import ScoresBuilder
 
 

--- a/matchms/importing/load_scores.py
+++ b/matchms/importing/load_scores.py
@@ -2,19 +2,19 @@ import pickle
 from matchms.Scores import ScoresBuilder
 
 
-def scores_from_json(file_path):
+def scores_from_json(filename):
     """
     Load :py:class:`~matchms.Score.Score` object from a json file.
 
     Parameters
     ----------
-    file_path : str
+    filename : str
         Path to json file containing scores.
     """
-    return ScoresBuilder().from_json(file_path).build()
+    return ScoresBuilder().from_json(filename).build()
 
 
-def scores_from_pickle(file_path):
+def scores_from_pickle(filename):
     """
     Load :py:class:`~matchms.Score.Score` object from a pickle file.
 
@@ -23,8 +23,8 @@ def scores_from_pickle(file_path):
 
     Parameters
     ----------
-    file_path : str
+    filename : str
         Path to pickle file containing scores.
     """
-    with open(file_path, "rb") as f:
+    with open(filename, "rb") as f:
         return pickle.load(f)

--- a/matchms/similarity/BaseSimilarity.py
+++ b/matchms/similarity/BaseSimilarity.py
@@ -82,3 +82,8 @@ class BaseSimilarity:
             Indexes of sorted scores.
         """
         return scores.argsort()[::-1]
+
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of a similarity function."""
+        return {"__Similarity__": self.__class__.__name__,
+                **self.__dict__}

--- a/matchms/similarity/PrecursorMzMatch.py
+++ b/matchms/similarity/PrecursorMzMatch.py
@@ -128,6 +128,11 @@ class PrecursorMzMatch(BaseSimilarity):
         return precursormz_scores_ppm(precursors_ref, precursors_query,
                                       self.tolerance).astype(self.score_datatype)
 
+    def to_dict(self) -> dict:
+        dct = super().to_dict()
+        dct["tolerance_type"] = dct.pop("type")
+        return dct
+
 
 @numba.njit
 def precursormz_scores(precursors_ref, precursors_query, tolerance):

--- a/matchms/similarity/__init__.py
+++ b/matchms/similarity/__init__.py
@@ -44,7 +44,7 @@ __all__ = [
 
 def _get_similarity_function_by_name(similarity_function_name: str):
     """
-    Get a similarity function by name.
+    Get a similarity function by the name of its class.
 
     Parameters
     ----------

--- a/matchms/similarity/__init__.py
+++ b/matchms/similarity/__init__.py
@@ -40,3 +40,23 @@ __all__ = [
     "ParentMassMatch",
     "PrecursorMzMatch",
 ]
+
+
+def _get_similarity_function_by_name(similarity_function_name: str):
+    """
+    Get a similarity function by name.
+
+    Parameters
+    ----------
+    similarity_function_name : str
+        Name of the similarity function.
+    """
+    names = __all__
+    functions = [CosineGreedy, CosineHungarian, FingerprintSimilarity, IntersectMz, MetadataMatch, ModifiedCosine,
+                 NeutralLossesCosine, ParentMassMatch, PrecursorMzMatch]
+
+    assert similarity_function_name in names, f"Unknown similarity function: {similarity_function_name}"
+    assert len(names) == len(functions), "Number of similarity functions and names do not match"
+
+    mapper = dict(zip(names, functions))
+    return mapper[similarity_function_name]

--- a/matchms/similarity/__init__.py
+++ b/matchms/similarity/__init__.py
@@ -42,7 +42,7 @@ __all__ = [
 ]
 
 
-def _get_similarity_function_by_name(similarity_function_name: str):
+def get_similarity_function_by_name(similarity_function_name: str):
     """
     Get a similarity function by the name of its class.
 

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -14,6 +14,13 @@ from matchms.metadata_utils import (clean_adduct,
                                     mol_converter)
 
 
+@pytest.fixture()
+def reload_metadata_utils():
+    """Reload metadata_utils module after test has finished."""
+    yield
+    reload(matchms.metadata_utils)
+
+
 def test_mol_converter_smiles_to_inchi():
     """Test if smiles is correctly converted to inchi."""
     pytest.importorskip("rdkit")
@@ -157,7 +164,7 @@ def test_derive_fingerprint_different_types_from_smiles():
         assert numpy.all(fingerprint == expected_fingerprints[i]), "Expected different fingerprint."
 
 
-def test_missing_rdkit_module_error():
+def test_missing_rdkit_module_error(reload_metadata_utils):
     """Test if different functions return correct error when *rdkit* is not available"""
     if find_spec("rdkit") is not None:
         context = mock.patch.dict(sys.modules, {"rdkit": None})

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -4,7 +4,7 @@ import tempfile
 import numpy
 import pytest
 from matchms import Scores, calculate_scores
-from matchms.similarity import CosineGreedy, IntersectMz
+from matchms.similarity import CosineGreedy, IntersectMz, MetadataMatch
 from matchms.similarity.BaseSimilarity import BaseSimilarity
 from .builder_Spectrum import SpectrumBuilder
 
@@ -266,13 +266,14 @@ def test_scores_by_query_non_tuple_score():
     assert selected_scores == expected_result, "Expected different scores."
 
 
-def test_export_to_file_import_from_file(filename):
+@pytest.mark.parametrize("similarity_function", [CosineGreedy(), IntersectMz(), MetadataMatch(field="id")])
+def test_export_to_file_import_from_file(filename, similarity_function):
     "Test export_to_file method."
     spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
     references = [spectrum_1, spectrum_2, spectrum_3]
     queries = [spectrum_2, spectrum_3, spectrum_4]
 
-    scores = calculate_scores(references, queries, CosineGreedy())
+    scores = calculate_scores(references, queries, similarity_function)
     scores.export_to_file(filename)
 
     scores_loaded = Scores.import_from_json(filename)

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -315,3 +315,13 @@ def test_comparing_scores_with_same_shape_different_scores_values(similarity_fun
     scores_parametrized_mirrored = calculate_scores(spectrums, spectrums, similarity_function_b)
 
     assert scores_parametrized != scores_parametrized_mirrored
+
+
+def test_compare_same_scores_with_different_similarity_funcs():
+    "Test comparing same (empty) scores objects with different similarity functions."
+    scores_cosine = calculate_scores([], [], CosineGreedy())
+    scores_cosine_copy = calculate_scores([], [], CosineGreedy())
+    scores_intersect = calculate_scores([], [], IntersectMz())
+
+    assert scores_cosine == scores_cosine_copy
+    assert scores_cosine != scores_intersect

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -299,15 +299,14 @@ def test_comparing_scores():
     scores_symmetric_cosine_copy = calculate_scores(spectrums[0:3], spectrums[0:3], CosineGreedy())
     scores_symmetric_intersect = calculate_scores(spectrums[0:3], spectrums[0:3], IntersectMz())
 
-    assert scores_symmetric_cosine == scores_symmetric_cosine
-    assert scores_symmetric_intersect == scores_symmetric_intersect
     assert scores_symmetric_cosine == scores_symmetric_cosine_copy
     assert scores_symmetric_cosine != scores_symmetric_intersect
 
     scores_asymmetric_cosine = calculate_scores(spectrums[0:3], spectrums, CosineGreedy())
+    scores_asymmetric_cosine_copy = calculate_scores(spectrums[0:3], spectrums, CosineGreedy())
     scores_asymmetric_cosine_mirrored = calculate_scores(spectrums, spectrums[0:3], CosineGreedy())
 
-    assert scores_asymmetric_cosine == scores_asymmetric_cosine
+    assert scores_asymmetric_cosine == scores_asymmetric_cosine_copy
     assert scores_asymmetric_cosine != scores_asymmetric_cosine_mirrored
 
     scores_parametrized = calculate_scores(spectrums, spectrums, CosineGreedy(tolerance=0.1, mz_power=0.5))

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -270,30 +270,36 @@ def test_scores_by_query_non_tuple_score():
     assert selected_scores == expected_result, "Expected different scores."
 
 
-def test_comparing_symmetric_scores():
+@pytest.mark.parametrize(
+    "similarity_function_a,similarity_function_b",
+    [(CosineGreedy(), IntersectMz()), (IntersectMz(), CosineGreedy())])
+def test_comparing_symmetric_scores(similarity_function_a, similarity_function_b):
     "Test comparing symmetric scores objects."
     spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
     spectrums = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
 
-    scores_symmetric_cosine = calculate_scores(spectrums[0:3], spectrums[0:3], CosineGreedy())
-    scores_symmetric_cosine_copy = calculate_scores(spectrums[0:3], spectrums[0:3], CosineGreedy())
-    scores_symmetric_intersect = calculate_scores(spectrums[0:3], spectrums[0:3], IntersectMz())
+    scores_similarity_a = calculate_scores(spectrums, spectrums, similarity_function_a)
+    scores_similarity_a_copy = calculate_scores(spectrums, spectrums, similarity_function_a)
+    scores_similarity_b = calculate_scores(spectrums, spectrums, similarity_function_b)
 
-    assert scores_symmetric_cosine == scores_symmetric_cosine_copy
-    assert scores_symmetric_cosine != scores_symmetric_intersect
+    assert scores_similarity_a == scores_similarity_a_copy
+    assert scores_similarity_a != scores_similarity_b
 
 
-def test_comparing_asymmetric_scores():
+@pytest.mark.parametrize(
+    "similarity_function_a,similarity_function_b",
+    [(CosineGreedy(), IntersectMz()), (IntersectMz(), CosineGreedy())])
+def test_comparing_asymmetric_scores(similarity_function_a, similarity_function_b):
     "Test comparing asymmetric scores objects."
     spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
     spectrums = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
 
-    scores_asymmetric_cosine = calculate_scores(spectrums[0:3], spectrums, CosineGreedy())
-    scores_asymmetric_cosine_copy = calculate_scores(spectrums[0:3], spectrums, CosineGreedy())
-    scores_asymmetric_cosine_mirrored = calculate_scores(spectrums, spectrums[0:3], CosineGreedy())
+    scores_similarity_a = calculate_scores(spectrums[0:3], spectrums, similarity_function_a)
+    scores_similarity_a_copy = calculate_scores(spectrums[0:3], spectrums, similarity_function_a)
+    scores_similarity_b = calculate_scores(spectrums, spectrums[0:3], similarity_function_b)
 
-    assert scores_asymmetric_cosine == scores_asymmetric_cosine_copy
-    assert scores_asymmetric_cosine != scores_asymmetric_cosine_mirrored
+    assert scores_similarity_a == scores_similarity_a_copy
+    assert scores_similarity_a != scores_similarity_b
 
 
 def test_comparing_scores_with_parametrized_similarity_funcs():

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -3,7 +3,7 @@ import tempfile
 import numpy
 import pytest
 from matchms import Scores, calculate_scores
-from matchms.similarity import CosineGreedy, IntersectMz, MetadataMatch
+from matchms.similarity import CosineGreedy, IntersectMz
 from matchms.similarity.BaseSimilarity import BaseSimilarity
 from .builder_Spectrum import SpectrumBuilder
 

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -288,3 +288,29 @@ def test_export_to_file_import_from_file(filename, file_format, similarity_funct
         NotImplementedError(f"Unknown file format: {file_format}. Doublecheck the file_format fixture.")
 
     assert scores == scores_loaded
+
+
+def test_comparing_scores():
+    "Test comparing scores objects."
+    spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
+    spectrums = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
+
+    scores_symmetric_cosine = calculate_scores(spectrums[0:3], spectrums[0:3], CosineGreedy())
+    scores_symmetric_cosine_copy = calculate_scores(spectrums[0:3], spectrums[0:3], CosineGreedy())
+    scores_symmetric_intersect = calculate_scores(spectrums[0:3], spectrums[0:3], IntersectMz())
+
+    assert scores_symmetric_cosine == scores_symmetric_cosine
+    assert scores_symmetric_intersect == scores_symmetric_intersect
+    assert scores_symmetric_cosine == scores_symmetric_cosine_copy
+    assert scores_symmetric_cosine != scores_symmetric_intersect
+
+    scores_asymmetric_cosine = calculate_scores(spectrums[0:3], spectrums, CosineGreedy())
+    scores_asymmetric_cosine_mirrored = calculate_scores(spectrums, spectrums[0:3], CosineGreedy())
+
+    assert scores_asymmetric_cosine == scores_asymmetric_cosine
+    assert scores_asymmetric_cosine != scores_asymmetric_cosine_mirrored
+
+    scores_parametrized = calculate_scores(spectrums, spectrums, CosineGreedy(tolerance=0.1, mz_power=0.5))
+    scores_parametrized_mirrored = calculate_scores(spectrums, spectrums, CosineGreedy(tolerance=0.5, mz_power=0.1))
+
+    assert scores_parametrized != scores_parametrized_mirrored

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -270,26 +270,6 @@ def test_scores_by_query_non_tuple_score():
     assert selected_scores == expected_result, "Expected different scores."
 
 
-@pytest.mark.parametrize("similarity_function", [CosineGreedy(), IntersectMz(), MetadataMatch(field="id")])
-def test_export_to_file_import_from_file(filename, file_format, similarity_function):
-    "Test export_to_file method."
-    spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
-    references = [spectrum_1, spectrum_2, spectrum_3]
-    queries = [spectrum_2, spectrum_3, spectrum_4]
-
-    scores = calculate_scores(references, queries, similarity_function)
-    scores.export_to_file(filename, file_format)
-
-    if file_format == "json":
-        scores_loaded = Scores.import_from_json(filename)
-    elif file_format == "pkl":
-        scores_loaded = Scores.import_from_pickle(filename)
-    else:
-        NotImplementedError(f"Unknown file format: {file_format}. Doublecheck the file_format fixture.")
-
-    assert scores == scores_loaded
-
-
 def test_comparing_scores():
     "Test comparing scores objects."
     spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -275,6 +275,6 @@ def test_export_to_file_import_from_file(filename):
     scores = calculate_scores(references, queries, CosineGreedy())
     scores.export_to_file(filename)
 
-    scores_loaded = Scores.import_from_file(filename)
+    scores_loaded = Scores.import_from_json(filename)
 
     assert scores == scores_loaded

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -302,12 +302,16 @@ def test_comparing_asymmetric_scores(similarity_function_a, similarity_function_
     assert scores_similarity_a != scores_similarity_b
 
 
-def test_comparing_scores_with_parametrized_similarity_funcs():
-    "Test comparing scores objects with parametrized similarity function."
+@pytest.mark.parametrize(
+    "similarity_function_a,similarity_function_b",
+    [(CosineGreedy(tolerance=0.5, mz_power=0.5), CosineGreedy(tolerance=0.1, mz_power=0.1)),
+     (IntersectMz(scaling=1.0), IntersectMz(scaling=2.0))])
+def test_comparing_scores_with_same_shape_different_scores_values(similarity_function_a, similarity_function_b):
+    "Test comparing scores objects with same similarity functions but different values of scores."
     spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
     spectrums = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
 
-    scores_parametrized = calculate_scores(spectrums, spectrums, CosineGreedy(tolerance=0.1, mz_power=0.5))
-    scores_parametrized_mirrored = calculate_scores(spectrums, spectrums, CosineGreedy(tolerance=0.5, mz_power=0.1))
+    scores_parametrized = calculate_scores(spectrums, spectrums, similarity_function_a)
+    scores_parametrized_mirrored = calculate_scores(spectrums, spectrums, similarity_function_b)
 
     assert scores_parametrized != scores_parametrized_mirrored

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-
 import numpy
 import pytest
 from matchms import Scores, calculate_scores

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -270,8 +270,8 @@ def test_scores_by_query_non_tuple_score():
     assert selected_scores == expected_result, "Expected different scores."
 
 
-def test_comparing_scores():
-    "Test comparing scores objects."
+def test_comparing_symmetric_scores():
+    "Test comparing symmetric scores objects."
     spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
     spectrums = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
 
@@ -282,12 +282,24 @@ def test_comparing_scores():
     assert scores_symmetric_cosine == scores_symmetric_cosine_copy
     assert scores_symmetric_cosine != scores_symmetric_intersect
 
+
+def test_comparing_asymmetric_scores():
+    "Test comparing asymmetric scores objects."
+    spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
+    spectrums = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
+
     scores_asymmetric_cosine = calculate_scores(spectrums[0:3], spectrums, CosineGreedy())
     scores_asymmetric_cosine_copy = calculate_scores(spectrums[0:3], spectrums, CosineGreedy())
     scores_asymmetric_cosine_mirrored = calculate_scores(spectrums, spectrums[0:3], CosineGreedy())
 
     assert scores_asymmetric_cosine == scores_asymmetric_cosine_copy
     assert scores_asymmetric_cosine != scores_asymmetric_cosine_mirrored
+
+
+def test_comparing_scores_with_parametrized_similarity_funcs():
+    "Test comparing scores objects with parametrized similarity function."
+    spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
+    spectrums = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
 
     scores_parametrized = calculate_scores(spectrums, spectrums, CosineGreedy(tolerance=0.1, mz_power=0.5))
     scores_parametrized_mirrored = calculate_scores(spectrums, spectrums, CosineGreedy(tolerance=0.5, mz_power=0.1))

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -2,8 +2,10 @@ import os
 import tempfile
 import numpy
 import pytest
+from importlib import reload
 import matchms.similarity
 from matchms import calculate_scores
+from matchms import metadata_utils
 from matchms.filtering import add_fingerprint
 from matchms.importing import scores_from_json, scores_from_pickle
 from .builder_Spectrum import SpectrumBuilder
@@ -54,7 +56,8 @@ def spectra(similarity_function):
 
     spectra = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
     if similarity_function.__class__.__name__ == "FingerprintSimilarity":
-        yield [add_fingerprint(x, nbits=256) for x in spectra]
+        reload(matchms.metadata_utils)
+        yield [add_fingerprint(spectrum, nbits=256) for spectrum in spectra]
     else:
         yield spectra
 

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -5,7 +5,7 @@ import pytest
 import matchms.similarity
 from matchms import calculate_scores
 from matchms.filtering import add_fingerprint
-from matchms.importing.load_scores import scores_from_json, scores_from_pickle
+from matchms.importing import scores_from_json, scores_from_pickle
 from .builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -95,7 +95,7 @@ def test_scores_write_read_symmetrical(filename, file_format, symmetrical_scores
     elif file_format == "pkl":
         scores = scores_from_pickle(filename)
     else:
-        raise ValueError(f"Unknown file format: {file_format}. Check 'file_format' fixture.")
+        raise ValueError(f"Unsupported file format: {file_format}. Check 'file_format' fixture.")
 
     assert symmetrical_scores == scores
 
@@ -109,6 +109,6 @@ def test_scores_write_read_asymmetrical(filename, file_format, asymmetrical_scor
     elif file_format == "pkl":
         scores = scores_from_pickle(filename)
     else:
-        raise ValueError(f"Unknown file format: {file_format}. Check 'file_format' fixture.")
+        raise ValueError(f"Unsupported file format: {file_format}. Check 'file_format' fixture.")
 
     assert asymmetrical_scores == scores

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -80,19 +80,29 @@ def asymmetrical_scores(similarity_function, spectra):
     yield scores
 
 
-def test_writing_scores_to_file(filename, file_format, symmetrical_scores):
+def test_writing_scores_to_json(symmetrical_scores):
     """Test if writing scores to file works."""
-    symmetrical_scores.export_to_file(filename, file_format=file_format)
-    assert os.path.isfile(filename)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "test_scores.json")
+        symmetrical_scores.to_json(filename)
+        assert os.path.isfile(filename)
+
+
+def test_writing_scores_to_pickle(symmetrical_scores):
+    """Test if writing scores to file works."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = os.path.join(tmpdir, "test_scores.pkl")
+        symmetrical_scores.to_pickle(filename)
+        assert os.path.isfile(filename)
 
 
 def test_scores_write_read_symmetrical(filename, file_format, symmetrical_scores):
     """Test if writing and reading symmetrical scores does not change the scores."""
-    symmetrical_scores.export_to_file(filename, file_format=file_format)
-
     if file_format == "json":
+        symmetrical_scores.to_json(filename)
         scores = scores_from_json(filename)
     elif file_format == "pkl":
+        symmetrical_scores.to_pickle(filename)
         scores = scores_from_pickle(filename)
     else:
         raise ValueError(f"Unsupported file format: {file_format}. Check 'file_format' fixture.")
@@ -102,11 +112,11 @@ def test_scores_write_read_symmetrical(filename, file_format, symmetrical_scores
 
 def test_scores_write_read_asymmetrical(filename, file_format, asymmetrical_scores):
     """Test if writing and reading symmetrical scores does not change the scores."""
-    asymmetrical_scores.export_to_file(filename, file_format=file_format)
-
     if file_format == "json":
+        asymmetrical_scores.to_json(filename)
         scores = scores_from_json(filename)
     elif file_format == "pkl":
+        asymmetrical_scores.to_pickle(filename)
         scores = scores_from_pickle(filename)
     else:
         raise ValueError(f"Unsupported file format: {file_format}. Check 'file_format' fixture.")

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -2,12 +2,11 @@ import os
 import tempfile
 import numpy
 import pytest
-
-from .builder_Spectrum import SpectrumBuilder
+import matchms.similarity
 from matchms import calculate_scores
 from matchms.filtering import add_fingerprint
 from matchms.importing.load_scores import scores_from_json, scores_from_pickle
-import matchms.similarity
+from .builder_Spectrum import SpectrumBuilder
 
 
 @pytest.fixture(params=["json", "pkl"])

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -1,10 +1,9 @@
 import os
 import tempfile
-from importlib import reload
 import numpy
 import pytest
 import matchms.similarity
-from matchms import calculate_scores, metadata_utils
+from matchms import calculate_scores
 from matchms.filtering import add_fingerprint
 from matchms.importing import scores_from_json, scores_from_pickle
 from .builder_Spectrum import SpectrumBuilder
@@ -55,7 +54,6 @@ def spectra(similarity_function):
 
     spectra = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
     if similarity_function.__class__.__name__ == "FingerprintSimilarity":
-        reload(metadata_utils)
         yield [add_fingerprint(spectrum, nbits=256) for spectrum in spectra]
     else:
         yield spectra

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -1,0 +1,57 @@
+import os
+import tempfile
+import pytest
+
+from .test_scores import spectra
+from matchms import calculate_scores
+from matchms.importing.load_scores import scores_from_json, scores_from_pickle
+import matchms.similarity
+
+
+@pytest.fixture(params=["json", "pkl"])
+def file_format(request):
+    yield request.param
+
+
+@pytest.fixture()
+def filename(file_format):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield os.path.join(tmpdir, f"test_scores.{file_format}")
+
+
+@pytest.fixture(params=matchms.similarity.__all__)
+def symmetrical_scores(request):
+    """Return symmetrical scores for each similarity metric that matchms.similarity module exposes."""
+    spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
+    queries = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
+    references = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
+
+    scores = calculate_scores(queries, references, similarity_function=request.param)
+    yield scores
+
+
+@pytest.fixture(params=matchms.similarity.__all__)
+def asymmetrical_scores(request):
+    """Return asymmetrical scores for each similarity metric that matchms.similarity module exposes."""
+    spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
+    queries = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
+    references = [spectrum_2, spectrum_3]
+
+    scores = calculate_scores(queries, references, similarity_function=request.param)
+    yield scores
+
+
+def test_writing_scores_to_file(filename, symmetrical_scores):
+    """Test if writing scores to file works."""
+    symmetrical_scores.export_to_json(filename)
+    assert os.path.isfile(filename)
+
+
+def test_scores_write_read_symmetrical(filename, symmetrical_scores):
+    """Test if writing and reading symmetrical scores does not change the scores."""
+    pass
+
+
+def test_scores_write_read_asymmetrical(filename, asymmetrical_scores):
+    """Test if writing and reading symmetrical scores does not change the scores."""
+    pass

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -1,9 +1,11 @@
 import os
 import tempfile
+import numpy
 import pytest
 
-from .test_scores import spectra
+from .builder_Spectrum import SpectrumBuilder
 from matchms import calculate_scores
+from matchms.filtering import add_fingerprint
 from matchms.importing.load_scores import scores_from_json, scores_from_pickle
 import matchms.similarity
 
@@ -13,45 +15,100 @@ def file_format(request):
     yield request.param
 
 
-@pytest.fixture()
+@pytest.fixture
 def filename(file_format):
     with tempfile.TemporaryDirectory() as tmpdir:
         yield os.path.join(tmpdir, f"test_scores.{file_format}")
 
 
 @pytest.fixture(params=matchms.similarity.__all__)
-def symmetrical_scores(request):
+def similarity_function(request):
+    kwargs = {}
+
+    if request.param == "MetadataMatch":
+        kwargs["field"] = "id"
+
+    yield matchms.similarity.get_similarity_function_by_name(request.param)(**kwargs)
+
+
+@pytest.fixture
+def spectra(similarity_function):
+    builder = SpectrumBuilder()
+    spectrum_1 = builder.with_mz(numpy.array([100, 150, 200.])) \
+        .with_intensities(numpy.array([0.7, 0.2, 0.1])) \
+        .with_metadata({'id': 'spectrum1', "precursor_mz": 210, "parent_mass": 210, "smiles": "CCC(C)C(C(=O)O)NC(=O)CCl"}) \
+        .build()
+    spectrum_2 = builder.with_mz(numpy.array([100, 140, 190.])) \
+        .with_intensities(numpy.array([0.4, 0.2, 0.1])) \
+        .with_metadata({'id': 'spectrum2', "precursor_mz": 200, "parent_mass": 200, "smiles": "CCC(C)C(C(=O)O)NC(=O)CCl"}) \
+        .build()
+    spectrum_3 = builder.with_mz(numpy.array([110, 140, 195.])) \
+        .with_intensities(
+        numpy.array([0.6, 0.2, 0.1])) \
+        .with_metadata({'id': 'spectrum3', "precursor_mz": 205, "parent_mass": 205, "smiles": "C(C(=O)O)(NC(=O)O)S"}) \
+        .build()
+    spectrum_4 = builder.with_mz(numpy.array([100, 150, 200.])) \
+        .with_intensities(
+        numpy.array([0.6, 0.1, 0.6])) \
+        .with_metadata({'id': 'spectrum4', "precursor_mz": 210, "parent_mass": 210, "smiles": "C(C(=O)O)(NC(=O)O)S"}) \
+        .build()
+
+    spectra = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
+    if similarity_function.__class__.__name__ == "FingerprintSimilarity":
+        yield [add_fingerprint(x, nbits=256) for x in spectra]
+    else:
+        yield spectra
+
+
+@pytest.fixture
+def symmetrical_scores(similarity_function, spectra):
     """Return symmetrical scores for each similarity metric that matchms.similarity module exposes."""
-    spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
-    queries = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
-    references = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
+    queries = spectra
+    references = spectra
 
-    scores = calculate_scores(queries, references, similarity_function=request.param)
+    scores = calculate_scores(queries, references, similarity_function=similarity_function)
     yield scores
 
 
-@pytest.fixture(params=matchms.similarity.__all__)
-def asymmetrical_scores(request):
+@pytest.fixture
+def asymmetrical_scores(similarity_function, spectra):
     """Return asymmetrical scores for each similarity metric that matchms.similarity module exposes."""
-    spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()
-    queries = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
-    references = [spectrum_2, spectrum_3]
+    queries = spectra
+    references = spectra[1:3]
 
-    scores = calculate_scores(queries, references, similarity_function=request.param)
+    scores = calculate_scores(queries, references, similarity_function=similarity_function)
     yield scores
 
 
-def test_writing_scores_to_file(filename, symmetrical_scores):
+def test_writing_scores_to_file(filename, file_format, symmetrical_scores):
     """Test if writing scores to file works."""
-    symmetrical_scores.export_to_json(filename)
+    symmetrical_scores.export_to_file(filename, file_format=file_format)
     assert os.path.isfile(filename)
 
 
-def test_scores_write_read_symmetrical(filename, symmetrical_scores):
+def test_scores_write_read_symmetrical(filename, file_format, symmetrical_scores):
     """Test if writing and reading symmetrical scores does not change the scores."""
-    pass
+    symmetrical_scores.export_to_file(filename, file_format=file_format)
+
+    if file_format == "json":
+        scores = scores_from_json(filename)
+    elif file_format == "pkl":
+        scores = scores_from_pickle(filename)
+    else:
+        raise ValueError(f"Unknown file format: {file_format}. Check 'file_format' fixture.")
+
+    assert symmetrical_scores == scores
 
 
-def test_scores_write_read_asymmetrical(filename, asymmetrical_scores):
+def test_scores_write_read_asymmetrical(filename, file_format, asymmetrical_scores):
     """Test if writing and reading symmetrical scores does not change the scores."""
-    pass
+    asymmetrical_scores.export_to_file(filename, file_format=file_format)
+
+    if file_format == "json":
+        scores = scores_from_json(filename)
+    elif file_format == "pkl":
+        scores = scores_from_pickle(filename)
+    else:
+        raise ValueError(f"Unknown file format: {file_format}. Check 'file_format' fixture.")
+
+    assert asymmetrical_scores == scores

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -1,11 +1,10 @@
 import os
 import tempfile
+from importlib import reload
 import numpy
 import pytest
-from importlib import reload
 import matchms.similarity
-from matchms import calculate_scores
-from matchms import metadata_utils
+from matchms import calculate_scores, metadata_utils
 from matchms.filtering import add_fingerprint
 from matchms.importing import scores_from_json, scores_from_pickle
 from .builder_Spectrum import SpectrumBuilder
@@ -56,7 +55,7 @@ def spectra(similarity_function):
 
     spectra = [spectrum_1, spectrum_2, spectrum_3, spectrum_4]
     if similarity_function.__class__.__name__ == "FingerprintSimilarity":
-        reload(matchms.metadata_utils)
+        reload(metadata_utils)
         yield [add_fingerprint(spectrum, nbits=256) for spectrum in spectra]
     else:
         yield spectra


### PR DESCRIPTION
* added functionality to import and export Scores objects to/from `json` and `pickle` files.
* added `ScoresBuilder` class to `Scores.py`. The class can be extended if more file formats are added. If anything changes in the way the data is stored, e.g., new scores implementation, the builder can be adjusted without breaking the `Scores` interface.
* defined equality operator `__eq__` for `Scores` class. The operator compares all `Scores` attributes; for `similarity_function` only the class name is compared. I think comparing the parameters of the similarity metrics is not vital in this case, as it seems unlikely someone would want to recalculate scores with the same function and parameters after loading scores.

### Usage example (**UPDATED 8.7.**):
```python
from matchms.importing import scores_from_json, scores_from_pickle
from matchms import calculate_scores, Scores
from matchms.similarity import CosineGreedy

scores = calculate_scores(references, queries, CosineGreedy())

# write a Scores object to disk as json or pickle file
scores.to_json(filename="scores.json")
scores.to_pickle(filename="scores.pkl")

# use readers from matchms.importing to read files
scores_json = scores_from_json("scores.json")
scores_pickle = scores_from_pickle("scores.pkl")

print(scores == scores_json == scores_pickle)
>>> True
```

Closes #351 

### **UPD 8.7.:**
* added test coverage for all metrics from `similarity` subpackage
* found and fixed a bug when deserializing scores with `FingerprintSimilarity`
* move `Scores` readers to `importing` subpackage
* splitted `Scores` writer into `to_json` and `to_pickle` methods

### **UPD 24.7.:**
* fixed unexpected behavior of tests caused by `test_missing_rdkit_module_error()` (1d43add & 110a173) (test-interdependency)
   - because `metadata_utils` module was never reloaded after `rdkit` dependency was set to `None`, all downstream tests that relied on rdkit-dependent methods from `metadata_utils` would fail.