### PR TITLE
switch from numpy to np

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ Contains three plot types: `plot_spectrum()` or `spectrum.plot()`, `plot_spectra
 
 ### Changed
 
-- Use `bool` instead of `numpy.bool` [#245](https://github.com/matchms/matchms/pull/245)
+- Use `bool` instead of `np.bool` [#245](https://github.com/matchms/matchms/pull/245)
 
 ## [0.9.1] - 2021-06-16
 

--- a/integration-tests/test_user_workflow.py
+++ b/integration-tests/test_user_workflow.py
@@ -1,5 +1,5 @@
 import os
-import numpy
+import numpy as np
 import pytest
 from matchms import calculate_scores
 from matchms.filtering import (add_parent_mass, default_filters,
@@ -52,16 +52,16 @@ def test_user_workflow():
 
     score_datatype = cosine_greedy.score_datatype
     expected_top10 = [
-        (references[48], queries[50], numpy.array([(0.9994783627790967, 25)], dtype=score_datatype)[0]),
-        (references[50], queries[48], numpy.array([(0.9994783627790967, 25)], dtype=score_datatype)[0]),
-        (references[46], queries[48], numpy.array([(0.9990141860269471, 27)], dtype=score_datatype)[0]),
-        (references[48], queries[46], numpy.array([(0.9990141860269471, 27)], dtype=score_datatype)[0]),
-        (references[46], queries[50], numpy.array([(0.9988793406908721, 22)], dtype=score_datatype)[0]),
-        (references[50], queries[46], numpy.array([(0.9988793406908721, 22)], dtype=score_datatype)[0]),
-        (references[57], queries[59], numpy.array([(0.9982171275552503, 46)], dtype=score_datatype)[0]),
-        (references[59], queries[57], numpy.array([(0.9982171275552503, 46)], dtype=score_datatype)[0]),
-        (references[73], queries[74], numpy.array([(0.9973823244169199, 23)], dtype=score_datatype)[0]),
-        (references[74], queries[73], numpy.array([(0.9973823244169199, 23)], dtype=score_datatype)[0]),
+        (references[48], queries[50], np.array([(0.9994783627790967, 25)], dtype=score_datatype)[0]),
+        (references[50], queries[48], np.array([(0.9994783627790967, 25)], dtype=score_datatype)[0]),
+        (references[46], queries[48], np.array([(0.9990141860269471, 27)], dtype=score_datatype)[0]),
+        (references[48], queries[46], np.array([(0.9990141860269471, 27)], dtype=score_datatype)[0]),
+        (references[46], queries[50], np.array([(0.9988793406908721, 22)], dtype=score_datatype)[0]),
+        (references[50], queries[46], np.array([(0.9988793406908721, 22)], dtype=score_datatype)[0]),
+        (references[57], queries[59], np.array([(0.9982171275552503, 46)], dtype=score_datatype)[0]),
+        (references[59], queries[57], np.array([(0.9982171275552503, 46)], dtype=score_datatype)[0]),
+        (references[73], queries[74], np.array([(0.9973823244169199, 23)], dtype=score_datatype)[0]),
+        (references[74], queries[73], np.array([(0.9973823244169199, 23)], dtype=score_datatype)[0]),
     ]
     assert [x[2][0] for x in actual_top10] == pytest.approx([x[2][0] for x in expected_top10], 1e-8), \
         "Expected different scores."

--- a/matchms/Fragments.py
+++ b/matchms/Fragments.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 
 
 class Fragments:
@@ -33,8 +33,8 @@ class Fragments:
 
     """
     def __init__(self, mz=None, intensities=None):
-        assert isinstance(mz, numpy.ndarray), "Input argument 'mz' should be a numpy.array."
-        assert isinstance(intensities, numpy.ndarray), "Input argument 'intensities' should be a numpy.array."
+        assert isinstance(mz, np.ndarray), "Input argument 'mz' should be a np.array."
+        assert isinstance(intensities, np.ndarray), "Input argument 'intensities' should be a np.array."
         assert mz.shape == intensities.shape, "Input arguments 'mz' and 'intensities' should be the same shape."
         assert mz.dtype == "float", "Input argument 'mz' should be an array of type float."
         assert intensities.dtype == "float", "Input argument 'intensities' should be an array of type float."
@@ -47,18 +47,18 @@ class Fragments:
     def __eq__(self, other):
         return \
             self.mz.shape == other.mz.shape and \
-            numpy.allclose(self.mz, other.mz) and \
+            np.allclose(self.mz, other.mz) and \
             self.intensities.shape == other.intensities.shape and \
-            numpy.allclose(self.intensities, other.intensities)
+            np.allclose(self.intensities, other.intensities)
 
     def __len__(self):
         return self._mz.size
 
     def __getitem__(self, item):
-        return numpy.asarray([self.mz[item], self.intensities[item]])
+        return np.asarray([self.mz[item], self.intensities[item]])
 
     def _is_sorted(self):
-        return numpy.all(self.mz[:-1] <= self.mz[1:])
+        return np.all(self.mz[:-1] <= self.mz[1:])
 
     def clone(self):
         return Fragments(self.mz, self.intensities)
@@ -77,4 +77,4 @@ class Fragments:
     def to_numpy(self):
         """getter method to return stacked numpy array of both peak mz and
         intensities"""
-        return numpy.vstack((self.mz, self.intensities)).T
+        return np.vstack((self.mz, self.intensities)).T

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import json
 import pickle
-import numpy
+import numpy as np
 import numpy.lib.recfunctions
 from deprecated.sphinx import deprecated
 from matchms.exporting.save_as_json import ScoresJSONEncoder
@@ -81,22 +81,22 @@ class Scores:
 
         self.n_rows = len(references)
         self.n_cols = len(queries)
-        self.references = numpy.asarray(references)
-        self.queries = numpy.asarray(queries)
+        self.references = np.asarray(references)
+        self.queries = np.asarray(queries)
         self.similarity_function = similarity_function
         self.is_symmetric = is_symmetric
-        self._scores = numpy.empty([self.n_rows, self.n_cols], dtype="object")
+        self._scores = np.empty([self.n_rows, self.n_cols], dtype="object")
         self._index = 0
 
     def __eq__(self, other):
         if isinstance(other, Scores):
-            return numpy.array_equal(self._scores, other._scores) and \
+            return np.array_equal(self._scores, other._scores) and \
                    self.similarity_function.__class__ == other.similarity_function.__class__ and \
                    self.is_symmetric == other.is_symmetric and \
                    self.n_rows == other.n_rows and \
                    self.n_cols == other.n_cols and \
-                   numpy.array_equal(self.references, other.references) and \
-                   numpy.array_equal(self.queries, other.queries)
+                   np.array_equal(self.references, other.references) and \
+                   np.array_equal(self.queries, other.queries)
         return NotImplemented
 
     def __iter__(self):
@@ -105,7 +105,7 @@ class Scores:
     def __next__(self):
         if self._index < self.scores.size:
             # pylint: disable=unbalanced-tuple-unpacking
-            r, c = numpy.unravel_index(self._index, self._scores.shape)
+            r, c = np.unravel_index(self._index, self._scores.shape)
             self._index += 1
             result = self._scores[r, c]
             if not isinstance(result, tuple):
@@ -119,11 +119,11 @@ class Scores:
 
     @staticmethod
     def _validate_input_arguments(references, queries, similarity_function):
-        assert isinstance(references, (list, tuple, numpy.ndarray)), \
-            "Expected input argument 'references' to be list or tuple or numpy.ndarray."
+        assert isinstance(references, (list, tuple, np.ndarray)), \
+            "Expected input argument 'references' to be list or tuple or np.ndarray."
 
-        assert isinstance(queries, (list, tuple, numpy.ndarray)), \
-            "Expected input argument 'queries' to be list or tuple or numpy.ndarray."
+        assert isinstance(queries, (list, tuple, np.ndarray)), \
+            "Expected input argument 'queries' to be list or tuple or np.ndarray."
 
         assert isinstance(similarity_function, BaseSimilarity), \
             "Expected input argument 'similarity_function' to have BaseSimilarity as super-class."
@@ -145,7 +145,7 @@ class Scores:
         return self
 
     def scores_by_reference(self, reference: ReferencesType,
-                            sort: bool = False) -> numpy.ndarray:
+                            sort: bool = False) -> np.ndarray:
         """Return all scores for the given reference spectrum.
 
         Parameters
@@ -157,14 +157,14 @@ class Scores:
             :meth:`~.BaseSimilarity.sort` function from the given similarity_function).
         """
         assert reference in self.references, "Given input not found in references."
-        selected_idx = int(numpy.where(self.references == reference)[0])
+        selected_idx = int(np.where(self.references == reference)[0])
         if sort:
             query_idx_sorted = self.similarity_function.sort(self._scores[selected_idx, :])
             return list(zip(self.queries[query_idx_sorted],
                             self._scores[selected_idx, query_idx_sorted].copy()))
         return list(zip(self.queries, self._scores[selected_idx, :].copy()))
 
-    def scores_by_query(self, query: QueriesType, sort: bool = False) -> numpy.ndarray:
+    def scores_by_query(self, query: QueriesType, sort: bool = False) -> np.ndarray:
         """Return all scores for the given query spectrum.
 
         For example
@@ -210,7 +210,7 @@ class Scores:
 
         """
         assert query in self.queries, "Given input not found in queries."
-        selected_idx = int(numpy.where(self.queries == query)[0])
+        selected_idx = int(np.where(self.queries == query)[0])
         if sort:
             references_idx_sorted = self.similarity_function.sort(self._scores[:, selected_idx])
             return list(zip(self.references[references_idx_sorted],
@@ -249,7 +249,7 @@ class Scores:
                 "scores": self.scores.tolist()}
 
     @property
-    def scores(self) -> numpy.ndarray:
+    def scores(self) -> np.ndarray:
         """Scores as numpy array
 
         For example
@@ -329,15 +329,15 @@ class ScoresBuilder:
 
         return self
 
-    def _restructure_scores(self, scores: dict) -> numpy.ndarray:
+    def _restructure_scores(self, scores: dict) -> np.ndarray:
         """
         Restructure scores from a nested list to a numpy array. If scores were stored as an array of tuples, restores
         their original form.
         """
-        scores = numpy.array(scores)
+        scores = np.array(scores)
 
         if len(scores.shape) > 2:
-            dt = numpy.dtype(self.similarity_function.score_datatype)
+            dt = np.dtype(self.similarity_function.score_datatype)
             return numpy.lib.recfunctions.unstructured_to_structured(scores, dtype=dt)
         return scores
 

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -13,13 +13,13 @@ def save_as_json(spectrums: List[Spectrum], filename: str):
 
     .. code-block:: python
 
-        import numpy
+        import numpy as np
         from matchms import Spectrum
         from matchms.exporting import save_as_json
 
         # Create dummy spectrum
-        spectrum = Spectrum(mz=numpy.array([100, 200, 300], dtype="float"),
-                            intensities=numpy.array([10, 10, 500], dtype="float"),
+        spectrum = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
+                            intensities=np.array([10, 10, 500], dtype="float"),
                             metadata={"charge": -1,
                                       "inchi": '"InChI=1S/C6H12"',
                                       "precursor_mz": 222.2})

--- a/matchms/exporting/save_as_mgf.py
+++ b/matchms/exporting/save_as_mgf.py
@@ -12,13 +12,13 @@ def save_as_mgf(spectrums: List[Spectrum], filename: str):
 
     .. code-block:: python
 
-        import numpy
+        import numpy as np
         from matchms import Spectrum
         from matchms.exporting import save_as_mgf
 
         # Create dummy spectrum
-        spectrum = Spectrum(mz=numpy.array([100, 200, 300], dtype="float"),
-                            intensities=numpy.array([10, 10, 500], dtype="float"),
+        spectrum = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
+                            intensities=np.array([10, 10, 500], dtype="float"),
                             metadata={"charge": -1,
                                       "inchi": '"InChI=1S/C6H12"',
                                       "precursor_mz": 222.2})

--- a/matchms/exporting/save_as_msp.py
+++ b/matchms/exporting/save_as_msp.py
@@ -22,13 +22,13 @@ def save_as_msp(spectrums: List[Spectrum], filename: str,
 
     .. code-block:: python
 
-        import numpy
+        import numpy as np
         from matchms import Spectrum
         from matchms.exporting import save_as_msp
 
         # Create dummy spectrum
-        spectrum = Spectrum(mz=numpy.array([100, 200, 300], dtype="float"),
-                            intensities=numpy.array([10, 10, 500], dtype="float"),
+        spectrum = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
+                            intensities=np.array([10, 10, 500], dtype="float"),
                             metadata={"charge": -1,
                                       "inchi": '"InChI=1S/C6H12"',
                                       "precursor_mz": 222.2})

--- a/matchms/filtering/add_fingerprint.py
+++ b/matchms/filtering/add_fingerprint.py
@@ -1,5 +1,5 @@
 import logging
-import numpy
+import numpy as np
 from ..metadata_utils import (derive_fingerprint_from_inchi,
                               derive_fingerprint_from_smiles)
 from ..typing import SpectrumType
@@ -34,7 +34,7 @@ def add_fingerprint(spectrum_in: SpectrumType, fingerprint_type: str = "daylight
     if spectrum.get("smiles", None):
         fingerprint = derive_fingerprint_from_smiles(spectrum.get("smiles"),
                                                      fingerprint_type, nbits)
-        if isinstance(fingerprint, numpy.ndarray) and fingerprint.sum() > 0:
+        if isinstance(fingerprint, np.ndarray) and fingerprint.sum() > 0:
             spectrum.set("fingerprint", fingerprint)
             return spectrum
 
@@ -42,7 +42,7 @@ def add_fingerprint(spectrum_in: SpectrumType, fingerprint_type: str = "daylight
     if spectrum.get("inchi", None):
         fingerprint = derive_fingerprint_from_inchi(spectrum.get("inchi"),
                                                     fingerprint_type, nbits)
-        if isinstance(fingerprint, numpy.ndarray) and fingerprint.sum() > 0:
+        if isinstance(fingerprint, np.ndarray) and fingerprint.sum() > 0:
             spectrum.set("fingerprint", fingerprint)
             return spectrum
 

--- a/matchms/filtering/add_losses.py
+++ b/matchms/filtering/add_losses.py
@@ -1,5 +1,5 @@
 import logging
-import numpy
+import numpy as np
 from ..Fragments import Fragments
 from ..typing import SpectrumType
 
@@ -32,7 +32,7 @@ def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -
         losses_mz = (precursor_mz - peaks_mz)[::-1]
         losses_intensities = peaks_intensities[::-1]
         # Add losses which are within given boundaries
-        mask = numpy.where((losses_mz >= loss_mz_from)
+        mask = np.where((losses_mz >= loss_mz_from)
                            & (losses_mz <= loss_mz_to))
         spectrum.losses = Fragments(mz=losses_mz[mask],
                                     intensities=losses_intensities[mask])

--- a/matchms/filtering/correct_charge.py
+++ b/matchms/filtering/correct_charge.py
@@ -1,5 +1,5 @@
 import logging
-import numpy
+import numpy as np
 from ..typing import SpectrumType
 
 
@@ -43,10 +43,10 @@ def correct_charge(spectrum_in: SpectrumType) -> SpectrumType:
         logger.info("Guessed charge to -1 based on negative ionmode")
 
     # Correct charge when in conflict with ionmode (trust ionmode more!)
-    if numpy.sign(charge) == 1 and ionmode == 'negative':
+    if np.sign(charge) == 1 and ionmode == 'negative':
         charge *= -1
         logger.warning("Changed sign of given charge to match negative ionmode")
-    elif numpy.sign(charge) == -1 and ionmode == 'positive':
+    elif np.sign(charge) == -1 and ionmode == 'positive':
         charge *= -1
         logger.warning("Changed sign of given charge to match positive ionmode")
 

--- a/matchms/filtering/load_adducts.py
+++ b/matchms/filtering/load_adducts.py
@@ -2,7 +2,7 @@ import csv
 import os
 from functools import lru_cache
 from typing import Dict
-import numpy
+import numpy as np
 
 
 @lru_cache(maxsize=4)
@@ -88,7 +88,7 @@ def _convert_and_fill_dict(adduct_dict: Dict[str, dict]) -> Dict[str, dict]:
         if is_float(correction_mass):
             correction_mass = float(correction_mass)
         else:
-            correction_mass = 1.007276 * numpy.sign(charge)
+            correction_mass = 1.007276 * np.sign(charge)
         values["correction_mass"] = correction_mass
 
         filled_dict[adduct] = values

--- a/matchms/filtering/normalize_intensities.py
+++ b/matchms/filtering/normalize_intensities.py
@@ -1,5 +1,5 @@
 import logging
-import numpy
+import numpy as np
 from matchms.typing import SpectrumType
 from ..Fragments import Fragments
 
@@ -18,7 +18,7 @@ def normalize_intensities(spectrum_in: SpectrumType) -> SpectrumType:
     if len(spectrum.peaks) == 0:
         return spectrum
 
-    max_intensity = numpy.max(spectrum.peaks.intensities)
+    max_intensity = np.max(spectrum.peaks.intensities)
 
     if max_intensity <= 0:
         logger.warning("Spectrum with all peak intensities <= 0 was set to None.")

--- a/matchms/filtering/reduce_to_number_of_peaks.py
+++ b/matchms/filtering/reduce_to_number_of_peaks.py
@@ -1,7 +1,7 @@
 import logging
 from math import ceil
 from typing import Optional
-import numpy
+import numpy as np
 from ..Fragments import Fragments
 from ..typing import SpectrumType
 
@@ -9,7 +9,7 @@ from ..typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 1, n_max: int = numpy.inf,
+def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 1, n_max: int = np.inf,
                               ratio_desired: Optional[float] = None) -> SpectrumType:
     """Lowest intensity peaks will be removed when it has more peaks than desired.
 

--- a/matchms/filtering/remove_peaks_around_precursor_mz.py
+++ b/matchms/filtering/remove_peaks_around_precursor_mz.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from ..Fragments import Fragments
 from ..typing import SpectrumType
 
@@ -28,7 +28,7 @@ def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: fl
     assert mz_tolerance >= 0, "mz_tolerance must be a positive scalar."
 
     mzs, intensities = spectrum.peaks.mz, spectrum.peaks.intensities
-    peaks_to_remove = ((numpy.abs(precursor_mz-mzs) <= mz_tolerance) & (mzs != precursor_mz))
+    peaks_to_remove = ((np.abs(precursor_mz-mzs) <= mz_tolerance) & (mzs != precursor_mz))
     new_mzs, new_intensities = mzs[~peaks_to_remove], intensities[~peaks_to_remove]
     spectrum.peaks = Fragments(mz=new_mzs, intensities=new_intensities)
 

--- a/matchms/filtering/remove_peaks_outside_top_k.py
+++ b/matchms/filtering/remove_peaks_outside_top_k.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from ..Fragments import Fragments
 from ..typing import SpectrumType
 
@@ -34,7 +34,7 @@ def remove_peaks_outside_top_k(spectrum_in: SpectrumType, k: int = 6,
     for i in indices:
 
         compare = abs(mzs[i]-k_ordered_mzs) <= mz_window
-        if numpy.any(compare):
+        if np.any(compare):
             keep_idx.append(i)
 
     keep_idx.sort()

--- a/matchms/filtering/select_by_intensity.py
+++ b/matchms/filtering/select_by_intensity.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from ..Fragments import Fragments
 from ..typing import SpectrumType
 
@@ -23,7 +23,7 @@ def select_by_intensity(spectrum_in: SpectrumType, intensity_from: float = 10.0,
 
     assert intensity_from <= intensity_to, "'intensity_from' should be smaller than or equal to 'intensity_to'."
 
-    condition = numpy.logical_and(intensity_from <= spectrum.peaks.intensities,
+    condition = np.logical_and(intensity_from <= spectrum.peaks.intensities,
                                   spectrum.peaks.intensities <= intensity_to)
 
     spectrum.peaks = Fragments(mz=spectrum.peaks.mz[condition],

--- a/matchms/filtering/select_by_mz.py
+++ b/matchms/filtering/select_by_mz.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from ..Fragments import Fragments
 from ..typing import SpectrumType
 
@@ -21,7 +21,7 @@ def select_by_mz(spectrum_in: SpectrumType, mz_from: float = 0.0,
 
     assert mz_from <= mz_to, "'mz_from' should be smaller than or equal to 'mz_to'."
 
-    condition = numpy.logical_and(mz_from <= spectrum.peaks.mz, spectrum.peaks.mz <= mz_to)
+    condition = np.logical_and(mz_from <= spectrum.peaks.mz, spectrum.peaks.mz <= mz_to)
 
     spectrum.peaks = Fragments(mz=spectrum.peaks.mz[condition],
                                intensities=spectrum.peaks.intensities[condition])

--- a/matchms/filtering/select_by_relative_intensity.py
+++ b/matchms/filtering/select_by_relative_intensity.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from ..Fragments import Fragments
 from ..typing import SpectrumType
 
@@ -25,9 +25,9 @@ def select_by_relative_intensity(spectrum_in: SpectrumType, intensity_from: floa
     assert intensity_from <= intensity_to, "'intensity_from' should be smaller than or equal to 'intensity_to'."
 
     if len(spectrum.peaks) > 0:
-        scale_factor = numpy.max(spectrum.peaks.intensities)
+        scale_factor = np.max(spectrum.peaks.intensities)
         normalized_intensities = spectrum.peaks.intensities / scale_factor
-        condition = numpy.logical_and(intensity_from <= normalized_intensities, normalized_intensities <= intensity_to)
+        condition = np.logical_and(intensity_from <= normalized_intensities, normalized_intensities <= intensity_to)
         spectrum.peaks = Fragments(mz=spectrum.peaks.mz[condition],
                                    intensities=spectrum.peaks.intensities[condition])
 

--- a/matchms/importing/load_from_json.py
+++ b/matchms/importing/load_from_json.py
@@ -2,7 +2,7 @@ import ast
 import json
 import logging
 from typing import List, Union
-import numpy
+import numpy as np
 from ..Spectrum import Spectrum
 
 
@@ -98,12 +98,12 @@ def dict2spectrum(spectrum_dict: dict,
                      for key in spectrum_dict if key not in not_metadata_fields}
     peaks_list = get_peaks_list(spectrum_dict, "peaks_json")
     if len(peaks_list) > 0 and metadata_dict:
-        mz = numpy.array(peaks_list)[:, 0]
-        intensities = numpy.array(peaks_list)[:, 1]
+        mz = np.array(peaks_list)[:, 0]
+        intensities = np.array(peaks_list)[:, 1]
 
         # Sort by mz (if not sorted already)
-        if not numpy.all(mz[:-1] <= mz[1:]):
-            idx_sorted = numpy.argsort(mz)
+        if not np.all(mz[:-1] <= mz[1:]):
+            idx_sorted = np.argsort(mz)
             mz = mz[idx_sorted]
             intensities = intensities[idx_sorted]
         return Spectrum(mz=mz,

--- a/matchms/importing/load_from_mgf.py
+++ b/matchms/importing/load_from_mgf.py
@@ -1,5 +1,5 @@
 from typing import Generator, TextIO, Union
-import numpy
+import numpy as np
 from pyteomics.mgf import MGF
 from ..Spectrum import Spectrum
 
@@ -41,8 +41,8 @@ def load_from_mgf(source: Union[str, TextIO],
         intensities = pyteomics_spectrum["intensity array"]
 
         # Sort by mz (if not sorted already)
-        if not numpy.all(mz[:-1] <= mz[1:]):
-            idx_sorted = numpy.argsort(mz)
+        if not np.all(mz[:-1] <= mz[1:]):
+            idx_sorted = np.argsort(mz)
             mz = mz[idx_sorted]
             intensities = intensities[idx_sorted]
 

--- a/matchms/importing/load_from_msp.py
+++ b/matchms/importing/load_from_msp.py
@@ -1,6 +1,6 @@
 import re
 from typing import Generator, Iterator, Tuple
-import numpy
+import numpy as np
 from ..Spectrum import Spectrum
 
 
@@ -44,8 +44,8 @@ def load_from_msp(filename: str,
             metadata["peak_comments"] = peak_comments
 
         # Sort by mz (if not sorted already)
-        if not numpy.all(mz[:-1] <= mz[1:]):
-            idx_sorted = numpy.argsort(mz)
+        if not np.all(mz[:-1] <= mz[1:]):
+            idx_sorted = np.argsort(mz)
             mz = mz[idx_sorted]
             intensities = intensities[idx_sorted]
 
@@ -95,8 +95,8 @@ def parse_msp_file(filename: str) -> Generator[dict, None, None]:
                     peakscount = 0
                     yield {
                         'params': (params),
-                        'm/z array': numpy.array(masses),
-                        'intensity array': numpy.array(intensities),
+                        'm/z array': np.array(masses),
+                        'intensity array': np.array(intensities),
                         'peak comments': peak_comments
                     }
 

--- a/matchms/importing/load_from_mzml.py
+++ b/matchms/importing/load_from_mzml.py
@@ -1,5 +1,5 @@
 from typing import Generator
-import numpy
+import numpy as np
 from pyteomics import mzml
 from matchms.importing.parsing_utils import parse_mzml_mzxml_metadata
 from matchms.Spectrum import Spectrum
@@ -35,13 +35,13 @@ def load_from_mzml(filename: str, ms_level: int = 2,
     for pyteomics_spectrum in mzml.read(filename, dtype=dict):
         if "ms level" in pyteomics_spectrum and pyteomics_spectrum["ms level"] == ms_level:
             metadata = parse_mzml_mzxml_metadata(pyteomics_spectrum)
-            mz = numpy.asarray(pyteomics_spectrum["m/z array"], dtype="float")
-            intensities = numpy.asarray(pyteomics_spectrum["intensity array"], dtype="float")
+            mz = np.asarray(pyteomics_spectrum["m/z array"], dtype="float")
+            intensities = np.asarray(pyteomics_spectrum["intensity array"], dtype="float")
 
             if mz.shape[0] > 0:
                 # Sort by mz (if not sorted already)
-                if not numpy.all(mz[:-1] <= mz[1:]):
-                    idx_sorted = numpy.argsort(mz)
+                if not np.all(mz[:-1] <= mz[1:]):
+                    idx_sorted = np.argsort(mz)
                     mz = mz[idx_sorted]
                     intensities = intensities[idx_sorted]
 

--- a/matchms/importing/load_from_mzxml.py
+++ b/matchms/importing/load_from_mzxml.py
@@ -1,5 +1,5 @@
 from typing import Generator
-import numpy
+import numpy as np
 from pyteomics import mzxml
 from matchms.importing.parsing_utils import parse_mzml_mzxml_metadata
 from matchms.Spectrum import Spectrum
@@ -36,13 +36,13 @@ def load_from_mzxml(filename: str, ms_level: int = 2,
         if ("ms level" in pyteomics_spectrum and pyteomics_spectrum["ms level"] == ms_level
                 or "msLevel" in pyteomics_spectrum and pyteomics_spectrum["msLevel"] == ms_level):
             metadata = parse_mzml_mzxml_metadata(pyteomics_spectrum)
-            mz = numpy.asarray(pyteomics_spectrum["m/z array"], dtype="float")
-            intensities = numpy.asarray(pyteomics_spectrum["intensity array"], dtype="float")
+            mz = np.asarray(pyteomics_spectrum["m/z array"], dtype="float")
+            intensities = np.asarray(pyteomics_spectrum["intensity array"], dtype="float")
 
             if mz.shape[0] > 0:
                 # Sort by mz (if not sorted already)
-                if not numpy.all(mz[:-1] <= mz[1:]):
-                    idx_sorted = numpy.argsort(mz)
+                if not np.all(mz[:-1] <= mz[1:]):
+                    idx_sorted = np.argsort(mz)
                     mz = mz[idx_sorted]
                     intensities = intensities[idx_sorted]
 

--- a/matchms/metadata_utils.py
+++ b/matchms/metadata_utils.py
@@ -1,6 +1,6 @@
 import re
 from typing import Optional
-import numpy
+import numpy as np
 from matchms.filtering.load_adducts import (load_adducts_dict,
                                             load_known_adduct_conversions)
 
@@ -150,7 +150,7 @@ def is_valid_inchikey(inchikey: str) -> bool:
     return False
 
 
-def derive_fingerprint_from_smiles(smiles: str, fingerprint_type: str, nbits: int) -> numpy.ndarray:
+def derive_fingerprint_from_smiles(smiles: str, fingerprint_type: str, nbits: int) -> np.ndarray:
     """Calculate molecule fingerprint based on given smiles or inchi (using rdkit).
     Requires conda package *rdkit* to be installed.
 
@@ -178,7 +178,7 @@ def derive_fingerprint_from_smiles(smiles: str, fingerprint_type: str, nbits: in
     return mol_to_fingerprint(mol, fingerprint_type, nbits)
 
 
-def derive_fingerprint_from_inchi(inchi: str, fingerprint_type: str, nbits: int) -> numpy.ndarray:
+def derive_fingerprint_from_inchi(inchi: str, fingerprint_type: str, nbits: int) -> np.ndarray:
     """Calculate molecule fingerprint based on given inchi (using rdkit).
     Requires conda package *rdkit* to be installed.
 
@@ -194,7 +194,7 @@ def derive_fingerprint_from_inchi(inchi: str, fingerprint_type: str, nbits: int)
 
     Returns
     -------
-    fingerprint: numpy.array
+    fingerprint: np.array
         Molecular fingerprint.
     """
     if not _has_rdkit:
@@ -206,7 +206,7 @@ def derive_fingerprint_from_inchi(inchi: str, fingerprint_type: str, nbits: int)
     return mol_to_fingerprint(mol, fingerprint_type, nbits)
 
 
-def mol_to_fingerprint(mol: Chem.rdchem.Mol, fingerprint_type: str, nbits: int) -> numpy.ndarray:
+def mol_to_fingerprint(mol: Chem.rdchem.Mol, fingerprint_type: str, nbits: int) -> np.ndarray:
     """Convert rdkit mol (molecule) to molecular fingerprint.
     Requires conda package *rdkit* to be installed.
 
@@ -240,7 +240,7 @@ def mol_to_fingerprint(mol: Chem.rdchem.Mol, fingerprint_type: str, nbits: int) 
         fp = AllChem.GetMorganFingerprintAsBitVect(mol, 3, nBits=nbits)
 
     if fp:
-        return numpy.array(fp)
+        return np.array(fp)
     return None
 
 

--- a/matchms/networking/SimilarityNetwork.py
+++ b/matchms/networking/SimilarityNetwork.py
@@ -1,7 +1,7 @@
 import json
 from typing import Optional
 import networkx as nx
-import numpy
+import numpy as np
 from matchms import Scores
 from .networking_functions import get_top_hits
 
@@ -93,7 +93,7 @@ class SimilarityNetwork:
         """NetworkX graph. Set after calling create_network()"""
 
     @staticmethod
-    def _select_edge_score(similars_scores: dict, scores_type: numpy.dtype):
+    def _select_edge_score(similars_scores: dict, scores_type: np.dtype):
         """Chose one value if score contains multiple values (e.g. "score" and "matches")"""
         if len(scores_type) > 1 and "score" in scores_type.names:
             return {key: value["score"] for key, value in similars_scores.items()}
@@ -114,7 +114,7 @@ class SimilarityNetwork:
             generating a network.
         """
         assert self.top_n >= self.max_links, "top_n must be >= max_links"
-        assert numpy.all(scores.queries == scores.references), \
+        assert np.all(scores.queries == scores.references), \
             "Expected symmetric scores object with queries==references"
         unique_ids = list({s.get(self.identifier_key) for s in scores.queries})
 
@@ -133,9 +133,9 @@ class SimilarityNetwork:
         for i, spec in enumerate(scores.queries):
             query_id = spec.get(self.identifier_key)
 
-            ref_candidates = numpy.array([scores.references[x].get(self.identifier_key)
+            ref_candidates = np.array([scores.references[x].get(self.identifier_key)
                                           for x in similars_idx[query_id]])
-            idx = numpy.where((similars_scores[query_id] >= self.score_cutoff) &
+            idx = np.where((similars_scores[query_id] >= self.score_cutoff) &
                               (ref_candidates != query_id))[0][:self.max_links]
             if self.link_method == "single":
                 new_edges = [(query_id, str(ref_candidates[x]),

--- a/matchms/similarity/BaseSimilarity.py
+++ b/matchms/similarity/BaseSimilarity.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from typing import List
-import numpy
+import numpy as np
 from matchms.typing import SpectrumType
 
 
@@ -18,7 +18,7 @@ class BaseSimilarity:
     # Set key characteristics as class attributes
     is_commutative = True
     # Set output data type, e.g. "float" or [("score", "float"), ("matches", "int")]
-    score_datatype = numpy.float64
+    score_datatype = np.float64
 
     @abstractmethod
     def pair(self, reference: SpectrumType, query: SpectrumType) -> float:
@@ -33,13 +33,13 @@ class BaseSimilarity:
 
         Returns
             score as numpy array (using self.score_datatype). For instance returning
-            numpy.asarray(score, dtype=self.score_datatype)
+            np.asarray(score, dtype=self.score_datatype)
         """
         raise NotImplementedError
 
     def matrix(self, references: List[SpectrumType], queries: List[SpectrumType],
-               is_symmetric: bool = False) -> numpy.ndarray:
-        """Optional: Provide optimized method to calculate an numpy.array of similarity scores
+               is_symmetric: bool = False) -> np.ndarray:
+        """Optional: Provide optimized method to calculate an np.array of similarity scores
         for given reference and query spectrums. If no method is added here, the following naive
         implementation (i.e. a double for-loop) is used.
 
@@ -56,7 +56,7 @@ class BaseSimilarity:
         """
         n_rows = len(references)
         n_cols = len(queries)
-        scores = numpy.empty([n_rows, n_cols], dtype=self.score_datatype)
+        scores = np.empty([n_rows, n_cols], dtype=self.score_datatype)
         for i_ref, reference in enumerate(references[:n_rows]):
             if is_symmetric and self.is_commutative:
                 for i_query, query in enumerate(queries[i_ref:n_cols], start=i_ref):
@@ -67,7 +67,7 @@ class BaseSimilarity:
                     scores[i_ref][i_query] = self.pair(reference, query)
         return scores
 
-    def sort(self, scores: numpy.ndarray):
+    def sort(self, scores: np.ndarray):
         """Return array of indexes for sorted list of scores.
         This method can be adapted for different styles of scores.
 

--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-import numpy
+import numpy as np
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
 from .spectrum_similarity_functions import (collect_peak_pairs,
@@ -49,7 +49,7 @@ class CosineGreedy(BaseSimilarity):
     # Set key characteristics as class attributes
     is_commutative = True
     # Set output data type, e.g. ("score", "float") or [("score", "float"), ("matches", "int")]
-    score_datatype = [("score", numpy.float64), ("matches", "int")]
+    score_datatype = [("score", np.float64), ("matches", "int")]
 
     def __init__(self, tolerance: float = 0.1, mz_power: float = 0.0,
                  intensity_power: float = 1.0):
@@ -90,14 +90,14 @@ class CosineGreedy(BaseSimilarity):
                                                 intensity_power=self.intensity_power)
             if matching_pairs is None:
                 return None
-            matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
+            matching_pairs = matching_pairs[np.argsort(matching_pairs[:, 2])[::-1], :]
             return matching_pairs
 
         spec1 = reference.peaks.to_numpy
         spec2 = query.peaks.to_numpy
         matching_pairs = get_matching_pairs()
         if matching_pairs is None:
-            return numpy.asarray((float(0), 0), dtype=self.score_datatype)
+            return np.asarray((float(0), 0), dtype=self.score_datatype)
         score = score_best_matches(matching_pairs, spec1, spec2,
                                    self.mz_power, self.intensity_power)
-        return numpy.asarray(score, dtype=self.score_datatype)
+        return np.asarray(score, dtype=self.score_datatype)

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-import numpy
+import numpy as np
 from scipy.optimize import linear_sum_assignment
 from matchms.similarity.spectrum_similarity_functions import collect_peak_pairs
 from matchms.typing import SpectrumType
@@ -21,7 +21,7 @@ class CosineHungarian(BaseSimilarity):
     # Set key characteristics as class attributes
     is_commutative = True
     # Set output data type, e.g. ("score", "float") or [("score", "float"), ("matches", "int")]
-    score_datatype = [("score", numpy.float64), ("matches", "int")]
+    score_datatype = [("score", np.float64), ("matches", "int")]
 
     def __init__(self, tolerance: float = 0.1, mz_power: float = 0.0,
                  intensity_power: float = 1.0):
@@ -62,7 +62,7 @@ class CosineHungarian(BaseSimilarity):
                                                 intensity_power=self.intensity_power)
             if matching_pairs is None:
                 return None
-            matching_pairs = matching_pairs[numpy.argsort(matching_pairs[:, 2])[::-1], :]
+            matching_pairs = matching_pairs[np.argsort(matching_pairs[:, 2])[::-1], :]
             return matching_pairs
 
         def get_matching_pairs_matrix():
@@ -81,7 +81,7 @@ class CosineHungarian(BaseSimilarity):
             paired_peaks1 = list(set(matching_pairs[:, 0]))
             paired_peaks2 = list(set(matching_pairs[:, 1]))
             matrix_size = (len(paired_peaks1), len(paired_peaks2))
-            matching_pairs_matrix = numpy.ones(matrix_size)
+            matching_pairs_matrix = np.ones(matrix_size)
             for i in range(matching_pairs.shape[0]):
                 matching_pairs_matrix[paired_peaks1.index(matching_pairs[i, 0]),
                                       paired_peaks2.index(matching_pairs[i, 1])] = 1 - matching_pairs[i, 2]
@@ -97,15 +97,15 @@ class CosineHungarian(BaseSimilarity):
         def calc_score():
             """Calculate cosine similarity score."""
             if matching_pairs_matrix is None:
-                return numpy.asarray((0.0, 0), dtype=self.score_datatype)
+                return np.asarray((0.0, 0), dtype=self.score_datatype)
             score, used_matches = solve_hungarian()
             # Normalize score:
-            spec1_power = numpy.power(spec1[:, 0], self.mz_power) \
-                * numpy.power(spec1[:, 1], self.intensity_power)
-            spec2_power = numpy.power(spec2[:, 0], self.mz_power) \
-                * numpy.power(spec2[:, 1], self.intensity_power)
-            score = score/(numpy.sqrt(numpy.sum(spec1_power**2)) * numpy.sqrt(numpy.sum(spec2_power**2)))
-            return numpy.asarray((score, len(used_matches)), dtype=self.score_datatype)
+            spec1_power = np.power(spec1[:, 0], self.mz_power) \
+                * np.power(spec1[:, 1], self.intensity_power)
+            spec2_power = np.power(spec2[:, 0], self.mz_power) \
+                * np.power(spec2[:, 1], self.intensity_power)
+            score = score/(np.sqrt(np.sum(spec1_power**2)) * np.sqrt(np.sum(spec2_power**2)))
+            return np.asarray((score, len(used_matches)), dtype=self.score_datatype)
 
         spec1 = reference.peaks.to_numpy
         spec2 = query.peaks.to_numpy

--- a/matchms/similarity/FingerprintSimilarity.py
+++ b/matchms/similarity/FingerprintSimilarity.py
@@ -1,5 +1,5 @@
 from typing import List, Union
-import numpy
+import numpy as np
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
 from .vector_similarity_functions import (cosine_similarity,
@@ -59,7 +59,7 @@ class FingerprintSimilarity(BaseSimilarity):
     # Set key characteristics as class attributes
     is_commutative = True
     # Set output data type, e.g.  "float" or [("score", "float"), ("matches", "int")]
-    score_datatype = numpy.float64
+    score_datatype = np.float64
 
     def __init__(self, similarity_measure: str = "jaccard",
                  set_empty_scores: Union[float, int, str] = "nan"):
@@ -73,7 +73,7 @@ class FingerprintSimilarity(BaseSimilarity):
         set_empty_scores:
             Define what should be given instead of a similarity score in cases
             where fingprints are missing. The default is "nan", which will return
-            numpy.nan's in such cases.
+            np.nan's in such cases.
         """
         self.set_empty_scores = set_empty_scores
         assert similarity_measure in ["cosine", "dice", "jaccard"], "Unknown similarity measure."
@@ -99,12 +99,12 @@ class FingerprintSimilarity(BaseSimilarity):
 
         if self.similarity_measure == "cosine":
             score = cosine_similarity(fingerprint_ref, fingerprint_query)
-            return numpy.asarray(score, dtype=self.score_datatype)
+            return np.asarray(score, dtype=self.score_datatype)
 
         raise NotImplementedError
 
     def matrix(self, references: List[SpectrumType], queries: List[SpectrumType],
-               is_symmetric: bool = False) -> numpy.array:
+               is_symmetric: bool = False) -> np.array:
         """Calculate matrix of fingerprint based similarity scores.
 
         Parameters
@@ -126,13 +126,13 @@ class FingerprintSimilarity(BaseSimilarity):
                 if fp is not None:
                     idx_fingerprints.append(index)
                     fingerprints.append(fp)
-            return numpy.asarray(fingerprints), numpy.asarray(idx_fingerprints)
+            return np.asarray(fingerprints), np.asarray(idx_fingerprints)
 
         def create_full_matrix():
             """Create matrix for all similarities."""
-            similarity_matrix = numpy.zeros((len(references), len(queries)))
+            similarity_matrix = np.zeros((len(references), len(queries)))
             if self.set_empty_scores == "nan":
-                similarity_matrix[:] = numpy.nan
+                similarity_matrix[:] = np.nan
             elif isinstance(self.set_empty_scores, (float, int)):
                 similarity_matrix[:] = self.set_empty_scores
             return similarity_matrix
@@ -145,15 +145,15 @@ class FingerprintSimilarity(BaseSimilarity):
         # Calculate similarity score matrix following specified method
         similarity_matrix = create_full_matrix()
         if self.similarity_measure == "jaccard":
-            similarity_matrix[numpy.ix_(idx_fingerprints1,
+            similarity_matrix[np.ix_(idx_fingerprints1,
                                         idx_fingerprints2)] = jaccard_similarity_matrix(fingerprints1,
                                                                                         fingerprints2)
         elif self.similarity_measure == "dice":
-            similarity_matrix[numpy.ix_(idx_fingerprints1,
+            similarity_matrix[np.ix_(idx_fingerprints1,
                                         idx_fingerprints2)] = dice_similarity_matrix(fingerprints1,
                                                                                      fingerprints2)
         elif self.similarity_measure == "cosine":
-            similarity_matrix[numpy.ix_(idx_fingerprints1,
+            similarity_matrix[np.ix_(idx_fingerprints1,
                                         idx_fingerprints2)] = cosine_similarity_matrix(fingerprints1,
                                                                                        fingerprints2)
         return similarity_matrix.astype(self.score_datatype)

--- a/matchms/similarity/IntersectMz.py
+++ b/matchms/similarity/IntersectMz.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
 
@@ -57,4 +57,4 @@ class IntersectMz(BaseSimilarity):
         if len(unioned) == 0:
             return 0
 
-        return numpy.float64(self.scaling * len(intersected) / len(unioned))
+        return np.float64(self.scaling * len(intersected) / len(unioned))

--- a/matchms/similarity/ParentMassMatch.py
+++ b/matchms/similarity/ParentMassMatch.py
@@ -1,6 +1,6 @@
 from typing import List
 import numba
-import numpy
+import numpy as np
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
 
@@ -78,10 +78,10 @@ class ParentMassMatch(BaseSimilarity):
         assert parentmass_ref is not None and parentmass_query is not None, "Missing parent mass."
 
         score = abs(parentmass_ref - parentmass_query) <= self.tolerance
-        return numpy.asarray(score, dtype=self.score_datatype)
+        return np.asarray(score, dtype=self.score_datatype)
 
     def matrix(self, references: List[SpectrumType], queries: List[SpectrumType],
-               is_symmetric: bool = False) -> numpy.ndarray:
+               is_symmetric: bool = False) -> np.ndarray:
         """Compare parent masses between all references and queries.
 
         Parameters
@@ -102,7 +102,7 @@ class ParentMassMatch(BaseSimilarity):
                 parentmass = spectrum.get("parent_mass")
                 assert parentmass is not None, "Missing parent mass."
                 parentmasses.append(parentmass)
-            return numpy.asarray(parentmasses)
+            return np.asarray(parentmasses)
 
         parentmasses_ref = collect_parentmasses(references)
         parentmasses_query = collect_parentmasses(queries)
@@ -115,7 +115,7 @@ class ParentMassMatch(BaseSimilarity):
 
 @numba.njit
 def parentmass_scores(parentmasses_ref, parentmasses_query, tolerance):
-    scores = numpy.zeros((len(parentmasses_ref), len(parentmasses_query)))
+    scores = np.zeros((len(parentmasses_ref), len(parentmasses_query)))
     for i, parentmass_ref in enumerate(parentmasses_ref):
         for j, parentmass_query in enumerate(parentmasses_query):
             scores[i, j] = (abs(parentmass_ref - parentmass_query) <= tolerance)
@@ -124,7 +124,7 @@ def parentmass_scores(parentmasses_ref, parentmasses_query, tolerance):
 
 @numba.njit
 def parentmass_scores_symmetric(parentmasses_ref, parentmasses_query, tolerance):
-    scores = numpy.zeros((len(parentmasses_ref), len(parentmasses_query)))
+    scores = np.zeros((len(parentmasses_ref), len(parentmasses_query)))
     for i, parentmass_ref in enumerate(parentmasses_ref):
         for j in range(i, len(parentmasses_query)):
             scores[i, j] = (abs(parentmass_ref - parentmasses_query[j]) <= tolerance)

--- a/matchms/similarity/PrecursorMzMatch.py
+++ b/matchms/similarity/PrecursorMzMatch.py
@@ -1,6 +1,6 @@
 from typing import List
 import numba
-import numpy
+import numpy as np
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
 
@@ -88,10 +88,10 @@ class PrecursorMzMatch(BaseSimilarity):
 
         mean_mz = (precursormz_ref + precursormz_query) / 2
         score = abs(precursormz_ref - precursormz_query)/mean_mz <= self.tolerance
-        return numpy.asarray(score, dtype=self.score_datatype)
+        return np.asarray(score, dtype=self.score_datatype)
 
     def matrix(self, references: List[SpectrumType], queries: List[SpectrumType],
-               is_symmetric: bool = False) -> numpy.ndarray:
+               is_symmetric: bool = False) -> np.ndarray:
         """Compare parent masses between all references and queries.
 
         Parameters
@@ -112,7 +112,7 @@ class PrecursorMzMatch(BaseSimilarity):
                 precursormz = spectrum.get("precursor_mz")
                 assert precursormz is not None, "Missing precursor m/z."
                 precursors.append(precursormz)
-            return numpy.asarray(precursors)
+            return np.asarray(precursors)
 
         precursors_ref = collect_precursormz(references)
         precursors_query = collect_precursormz(queries)
@@ -136,7 +136,7 @@ class PrecursorMzMatch(BaseSimilarity):
 
 @numba.njit
 def precursormz_scores(precursors_ref, precursors_query, tolerance):
-    scores = numpy.zeros((len(precursors_ref), len(precursors_query)))
+    scores = np.zeros((len(precursors_ref), len(precursors_query)))
     for i, precursormz_ref in enumerate(precursors_ref):
         for j, precursormz_query in enumerate(precursors_query):
             scores[i, j] = (abs(precursormz_ref - precursormz_query) <= tolerance)
@@ -145,7 +145,7 @@ def precursormz_scores(precursors_ref, precursors_query, tolerance):
 
 @numba.njit
 def precursormz_scores_symmetric(precursors_ref, precursors_query, tolerance):
-    scores = numpy.zeros((len(precursors_ref), len(precursors_query)))
+    scores = np.zeros((len(precursors_ref), len(precursors_query)))
     for i, precursormz_ref in enumerate(precursors_ref):
         for j in range(i, len(precursors_query)):
             scores[i, j] = (abs(precursormz_ref - precursors_query[j]) <= tolerance)
@@ -155,7 +155,7 @@ def precursormz_scores_symmetric(precursors_ref, precursors_query, tolerance):
 
 @numba.njit
 def precursormz_scores_ppm(precursors_ref, precursors_query, tolerance_ppm):
-    scores = numpy.zeros((len(precursors_ref), len(precursors_query)))
+    scores = np.zeros((len(precursors_ref), len(precursors_query)))
     for i, precursormz_ref in enumerate(precursors_ref):
         for j, precursormz_query in enumerate(precursors_query):
             mean_mz = (precursormz_ref + precursormz_query)/2
@@ -165,7 +165,7 @@ def precursormz_scores_ppm(precursors_ref, precursors_query, tolerance_ppm):
 
 @numba.njit
 def precursormz_scores_symmetric_ppm(precursors_ref, precursors_query, tolerance_ppm):
-    scores = numpy.zeros((len(precursors_ref), len(precursors_query)))
+    scores = np.zeros((len(precursors_ref), len(precursors_query)))
     for i, precursormz_ref in enumerate(precursors_ref):
         for j in range(i, len(precursors_query)):
             mean_mz = (precursormz_ref + precursors_query[j])/2

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -1,10 +1,10 @@
 from typing import List, Tuple
 import numba
-import numpy
+import numpy as np
 
 
 @numba.njit
-def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
+def collect_peak_pairs(spec1: np.ndarray, spec2: np.ndarray,
                        tolerance: float, shift: float = 0, mz_power: float = 0.0,
                        intensity_power: float = 1.0):
     # pylint: disable=too-many-arguments
@@ -41,11 +41,11 @@ def collect_peak_pairs(spec1: numpy.ndarray, spec2: numpy.ndarray,
         power_prod_spec1 = (spec1[idx, 0] ** mz_power) * (spec1[idx, 1] ** intensity_power)
         power_prod_spec2 = (spec2[idx2[i], 0] ** mz_power) * (spec2[idx2[i], 1] ** intensity_power)
         matching_pairs.append([idx1[i], idx2[i], power_prod_spec1 * power_prod_spec2])
-    return numpy.array(matching_pairs.copy())
+    return np.array(matching_pairs.copy())
 
 
 @numba.njit
-def find_matches(spec1_mz: numpy.ndarray, spec2_mz: numpy.ndarray,
+def find_matches(spec1_mz: np.ndarray, spec2_mz: np.ndarray,
                  tolerance: float, shift: float = 0) -> List[Tuple[int, int]]:
     """Faster search for matching peaks.
     Makes use of the fact that spec1 and spec2 contain ordered peak m/z (from
@@ -86,8 +86,8 @@ def find_matches(spec1_mz: numpy.ndarray, spec2_mz: numpy.ndarray,
 
 
 @numba.njit(fastmath=True)
-def score_best_matches(matching_pairs: numpy.ndarray, spec1: numpy.ndarray,
-                       spec2: numpy.ndarray, mz_power: float = 0.0,
+def score_best_matches(matching_pairs: np.ndarray, spec1: np.ndarray,
+                       spec2: np.ndarray, mz_power: float = 0.0,
                        intensity_power: float = 1.0) -> Tuple[float, int]:
     """Calculate cosine-like score by multiplying matches. Does require a sorted
     list of matching peaks (sorted by intensity product)."""
@@ -106,5 +106,5 @@ def score_best_matches(matching_pairs: numpy.ndarray, spec1: numpy.ndarray,
     spec1_power = spec1[:, 0] ** mz_power * spec1[:, 1] ** intensity_power
     spec2_power = spec2[:, 0] ** mz_power * spec2[:, 1] ** intensity_power
 
-    score = score/(numpy.sum(spec1_power ** 2) ** 0.5 * numpy.sum(spec2_power ** 2) ** 0.5)
+    score = score/(np.sum(spec1_power ** 2) ** 0.5 * np.sum(spec2_power ** 2) ** 0.5)
     return score, used_matches

--- a/matchms/similarity/vector_similarity_functions.py
+++ b/matchms/similarity/vector_similarity_functions.py
@@ -1,10 +1,10 @@
 """Collection of functions for calculating vector-vector similarities."""
 import numba
-import numpy
+import numpy as np
 
 
 @numba.njit
-def jaccard_similarity_matrix(references: numpy.ndarray, queries: numpy.ndarray) -> numpy.ndarray:
+def jaccard_similarity_matrix(references: np.ndarray, queries: np.ndarray) -> np.ndarray:
     """Returns matrix of jaccard indices between all-vs-all vectors of references
     and queries.
 
@@ -25,7 +25,7 @@ def jaccard_similarity_matrix(references: numpy.ndarray, queries: numpy.ndarray)
     """
     size1 = references.shape[0]
     size2 = queries.shape[0]
-    scores = numpy.zeros((size1, size2))
+    scores = np.zeros((size1, size2))
     for i in range(size1):
         for j in range(size2):
             scores[i, j] = jaccard_index(references[i, :], queries[j, :])
@@ -33,7 +33,7 @@ def jaccard_similarity_matrix(references: numpy.ndarray, queries: numpy.ndarray)
 
 
 @numba.njit
-def dice_similarity_matrix(references: numpy.ndarray, queries: numpy.ndarray) -> numpy.ndarray:
+def dice_similarity_matrix(references: np.ndarray, queries: np.ndarray) -> np.ndarray:
     """Returns matrix of dice similarity scores between all-vs-all vectors of references
     and queries.
 
@@ -54,7 +54,7 @@ def dice_similarity_matrix(references: numpy.ndarray, queries: numpy.ndarray) ->
     """
     size1 = references.shape[0]
     size2 = queries.shape[0]
-    scores = numpy.zeros((size1, size2))
+    scores = np.zeros((size1, size2))
     for i in range(size1):
         for j in range(size2):
             scores[i, j] = dice_similarity(references[i, :], queries[j, :])
@@ -62,7 +62,7 @@ def dice_similarity_matrix(references: numpy.ndarray, queries: numpy.ndarray) ->
 
 
 @numba.njit
-def cosine_similarity_matrix(references: numpy.ndarray, queries: numpy.ndarray) -> numpy.ndarray:
+def cosine_similarity_matrix(references: np.ndarray, queries: np.ndarray) -> np.ndarray:
     """Returns matrix of cosine similarity scores between all-vs-all vectors of
     references and queries.
 
@@ -83,7 +83,7 @@ def cosine_similarity_matrix(references: numpy.ndarray, queries: numpy.ndarray) 
     """
     size1 = references.shape[0]
     size2 = queries.shape[0]
-    scores = numpy.zeros((size1, size2))
+    scores = np.zeros((size1, size2))
     for i in range(size1):
         for j in range(size2):
             scores[i, j] = cosine_similarity(references[i, :], queries[j, :])
@@ -91,7 +91,7 @@ def cosine_similarity_matrix(references: numpy.ndarray, queries: numpy.ndarray) 
 
 
 @numba.njit
-def jaccard_index(u: numpy.ndarray, v: numpy.ndarray) -> numpy.float64:
+def jaccard_index(u: np.ndarray, v: np.ndarray) -> np.float64:
     r"""Computes the Jaccard-index (or Jaccard similarity coefficient) of two boolean
     1-D arrays.
     The Jaccard index between 1-D boolean arrays `u` and `v`,
@@ -114,16 +114,16 @@ def jaccard_index(u: numpy.ndarray, v: numpy.ndarray) -> numpy.float64:
     jaccard_similarity
         The Jaccard similarity coefficient between vectors `u` and `v`.
     """
-    u_or_v = numpy.bitwise_or(u != 0, v != 0)
-    u_and_v = numpy.bitwise_and(u != 0, v != 0)
+    u_or_v = np.bitwise_or(u != 0, v != 0)
+    u_and_v = np.bitwise_and(u != 0, v != 0)
     jaccard_score = 0
     if u_or_v.sum() != 0:
-        jaccard_score = numpy.float64(u_and_v.sum()) / numpy.float64(u_or_v.sum())
+        jaccard_score = np.float64(u_and_v.sum()) / np.float64(u_or_v.sum())
     return jaccard_score
 
 
 @numba.njit
-def dice_similarity(u: numpy.ndarray, v: numpy.ndarray) -> numpy.float64:
+def dice_similarity(u: np.ndarray, v: np.ndarray) -> np.float64:
     r"""Computes the Dice similarity coefficient (DSC) between two boolean 1-D arrays.
 
     The Dice similarity coefficient between `u` and `v`, is
@@ -145,16 +145,16 @@ def dice_similarity(u: numpy.ndarray, v: numpy.ndarray) -> numpy.float64:
     dice_similarity
         The Dice similarity coefficient between 1-D arrays `u` and `v`.
     """
-    u_and_v = numpy.bitwise_and(u != 0, v != 0)
-    u_abs_and_v_abs = numpy.abs(u).sum() + numpy.abs(v).sum()
+    u_and_v = np.bitwise_and(u != 0, v != 0)
+    u_abs_and_v_abs = np.abs(u).sum() + np.abs(v).sum()
     dice_score = 0
     if u_abs_and_v_abs != 0:
-        dice_score = 2.0 * numpy.float64(u_and_v.sum()) / numpy.float64(u_abs_and_v_abs)
+        dice_score = 2.0 * np.float64(u_and_v.sum()) / np.float64(u_abs_and_v_abs)
     return dice_score
 
 
 @numba.njit
-def cosine_similarity(u: numpy.ndarray, v: numpy.ndarray) -> numpy.float64:
+def cosine_similarity(u: np.ndarray, v: np.ndarray) -> np.float64:
     """Calculate cosine similarity score.
 
     Parameters
@@ -179,5 +179,5 @@ def cosine_similarity(u: numpy.ndarray, v: numpy.ndarray) -> numpy.float64:
         vv += v[i] * v[i]
     cosine_score = 0
     if uu != 0 and vv != 0:
-        cosine_score = uv / numpy.sqrt(uu * vv)
-    return numpy.float64(cosine_score)
+        cosine_score = uv / np.sqrt(uu * vv)
+    return np.float64(cosine_score)

--- a/matchms/typing.py
+++ b/matchms/typing.py
@@ -1,9 +1,9 @@
 from typing import List, NewType, Tuple, Union
-import numpy
+import numpy as np
 
 
 SpectrumType = NewType("Spectrum", object)
-ReferencesType = QueriesType = Union[List[object], Tuple[object], numpy.ndarray]
+ReferencesType = QueriesType = Union[List[object], Tuple[object], np.ndarray]
 
 
 """Result of a similarity function"""

--- a/tests/builder_Spectrum.py
+++ b/tests/builder_Spectrum.py
@@ -1,30 +1,30 @@
-import numpy
+import numpy as np
 from matchms import Spectrum
 
 
 class SpectrumBuilder:
     """Builder class to better handle Spectrum creation throughout all matchms unit tests."""
     def __init__(self):
-        self._mz = numpy.array([], dtype="float")
-        self._intensities = numpy.array([], dtype="float")
+        self._mz = np.array([], dtype="float")
+        self._intensities = np.array([], dtype="float")
         self._metadata = {}
         self._metadata_harmonization = False
 
     def from_spectrum(self, spectrum: Spectrum):
         return self.with_mz(spectrum.peaks.mz).with_intensities(spectrum.peaks.intensities).with_metadata(spectrum.metadata)
 
-    def with_mz(self, mz: numpy.ndarray):
-        if isinstance(mz, numpy.ndarray):
-            self._mz = numpy.copy(mz)
+    def with_mz(self, mz: np.ndarray):
+        if isinstance(mz, np.ndarray):
+            self._mz = np.copy(mz)
         else:
-            self._mz = numpy.array(mz, dtype="float")
+            self._mz = np.array(mz, dtype="float")
         return self
 
-    def with_intensities(self, intensities: numpy.ndarray):
-        if isinstance(intensities, numpy.ndarray):
-            self._intensities = numpy.copy(intensities)
+    def with_intensities(self, intensities: np.ndarray):
+        if isinstance(intensities, np.ndarray):
+            self._intensities = np.copy(intensities)
         else:
-            self._intensities = numpy.array(intensities, dtype="float")
+            self._intensities = np.array(intensities, dtype="float")
         return self
 
     def with_metadata(self, metadata: dict,

--- a/tests/test_ParentmassMatch.py
+++ b/tests/test_ParentmassMatch.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.similarity import ParentMassMatch
 from matchms.similarity.ParentMassMatch import (parentmass_scores,
@@ -14,7 +14,7 @@ def test_parentmass_match_parameterized(parent_mass, tolerance, expected):
     s0, s1 = spectra_factory('parent_mass', parent_mass)
     similarity_score = ParentMassMatch(tolerance=tolerance)
     scores = similarity_score.pair(s0, s1)
-    assert numpy.all(scores == numpy.array(expected)), "Expected different scores."
+    assert np.all(scores == np.array(expected)), "Expected different scores."
 
 
 def test_parentmass_match_missing_parentmass():
@@ -40,7 +40,7 @@ def test_parentmass_match_array_parameterized(parent_mass, tolerance, expected):
     s0, s1, s2, s3 = spectra_factory('parent_mass', parent_mass)
     similarity_score = ParentMassMatch(tolerance=tolerance)
     scores = similarity_score.matrix([s0, s1], [s2, s3])
-    assert numpy.all(scores == numpy.array(expected)), "Expected different scores."
+    assert np.all(scores == np.array(expected)), "Expected different scores."
 
 
 def test_parentmass_match_array_symmetric():
@@ -56,8 +56,8 @@ def test_parentmass_match_array_symmetric():
     scores = similarity_score.matrix(spectrums, spectrums, is_symmetric=True)
     scores2 = similarity_score.matrix(spectrums, spectrums, is_symmetric=False)
 
-    assert numpy.all(scores == scores2), "Expected identical scores"
-    assert numpy.all(scores == numpy.array(
+    assert np.all(scores == scores2), "Expected identical scores"
+    assert np.all(scores == np.array(
         [[True, False, True, False],
          [False, True, False, False],
          [True, False, True, False],
@@ -66,37 +66,37 @@ def test_parentmass_match_array_symmetric():
 
 def test_parentmass_scores_compiled():
     """Test the underlying score function (numba compiled)."""
-    parentmasses_ref = numpy.asarray([101, 200, 300])
-    parentmasses_query = numpy.asarray([100, 301])
+    parentmasses_ref = np.asarray([101, 200, 300])
+    parentmasses_query = np.asarray([100, 301])
     scores = parentmass_scores(parentmasses_ref, parentmasses_query, tolerance=2.0)
-    assert numpy.all(scores == numpy.array([[1., 0.],
+    assert np.all(scores == np.array([[1., 0.],
                                             [0., 0.],
                                             [0., 1.]])), "Expected different scores."
 
 
 def test_parentmass_scores():
     """Test the underlying score function (non-compiled)."""
-    parentmasses_ref = numpy.asarray([101, 200, 300])
-    parentmasses_query = numpy.asarray([100, 301])
+    parentmasses_ref = np.asarray([101, 200, 300])
+    parentmasses_query = np.asarray([100, 301])
     scores = parentmass_scores.py_func(parentmasses_ref, parentmasses_query, tolerance=2.0)
-    assert numpy.all(scores == numpy.array([[True, False],
+    assert np.all(scores == np.array([[True, False],
                                             [False, False],
                                             [False, True]])), "Expected different scores."
 
 
 def test_parentmass_scores_symmetric_compliled():
     """Test the underlying score function (numba-compiled)."""
-    parentmasses = numpy.asarray([101, 100, 200])
+    parentmasses = np.asarray([101, 100, 200])
     scores = parentmass_scores_symmetric(parentmasses, parentmasses, tolerance=2.0)
-    assert numpy.all(scores == numpy.array([[1., 1., 0.],
+    assert np.all(scores == np.array([[1., 1., 0.],
                                             [1., 1., 0.],
                                             [0., 0., 1.]])), "Expected different scores."
 
 
 def test_parentmass_scores_symmetric():
     """Test the underlying score function (non-compiled)."""
-    parentmasses = numpy.asarray([101, 100, 200])
+    parentmasses = np.asarray([101, 100, 200])
     scores = parentmass_scores_symmetric.py_func(parentmasses, parentmasses, tolerance=2.0)
-    assert numpy.all(scores == numpy.array([[1., 1., 0.],
+    assert np.all(scores == np.array([[1., 1., 0.],
                                             [1., 1., 0.],
                                             [0., 0., 1.]])), "Expected different scores."

--- a/tests/test_PrecursormzMatch.py
+++ b/tests/test_PrecursormzMatch.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.similarity import PrecursorMzMatch
 from matchms.similarity.PrecursorMzMatch import (
@@ -16,7 +16,7 @@ def test_precursormz_match_parameterized(precursor_mz, tolerance, tolerance_type
     s0, s1 = spectra_factory('precursor_mz', precursor_mz)
     similarity_score = PrecursorMzMatch(tolerance=tolerance, tolerance_type=tolerance_type)
     scores = similarity_score.pair(s0, s1)
-    assert numpy.all(scores == numpy.array(expected)), "Expected different scores."
+    assert np.all(scores == np.array(expected)), "Expected different scores."
 
 
 def test_precursormz_match_missing_precursormz():
@@ -43,7 +43,7 @@ def test_precursormz_match_array_parameterized(precursor_mz, tolerance, toleranc
     s0, s1, s2, s3 = spectra_factory('precursor_mz', precursor_mz)
     similarity_score = PrecursorMzMatch(tolerance=tolerance, tolerance_type=tolerance_type)
     scores = similarity_score.matrix([s0, s1], [s2, s3])
-    assert numpy.all(scores == numpy.array(expected)), "Expected different scores."
+    assert np.all(scores == np.array(expected)), "Expected different scores."
 
 
 @pytest.mark.parametrize('precursor_mz, tolerance, tolerance_type, expected', [
@@ -58,20 +58,20 @@ def test_precursormz_match_array_symmetric_parameterized(precursor_mz, tolerance
     scores = similarity_score.matrix(spectrums, spectrums, is_symmetric=True)
     scores2 = similarity_score.matrix(spectrums, spectrums, is_symmetric=False)
 
-    assert numpy.all(scores == scores2), "Expected identical scores"
-    assert numpy.all(scores == numpy.array(expected)), "Expected different scores"
+    assert np.all(scores == scores2), "Expected identical scores"
+    assert np.all(scores == np.array(expected)), "Expected different scores"
 
 
 @pytest.mark.parametrize("numba_compiled", [True, False])
 def test_precursormz_scores(numba_compiled):
     """Test the underlying score function (pure Python and numba compiled)."""
-    precursors_ref = numpy.asarray([101, 200, 300])
-    precursors_query = numpy.asarray([100, 301])
+    precursors_ref = np.asarray([101, 200, 300])
+    precursors_query = np.asarray([100, 301])
     if numba_compiled:
         scores = precursormz_scores(precursors_ref, precursors_query, tolerance=2.0)
     else:
         scores = precursormz_scores.py_func(precursors_ref, precursors_query, tolerance=2.0)
-    assert numpy.all(scores == numpy.array([[1., 0.],
+    assert np.all(scores == np.array([[1., 0.],
                                             [0., 0.],
                                             [0., 1.]])), "Expected different scores."
 
@@ -79,12 +79,12 @@ def test_precursormz_scores(numba_compiled):
 @pytest.mark.parametrize("numba_compiled", [True, False])
 def test_precursormz_scores_symmetric(numba_compiled):
     """Test the underlying score function (non-compiled)."""
-    precursors = numpy.asarray([101, 100, 200])
+    precursors = np.asarray([101, 100, 200])
     if numba_compiled:
         scores = precursormz_scores_symmetric(precursors, precursors, tolerance=2.0)
     else:
         scores = precursormz_scores_symmetric.py_func(precursors, precursors, tolerance=2.0)
-    assert numpy.all(scores == numpy.array([[1., 1., 0.],
+    assert np.all(scores == np.array([[1., 1., 0.],
                                             [1., 1., 0.],
                                             [0., 0., 1.]])), "Expected different scores."
 
@@ -92,13 +92,13 @@ def test_precursormz_scores_symmetric(numba_compiled):
 @pytest.mark.parametrize("numba_compiled", [True, False])
 def test_precursormz_scores_ppm(numba_compiled):
     """Test the underlying score function (pure Python and numba compiled)."""
-    precursors_ref = numpy.asarray([100.00001, 200, 300])
-    precursors_query = numpy.asarray([100, 300.00001])
+    precursors_ref = np.asarray([100.00001, 200, 300])
+    precursors_query = np.asarray([100, 300.00001])
     if numba_compiled:
         scores = precursormz_scores_ppm(precursors_ref, precursors_query, tolerance_ppm=2.0)
     else:
         scores = precursormz_scores_ppm.py_func(precursors_ref, precursors_query, tolerance_ppm=2.0)
-    assert numpy.all(scores == numpy.array([[1., 0.],
+    assert np.all(scores == np.array([[1., 0.],
                                             [0., 0.],
                                             [0., 1.]])), "Expected different scores."
 
@@ -106,11 +106,11 @@ def test_precursormz_scores_ppm(numba_compiled):
 @pytest.mark.parametrize("numba_compiled", [True, False])
 def test_precursormz_scores_symmetric_ppm(numba_compiled):
     """Test the underlying score function (non-compiled)."""
-    precursors = numpy.asarray([100.00001, 100, 200])
+    precursors = np.asarray([100.00001, 100, 200])
     if numba_compiled:
         scores = precursormz_scores_symmetric_ppm(precursors, precursors, tolerance_ppm=2.0)
     else:
         scores = precursormz_scores_symmetric_ppm.py_func(precursors, precursors, tolerance_ppm=2.0)
-    assert numpy.all(scores == numpy.array([[1., 1., 0.],
+    assert np.all(scores == np.array([[1., 1., 0.],
                                             [1., 1., 0.],
                                             [0., 0., 1.]])), "Expected different scores."

--- a/tests/test_add_fingerprint.py
+++ b/tests/test_add_fingerprint.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import add_fingerprint
@@ -8,14 +8,14 @@ from .builder_Spectrum import SpectrumBuilder
 
 
 @pytest.mark.parametrize('metadata, expected', [
-    [{"smiles": "[C+]#C[O-]"}, numpy.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])],
-    [{"inchi": "InChI=1S/C2O/c1-2-3"}, numpy.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])]
+    [{"smiles": "[C+]#C[O-]"}, np.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])],
+    [{"inchi": "InChI=1S/C2O/c1-2-3"}, np.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])]
 ])
 def test_add_fingerprint(metadata, expected):
     pytest.importorskip("rdkit")
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
     spectrum = add_fingerprint(spectrum_in, nbits=16)
-    assert numpy.all(spectrum.get("fingerprint") == expected), "Expected different fingerprint."
+    assert np.all(spectrum.get("fingerprint") == expected), "Expected different fingerprint."
 
 
 def test_add_fingerprint_no_smiles_no_inchi():

--- a/tests/test_add_losses.py
+++ b/tests/test_add_losses.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import add_losses
@@ -6,24 +6,24 @@ from .builder_Spectrum import SpectrumBuilder
 
 
 @pytest.mark.parametrize("mz, loss_mz_to, expected_mz, expected_intensities", [
-    [numpy.array([100, 150, 200, 300], dtype="float"), 1000, numpy.array([145, 245, 295, 345], "float"), numpy.array([1000, 100, 200, 700], "float")],
-    [numpy.array([100, 150, 200, 450], dtype="float"), 1000, numpy.array([245, 295, 345], "float"), numpy.array([100, 200, 700], "float")],
-    [numpy.array([100, 150, 200, 300], dtype="float"), 250, numpy.array([145, 245], "float"), numpy.array([1000, 100], "float")]
+    [np.array([100, 150, 200, 300], dtype="float"), 1000, np.array([145, 245, 295, 345], "float"), np.array([1000, 100, 200, 700], "float")],
+    [np.array([100, 150, 200, 450], dtype="float"), 1000, np.array([245, 295, 345], "float"), np.array([100, 200, 700], "float")],
+    [np.array([100, 150, 200, 300], dtype="float"), 250, np.array([145, 245], "float"), np.array([1000, 100], "float")]
 ])
 def test_add_losses_parameterized(mz, loss_mz_to, expected_mz, expected_intensities):
-    intensities = numpy.array([700, 200, 100, 1000], "float")
+    intensities = np.array([700, 200, 100, 1000], "float")
     metadata = {"precursor_mz": 445.0}
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(
         intensities).with_metadata(metadata).build()
 
     spectrum = add_losses(spectrum_in, loss_mz_to=loss_mz_to)
 
-    assert numpy.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
-    assert numpy.allclose(spectrum.losses.intensities, expected_intensities), "Expected different intensities."
+    assert np.allclose(spectrum.losses.mz, expected_mz), "Expected different loss m/z."
+    assert np.allclose(spectrum.losses.intensities, expected_intensities), "Expected different intensities."
 
 
 @pytest.mark.parametrize("mz, intensities", [
-    [numpy.array([100, 150, 200, 300], dtype="float"), numpy.array([700, 200, 100, 1000], dtype="float")],
+    [np.array([100, 150, 200, 300], dtype="float"), np.array([700, 200, 100, 1000], dtype="float")],
     [[], []]
 ])
 def test_add_losses_without_precursor_mz_parameterized(mz, intensities):
@@ -42,8 +42,8 @@ def test_add_losses_without_precursor_mz_parameterized(mz, intensities):
 
 def test_add_losses_with_precursor_mz_wrong_type():
     """Test if correct assert error is raised for precursor-mz as string."""
-    mz = numpy.array([100, 150, 200, 300], dtype="float")
-    intensities = numpy.array([700, 200, 100, 1000], "float")
+    mz = np.array([100, 150, 200, 300], dtype="float")
+    intensities = np.array([700, 200, 100, 1000], "float")
     metadata = {"precursor_mz": "445.0"}
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(
         intensities).with_metadata(metadata).build()

--- a/tests/test_add_parent_mass.py
+++ b/tests/test_add_parent_mass.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.constants import PROTON_MASS
 from matchms.filtering import add_parent_mass
@@ -24,7 +24,7 @@ def test_add_parent_mass_precursormz(caplog):
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
     spectrum = add_parent_mass(spectrum_in)
 
-    assert numpy.abs(spectrum.get("parent_mass") - 445.0) < .01, "Expected parent mass of about 445.0."
+    assert np.abs(spectrum.get("parent_mass") - 445.0) < .01, "Expected parent mass of about 445.0."
     assert isinstance(spectrum.get("parent_mass"), float), "Expected parent mass to be float."
     assert "Not sufficient spectrum metadata to derive parent mass." not in caplog.text
 
@@ -40,7 +40,7 @@ def test_add_parent_mass_using_adduct(adduct, expected):
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
     spectrum = add_parent_mass(spectrum_in)
 
-    assert numpy.allclose(spectrum.get("parent_mass"), expected, atol=1e-4), f"Expected parent mass of about {expected}."
+    assert np.allclose(spectrum.get("parent_mass"), expected, atol=1e-4), f"Expected parent mass of about {expected}."
     assert isinstance(spectrum.get("parent_mass"), float), "Expected parent mass to be float."
 
 
@@ -55,7 +55,7 @@ def test_add_parent_mass_overwrite(overwrite, expected):
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
     spectrum = add_parent_mass(spectrum_in, overwrite_existing_entry=overwrite)
 
-    assert numpy.allclose(spectrum.get("parent_mass"), expected, atol=1e-4), \
+    assert np.allclose(spectrum.get("parent_mass"), expected, atol=1e-4), \
         "Expected parent mass to be replaced by new value."
 
 
@@ -73,7 +73,7 @@ def test_add_parent_mass_already_present(parent_mass_field, parent_mass, expecte
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
     spectrum = add_parent_mass(spectrum_in)
 
-    assert numpy.allclose(spectrum.get("parent_mass"), expected, atol=1e-4), f"Expected parent mass of about {expected}."
+    assert np.allclose(spectrum.get("parent_mass"), expected, atol=1e-4), f"Expected parent mass of about {expected}."
     assert isinstance(spectrum.get("parent_mass"), (float, int)), "Expected parent mass to be float."
 
 

--- a/tests/test_add_precursor_mz.py
+++ b/tests/test_add_precursor_mz.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import add_precursor_mz
 from matchms.logging_functions import (reset_matchms_logger,
@@ -22,8 +22,8 @@ def test_add_precursor_mz(metadata, expected):
 def test_add_precursor_mz_only_pepmass_present(caplog):
     """Test if precursor_mz is correctly derived if only pepmass is present."""
     set_matchms_logger_level("INFO")
-    mz = numpy.array([], dtype='float')
-    intensities = numpy.array([], dtype='float')
+    mz = np.array([], dtype='float')
+    intensities = np.array([], dtype='float')
     metadata = {"pepmass": (444.0, 10)}
     spectrum_in = SpectrumBuilder().with_metadata(
         metadata).with_mz(mz).with_intensities(intensities).build()
@@ -48,8 +48,8 @@ def test_add_precursor_mz_only_pepmass_present(caplog):
     ["pepmass", None, None]])
 def test_add_precursor_mz_no_precursor_mz(key, value, expected):
     """Test if precursor_mz is correctly derived if "precursor_mz" is str."""
-    mz = numpy.array([], dtype='float')
-    intensities = numpy.array([], dtype='float')
+    mz = np.array([], dtype='float')
+    intensities = np.array([], dtype='float')
     metadata = {key: value}
     spectrum_in = SpectrumBuilder().with_metadata(
         metadata).with_mz(mz).with_intensities(intensities).build()
@@ -67,8 +67,8 @@ def test_add_precursor_mz_no_precursor_mz(key, value, expected):
     ["precursor_mz", [], "Found precursor_mz of undefined type."]])
 def test_add_precursor_mz_logging(key, value, expected_log, caplog):
     """Test if precursor_mz is correctly derived if "precursor_mz" is str."""
-    mz = numpy.array([], dtype='float')
-    intensities = numpy.array([], dtype='float')
+    mz = np.array([], dtype='float')
+    intensities = np.array([], dtype='float')
     metadata = {key: value}
     spectrum_in = SpectrumBuilder().with_metadata(
         metadata).with_mz(mz).with_intensities(intensities).build()

--- a/tests/test_cosine_greedy.py
+++ b/tests/test_cosine_greedy.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.similarity import CosineGreedy
 from .builder_Spectrum import SpectrumBuilder
@@ -11,8 +11,8 @@ def compute_expected_score(mz_power, intensity_power, spectrum_1, spectrum_2, ma
     mz2 = spectrum_2.peaks.mz
     multiply_matching_intensities = (mz1[matches[0]] ** mz_power) * (intensity1[matches[0]] ** intensity_power) \
         * (mz2[matches[1]] ** mz_power) * (intensity2[matches[1]] ** intensity_power)
-    denominator = numpy.sqrt((((mz1 ** mz_power) * (intensity1 ** intensity_power)) ** 2).sum()) \
-        * numpy.sqrt((((mz2 ** mz_power) * (intensity2 ** intensity_power)) ** 2).sum())
+    denominator = np.sqrt((((mz1 ** mz_power) * (intensity1 ** intensity_power)) ** 2).sum()) \
+        * np.sqrt((((mz2 ** mz_power) * (intensity2 ** intensity_power)) ** 2).sum())
     expected_score = multiply_matching_intensities.sum() / denominator
     return expected_score
 
@@ -20,26 +20,26 @@ def compute_expected_score(mz_power, intensity_power, spectrum_1, spectrum_2, ma
 @pytest.mark.parametrize("peaks, tolerance, mz_power, intensity_power, expected_matches", [
     [
         [
-            [numpy.array([100, 200, 300, 500, 510], dtype="float"), numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")],
-            [numpy.array([100, 200, 290, 490, 510], dtype="float"), numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")]
+            [np.array([100, 200, 300, 500, 510], dtype="float"), np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")],
+            [np.array([100, 200, 290, 490, 510], dtype="float"), np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")]
         ],
         0.1, 0.0, 1.0, [[0, 1, 4], [0, 1, 4]]
     ], [
         [
-            [numpy.array([100, 299, 300, 301, 510], dtype="float"), numpy.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float")],
-            [numpy.array([100, 300, 301, 511], dtype="float"), numpy.array([0.1, 1.0, 0.3, 0.4], dtype="float")],
+            [np.array([100, 299, 300, 301, 510], dtype="float"), np.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float")],
+            [np.array([100, 300, 301, 511], dtype="float"), np.array([0.1, 1.0, 0.3, 0.4], dtype="float")],
         ],
         0.2, 0.0, 1.0, [[0, 2, 3], [0, 1, 2]]
     ], [
         [
-            [numpy.array([100, 299, 300, 301, 510], dtype="float"), numpy.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float")],
-            [numpy.array([100, 300, 301, 511], dtype="float"), numpy.array([0.1, 1.0, 0.3, 0.4], dtype="float")],
+            [np.array([100, 299, 300, 301, 510], dtype="float"), np.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float")],
+            [np.array([100, 300, 301, 511], dtype="float"), np.array([0.1, 1.0, 0.3, 0.4], dtype="float")],
         ],
         2.0, 0.0, 1.0, [[0, 1, 3, 4], [0, 1, 2, 3]]
     ], [
         [
-            [numpy.array([100, 200, 300, 500, 510], dtype="float"), numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")],
-            [numpy.array([100, 200, 290, 490, 510], dtype="float"), numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")],
+            [np.array([100, 200, 300, 500, 510], dtype="float"), np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")],
+            [np.array([100, 200, 290, 490, 510], dtype="float"), np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")],
         ],
         1.0, 0.5, 2.0, [[0, 1, 4], [0, 1, 4]]
     ]
@@ -61,11 +61,11 @@ def test_cosine_greedy_pair(peaks, tolerance, mz_power, intensity_power, expecte
 @pytest.mark.parametrize("symmetric", [[True], [False]])
 def test_cosine_greedy_matrix(symmetric):
     builder = SpectrumBuilder()
-    spectrum_1 = builder.with_mz(numpy.array([100, 200, 300], dtype="float")).with_intensities(
-        numpy.array([0.1, 0.2, 1.0], dtype="float")).build()
+    spectrum_1 = builder.with_mz(np.array([100, 200, 300], dtype="float")).with_intensities(
+        np.array([0.1, 0.2, 1.0], dtype="float")).build()
 
-    spectrum_2 = builder.with_mz(numpy.array([110, 190, 290], dtype="float")).with_intensities(
-        numpy.array([0.5, 0.2, 1.0], dtype="float")).build()
+    spectrum_2 = builder.with_mz(np.array([110, 190, 290], dtype="float")).with_intensities(
+        np.array([0.5, 0.2, 1.0], dtype="float")).build()
 
     spectrums = [spectrum_1, spectrum_2]
     cosine_greedy = CosineGreedy()

--- a/tests/test_cosine_hungarian.py
+++ b/tests/test_cosine_hungarian.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms import Spectrum
 from matchms.similarity import CosineHungarian
@@ -6,11 +6,11 @@ from matchms.similarity import CosineHungarian
 
 def test_cosine_hungarian_without_parameters():
     """Compare output cosine score with own calculation on simple dummy spectrums."""
-    spectrum_1 = Spectrum(mz=numpy.array([100, 200, 300, 500, 510], dtype="float"),
-                          intensities=numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(mz=np.array([100, 200, 300, 500, 510], dtype="float"),
+                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
 
-    spectrum_2 = Spectrum(mz=numpy.array([100, 200, 290, 490, 510], dtype="float"),
-                          intensities=numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_2 = Spectrum(mz=np.array([100, 200, 290, 490, 510], dtype="float"),
+                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
     cosine_hungarian = CosineHungarian()
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
@@ -18,8 +18,8 @@ def test_cosine_hungarian_without_parameters():
     expected_matches = [0, 1, 4]  # Those peaks have matching mz values (within given tolerance)
     multiply_matching_intensities = spectrum_1.peaks.intensities[expected_matches] \
         * spectrum_2.peaks.intensities[expected_matches]
-    denominator = numpy.sqrt((spectrum_1.peaks.intensities ** 2).sum()) \
-        * numpy.sqrt((spectrum_2.peaks.intensities ** 2).sum())
+    denominator = np.sqrt((spectrum_1.peaks.intensities ** 2).sum()) \
+        * np.sqrt((spectrum_2.peaks.intensities ** 2).sum())
     expected_score = multiply_matching_intensities.sum() / denominator
 
     assert score["score"] == pytest.approx(expected_score, 0.0001), "Expected different cosine score."
@@ -28,11 +28,11 @@ def test_cosine_hungarian_without_parameters():
 
 def test_cosine_hungarian_matrix_without_parameters():
     """Compare output cosine score with expected scores."""
-    spectrum_1 = Spectrum(mz=numpy.array([100, 200, 300, 500, 510], dtype="float"),
-                          intensities=numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(mz=np.array([100, 200, 300, 500, 510], dtype="float"),
+                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
 
-    spectrum_2 = Spectrum(mz=numpy.array([100, 200, 290, 490, 510], dtype="float"),
-                          intensities=numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_2 = Spectrum(mz=np.array([100, 200, 290, 490, 510], dtype="float"),
+                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
     cosine_hungarian = CosineHungarian()
     scores = cosine_hungarian.matrix([spectrum_1, spectrum_2], [spectrum_1, spectrum_2])
 
@@ -45,11 +45,11 @@ def test_cosine_hungarian_matrix_without_parameters():
 
 def test_cosine_hungarian_with_tolerance_0_2():
     """Compare output cosine score for tolerance 0.2 with own calculation on simple dummy spectrums."""
-    spectrum_1 = Spectrum(mz=numpy.array([100, 299, 300, 301, 510], dtype="float"),
-                          intensities=numpy.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(mz=np.array([100, 299, 300, 301, 510], dtype="float"),
+                          intensities=np.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float"))
 
-    spectrum_2 = Spectrum(mz=numpy.array([100, 300, 301, 511], dtype="float"),
-                          intensities=numpy.array([0.1, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_2 = Spectrum(mz=np.array([100, 300, 301, 511], dtype="float"),
+                          intensities=np.array([0.1, 1.0, 0.3, 0.4], dtype="float"))
     cosine_hungarian = CosineHungarian(tolerance=0.2)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
@@ -57,8 +57,8 @@ def test_cosine_hungarian_with_tolerance_0_2():
     expected_matches = [[0, 2, 3], [0, 1, 2]]  # Those peaks have matching mz values (within given tolerance)
     multiply_matching_intensities = spectrum_1.peaks.intensities[expected_matches[0]] \
         * spectrum_2.peaks.intensities[expected_matches[1]]
-    denominator = numpy.sqrt((spectrum_1.peaks.intensities ** 2).sum()) \
-        * numpy.sqrt((spectrum_2.peaks.intensities ** 2).sum())
+    denominator = np.sqrt((spectrum_1.peaks.intensities ** 2).sum()) \
+        * np.sqrt((spectrum_2.peaks.intensities ** 2).sum())
     expected_score = multiply_matching_intensities.sum() / denominator
 
     assert score["score"] == pytest.approx(expected_score, 0.0001), "Expected different cosine score."
@@ -67,11 +67,11 @@ def test_cosine_hungarian_with_tolerance_0_2():
 
 def test_cosine_hungarian_with_tolerance_2_0():
     """Compare output cosine score for tolerance 2.0 with own calculation on simple dummy spectrums."""
-    spectrum_1 = Spectrum(mz=numpy.array([100, 299, 300, 301, 510], dtype="float"),
-                          intensities=numpy.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(mz=np.array([100, 299, 300, 301, 510], dtype="float"),
+                          intensities=np.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float"))
 
-    spectrum_2 = Spectrum(mz=numpy.array([100, 300, 301, 511], dtype="float"),
-                          intensities=numpy.array([0.1, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_2 = Spectrum(mz=np.array([100, 300, 301, 511], dtype="float"),
+                          intensities=np.array([0.1, 1.0, 0.3, 0.4], dtype="float"))
     cosine_hungarian = CosineHungarian(tolerance=2.0)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
@@ -79,8 +79,8 @@ def test_cosine_hungarian_with_tolerance_2_0():
     expected_matches = [[0, 1, 3, 4], [0, 1, 2, 3]]  # Those peaks have matching mz values (within given tolerance)
     multiply_matching_intensities = spectrum_1.peaks.intensities[expected_matches[0]] \
         * spectrum_2.peaks.intensities[expected_matches[1]]
-    denominator = numpy.sqrt((spectrum_1.peaks.intensities ** 2).sum()) \
-        * numpy.sqrt((spectrum_2.peaks.intensities ** 2).sum())
+    denominator = np.sqrt((spectrum_1.peaks.intensities ** 2).sum()) \
+        * np.sqrt((spectrum_2.peaks.intensities ** 2).sum())
     expected_score = multiply_matching_intensities.sum() / denominator
 
     assert score["score"] == pytest.approx(expected_score, 0.0001), "Expected different cosine score."
@@ -89,12 +89,12 @@ def test_cosine_hungarian_with_tolerance_2_0():
 
 def test_cosine_hungarian_order_of_arguments():
     """Compare cosine scores for A,B versus B,A, which should give the same score."""
-    spectrum_1 = Spectrum(mz=numpy.array([100, 200, 299, 300, 301, 500, 510], dtype="float"),
-                          intensities=numpy.array([0.02, 0.02, 1.0, 0.2, 0.4, 0.04, 0.2], dtype="float"),
+    spectrum_1 = Spectrum(mz=np.array([100, 200, 299, 300, 301, 500, 510], dtype="float"),
+                          intensities=np.array([0.02, 0.02, 1.0, 0.2, 0.4, 0.04, 0.2], dtype="float"),
                           metadata={})
 
-    spectrum_2 = Spectrum(mz=numpy.array([100, 200, 300, 301, 500, 512], dtype="float"),
-                          intensities=numpy.array([0.02, 0.02, 1.0, 0.2, 0.04, 0.2], dtype="float"),
+    spectrum_2 = Spectrum(mz=np.array([100, 200, 300, 301, 500, 512], dtype="float"),
+                          intensities=np.array([0.02, 0.02, 1.0, 0.2, 0.04, 0.2], dtype="float"),
                           metadata={})
 
     cosine_hungarian = CosineHungarian(tolerance=2.0)
@@ -107,12 +107,12 @@ def test_cosine_hungarian_order_of_arguments():
 
 def test_cosine_hungarian_case_where_greedy_would_fail():
     """Test case that would fail for cosine greedy implementations."""
-    spectrum_1 = Spectrum(mz=numpy.array([100.005, 100.016], dtype="float"),
-                          intensities=numpy.array([1.0, 0.9], dtype="float"),
+    spectrum_1 = Spectrum(mz=np.array([100.005, 100.016], dtype="float"),
+                          intensities=np.array([1.0, 0.9], dtype="float"),
                           metadata={})
 
-    spectrum_2 = Spectrum(mz=numpy.array([100.005, 100.01], dtype="float"),
-                          intensities=numpy.array([0.9, 1.0], dtype="float"),
+    spectrum_2 = Spectrum(mz=np.array([100.005, 100.01], dtype="float"),
+                          intensities=np.array([0.9, 1.0], dtype="float"),
                           metadata={})
 
     cosine_hungarian = CosineHungarian(tolerance=0.01)
@@ -123,12 +123,12 @@ def test_cosine_hungarian_case_where_greedy_would_fail():
 
 def test_cosine_hungarian_case_without_matches():
     """Test case for spectrums without any matching peaks."""
-    spectrum_1 = Spectrum(mz=numpy.array([100, 200], dtype="float"),
-                          intensities=numpy.array([1.0, 0.1], dtype="float"),
+    spectrum_1 = Spectrum(mz=np.array([100, 200], dtype="float"),
+                          intensities=np.array([1.0, 0.1], dtype="float"),
                           metadata={})
 
-    spectrum_2 = Spectrum(mz=numpy.array([110, 210], dtype="float"),
-                          intensities=numpy.array([1.0, 0.1], dtype="float"),
+    spectrum_2 = Spectrum(mz=np.array([110, 210], dtype="float"),
+                          intensities=np.array([1.0, 0.1], dtype="float"),
                           metadata={})
 
     cosine_hungarian = CosineHungarian()
@@ -143,11 +143,11 @@ def test_cosine_hungarian_with_peak_powers():
     """
     mz_power = 0.5
     intensity_power = 2.0
-    spectrum_1 = Spectrum(mz=numpy.array([100, 200, 300, 500, 510], dtype="float"),
-                          intensities=numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(mz=np.array([100, 200, 300, 500, 510], dtype="float"),
+                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
 
-    spectrum_2 = Spectrum(mz=numpy.array([100, 200, 290, 490, 510], dtype="float"),
-                          intensities=numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_2 = Spectrum(mz=np.array([100, 200, 290, 490, 510], dtype="float"),
+                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
     cosine_hungarian = CosineHungarian(tolerance=1.0, mz_power=mz_power, intensity_power=intensity_power)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
@@ -159,8 +159,8 @@ def test_cosine_hungarian_with_peak_powers():
     mz2 = spectrum_2.peaks.mz
     multiply_matching_intensities = (mz1[matches] ** mz_power) * (intensity1[matches] ** intensity_power) \
         * (mz2[matches] ** mz_power) * (intensity2[matches] ** intensity_power)
-    denominator = numpy.sqrt((((mz1 ** mz_power) * (intensity1 ** intensity_power)) ** 2).sum()) \
-        * numpy.sqrt((((mz2 ** mz_power) * (intensity2 ** intensity_power)) ** 2).sum())
+    denominator = np.sqrt((((mz1 ** mz_power) * (intensity1 ** intensity_power)) ** 2).sum()) \
+        * np.sqrt((((mz2 ** mz_power) * (intensity2 ** intensity_power)) ** 2).sum())
     expected_score = multiply_matching_intensities.sum() / denominator
 
     assert score["score"] == pytest.approx(expected_score, 0.0001), "Expected different cosine score."

--- a/tests/test_fingerprint_similarity.py
+++ b/tests/test_fingerprint_similarity.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms import Spectrum, calculate_scores
 from matchms.similarity import FingerprintSimilarity
@@ -7,14 +7,14 @@ from matchms.similarity import FingerprintSimilarity
 @pytest.mark.parametrize("test_method, expected_score", [("cosine", 0.6761234), ("jaccard", 0.5), ("dice", 2/3)])
 def test_fingerprint_similarity_pair_calculations(test_method, expected_score):
     """Test cosine score pair with two fingerprint."""
-    fingerprint1 = numpy.array([1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0])
-    spectrum1 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    fingerprint1 = np.array([1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0])
+    spectrum1 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={"fingerprint": fingerprint1})
 
-    fingerprint2 = numpy.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
-    spectrum2 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    fingerprint2 = np.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
+    spectrum2 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={"fingerprint": fingerprint2})
 
     similarity_measure = FingerprintSimilarity(similarity_measure=test_method)
@@ -25,20 +25,20 @@ def test_fingerprint_similarity_pair_calculations(test_method, expected_score):
 @pytest.mark.parametrize("test_method", ["cosine", "jaccard", "dice"])
 def test_fingerprint_similarity_parallel_empty_fingerprint(test_method):
     """Test score matrix with empty fingerprint using the provided methods."""
-    fingerprint1 = numpy.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-    spectrum1 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    fingerprint1 = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    spectrum1 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={"fingerprint": fingerprint1})
 
-    fingerprint2 = numpy.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
-    spectrum2 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    fingerprint2 = np.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
+    spectrum2 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={"fingerprint": fingerprint2})
 
     similarity_measure = FingerprintSimilarity(similarity_measure=test_method)
     score_matrix = similarity_measure.matrix([spectrum1, spectrum2],
                                              [spectrum1, spectrum2])
-    assert score_matrix == pytest.approx(numpy.array([[0, 0],
+    assert score_matrix == pytest.approx(np.array([[0, 0],
                                                       [0, 1.]]), 0.001), "Expected different values."
 
 
@@ -47,68 +47,68 @@ def test_fingerprint_similarity_parallel_empty_fingerprint(test_method):
                                                          ("dice", 0.83333333)])
 def test_fingerprint_similarity_parallel(test_method, expected_score):
     """Test score matrix with known values for the provided methods."""
-    spectrum0 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    spectrum0 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={})
 
-    fingerprint1 = numpy.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
-    spectrum1 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    fingerprint1 = np.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
+    spectrum1 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={"fingerprint": fingerprint1})
 
-    fingerprint2 = numpy.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
-    spectrum2 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    fingerprint2 = np.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
+    spectrum2 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={"fingerprint": fingerprint2})
 
     similarity_measure = FingerprintSimilarity(similarity_measure=test_method)
     score_matrix = similarity_measure.matrix([spectrum0, spectrum1, spectrum2],
                                              [spectrum0, spectrum1, spectrum2])
-    expected_matrix = numpy.array([[1., expected_score],
+    expected_matrix = np.array([[1., expected_score],
                                    [expected_score, 1.]])
     assert score_matrix[1:, 1:] == pytest.approx(expected_matrix, 0.001), "Expected different values."
-    assert numpy.all(numpy.isnan(score_matrix[:, 0])), "Expected 'nan' entries."
-    assert numpy.all(numpy.isnan(score_matrix[0, :])), "Expected 'nan' entries."
+    assert np.all(np.isnan(score_matrix[:, 0])), "Expected 'nan' entries."
+    assert np.all(np.isnan(score_matrix[0, :])), "Expected 'nan' entries."
 
 
 def test_fingerprint_similarity_parallel_cosine_set_empty_to_0():
     """Test cosine score matrix with known values. Set non-exising values to 0."""
-    spectrum0 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    spectrum0 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={})
 
-    fingerprint1 = numpy.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
-    spectrum1 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    fingerprint1 = np.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
+    spectrum1 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={"fingerprint": fingerprint1})
 
-    fingerprint2 = numpy.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
-    spectrum2 = Spectrum(mz=numpy.array([], dtype="float"),
-                         intensities=numpy.array([], dtype="float"),
+    fingerprint2 = np.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
+    spectrum2 = Spectrum(mz=np.array([], dtype="float"),
+                         intensities=np.array([], dtype="float"),
                          metadata={"fingerprint": fingerprint2})
 
     similarity_measure = FingerprintSimilarity(set_empty_scores=0, similarity_measure="cosine")
     score_matrix = similarity_measure.matrix([spectrum0, spectrum1, spectrum2],
                                              [spectrum0, spectrum1, spectrum2])
-    assert score_matrix == pytest.approx(numpy.array([[0, 0, 0],
+    assert score_matrix == pytest.approx(np.array([[0, 0, 0],
                                                       [0, 1., 0.84515425],
                                                       [0, 0.84515425, 1.]]), 0.001), "Expected different values."
 
 
 def test_fingerprint_similarity_with_scores_sorting():
     """Test if score works with Scores.scores_by_query and sorting."""
-    spectrum0 = Spectrum(mz=numpy.array([100.0, 101.0], dtype="float"),
-                         intensities=numpy.array([0.4, 0.5], dtype="float"),
+    spectrum0 = Spectrum(mz=np.array([100.0, 101.0], dtype="float"),
+                         intensities=np.array([0.4, 0.5], dtype="float"),
                          metadata={})
 
-    fingerprint1 = numpy.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
-    spectrum1 = Spectrum(mz=numpy.array([100.0, 101.0], dtype="float"),
-                         intensities=numpy.array([0.4, 0.5], dtype="float"),
+    fingerprint1 = np.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
+    spectrum1 = Spectrum(mz=np.array([100.0, 101.0], dtype="float"),
+                         intensities=np.array([0.4, 0.5], dtype="float"),
                          metadata={"fingerprint": fingerprint1})
 
-    fingerprint2 = numpy.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
-    spectrum2 = Spectrum(mz=numpy.array([100.0, 101.0], dtype="float"),
-                         intensities=numpy.array([0.4, 0.5], dtype="float"),
+    fingerprint2 = np.array([0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1])
+    spectrum2 = Spectrum(mz=np.array([100.0, 101.0], dtype="float"),
+                         intensities=np.array([0.4, 0.5], dtype="float"),
                          metadata={"fingerprint": fingerprint2})
 
     similarity_measure = FingerprintSimilarity(set_empty_scores=0, similarity_measure="cosine")
@@ -118,6 +118,6 @@ def test_fingerprint_similarity_with_scores_sorting():
                               similarity_measure)
 
     scores_by_ref_sorted = scores.scores_by_query(spectrum1, sort=True)
-    expected_scores = numpy.array([1.0, 0.84515425, 0.0])
-    assert numpy.allclose(numpy.array([x[1] for x in scores_by_ref_sorted]), expected_scores, atol=1e-6), \
+    expected_scores = np.array([1.0, 0.84515425, 0.0])
+    assert np.allclose(np.array([x[1] for x in scores_by_ref_sorted]), expected_scores, atol=1e-6), \
         "Expected different scores and/or order."

--- a/tests/test_fragments.py
+++ b/tests/test_fragments.py
@@ -1,24 +1,24 @@
-import numpy
+import numpy as np
 import pytest
 from matchms import Fragments
 
 
 def test_fragments_init():
 
-    mz = numpy.array([10, 20, 30], dtype="float")
-    intensities = numpy.array([100, 20, 300], dtype="float")
+    mz = np.array([10, 20, 30], dtype="float")
+    intensities = np.array([100, 20, 300], dtype="float")
 
     peaks = Fragments(mz=mz, intensities=intensities)
 
     assert peaks is not None
-    assert numpy.allclose(mz, peaks.mz)
-    assert numpy.allclose(intensities, peaks.intensities)
+    assert np.allclose(mz, peaks.mz)
+    assert np.allclose(intensities, peaks.intensities)
 
 
 def test_fragments_mz_wrong_numpy_dtype():
 
-    mz = numpy.array([10, 20, 30], dtype="int")
-    intensities = numpy.array([100, 20, 300], dtype="float")
+    mz = np.array([10, 20, 30], dtype="int")
+    intensities = np.array([100, 20, 300], dtype="float")
 
     with pytest.raises(AssertionError) as msg:
         _ = Fragments(mz=mz, intensities=intensities)
@@ -28,8 +28,8 @@ def test_fragments_mz_wrong_numpy_dtype():
 
 def test_fragments_intensities_wrong_numpy_dtype():
 
-    mz = numpy.array([10, 20, 30], dtype="float")
-    intensities = numpy.array([100, 20, 300], dtype="int")
+    mz = np.array([10, 20, 30], dtype="float")
+    intensities = np.array([100, 20, 300], dtype="int")
 
     with pytest.raises(AssertionError) as msg:
         _ = Fragments(mz=mz, intensities=intensities)
@@ -39,8 +39,8 @@ def test_fragments_intensities_wrong_numpy_dtype():
 
 def test_fragments_same_shape():
 
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([100, 20, 300], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([100, 20, 300], dtype="float")
 
     with pytest.raises(AssertionError) as msg:
         _ = Fragments(mz=mz, intensities=intensities)
@@ -51,29 +51,29 @@ def test_fragments_same_shape():
 def test_fragments_mz_wrong_data_type():
 
     mz = [10, 20, 30]
-    intensities = numpy.array([100, 20, 300], dtype="float")
+    intensities = np.array([100, 20, 300], dtype="float")
 
     with pytest.raises(AssertionError) as msg:
         _ = Fragments(mz=mz, intensities=intensities)
 
-    assert str(msg.value) == "Input argument 'mz' should be a numpy.array."
+    assert str(msg.value) == "Input argument 'mz' should be a np.array."
 
 
 def test_fragments_intensities_wrong_data_type():
 
-    mz = numpy.array([10, 20, 30], dtype="float")
+    mz = np.array([10, 20, 30], dtype="float")
     intensities = [100, 20, 300]
 
     with pytest.raises(AssertionError) as msg:
         _ = Fragments(mz=mz, intensities=intensities)
 
-    assert str(msg.value) == "Input argument 'intensities' should be a numpy.array."
+    assert str(msg.value) == "Input argument 'intensities' should be a np.array."
 
 
 def test_fragments_dot_clone():
 
-    mz = numpy.array([10, 20, 30], dtype="float")
-    intensities = numpy.array([100, 20, 300], dtype="float")
+    mz = np.array([10, 20, 30], dtype="float")
+    intensities = np.array([100, 20, 300], dtype="float")
 
     peaks = Fragments(mz=mz, intensities=intensities)
 
@@ -85,23 +85,23 @@ def test_fragments_dot_clone():
 
 def test_fragments_getitem():
 
-    mz = numpy.array([10, 20, 30], dtype="float")
-    intensities = numpy.array([100, 20, 300], dtype="float")
+    mz = np.array([10, 20, 30], dtype="float")
+    intensities = np.array([100, 20, 300], dtype="float")
 
     peaks = Fragments(mz=mz, intensities=intensities)
 
-    assert numpy.allclose(peaks[1], numpy.array(mz[1], intensities[1]))
-    assert numpy.allclose(peaks[:],
-                          numpy.stack((peaks.mz, peaks.intensities)))
+    assert np.allclose(peaks[1], np.array(mz[1], intensities[1]))
+    assert np.allclose(peaks[:],
+                          np.stack((peaks.mz, peaks.intensities)))
 
 
 def test_fragments_to_numpy():
     """Test conversion to stacked numpy array"""
-    mz = numpy.array([10, 20, 30], dtype="float")
-    intensities = numpy.array([100, 99.9, 300], dtype="float")
+    mz = np.array([10, 20, 30], dtype="float")
+    intensities = np.array([100, 99.9, 300], dtype="float")
 
     peaks = Fragments(mz=mz, intensities=intensities)
 
-    assert numpy.allclose(peaks.to_numpy, numpy.array([[10., 100.],
+    assert np.allclose(peaks.to_numpy, np.array([[10., 100.],
                                                        [20., 99.9],
                                                        [30., 300.]]))

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms import Spectrum
 from matchms.hashing import metadata_hash, spectrum_hash
@@ -7,8 +7,8 @@ from .builder_Spectrum import SpectrumBuilder
 
 @pytest.fixture
 def spectrum() -> Spectrum:
-    mz = numpy.array([100, 200, 290, 490, 490.5], dtype="float")
-    intensities = numpy.array([0.1, 0.11, 1.0, 0.3, 0.4], dtype="float")
+    mz = np.array([100, 200, 290, 490, 490.5], dtype="float")
+    intensities = np.array([0.1, 0.11, 1.0, 0.3, 0.4], dtype="float")
     metadata = {"precursor_mz": 505.0}
     builder = SpectrumBuilder().with_mz(mz).with_intensities(
         intensities).with_metadata(metadata)

--- a/tests/test_interpret_pepmass.py
+++ b/tests/test_interpret_pepmass.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import interpret_pepmass
 from .builder_Spectrum import SpectrumBuilder
@@ -13,8 +13,8 @@ from .builder_Spectrum import SpectrumBuilder
                           ((896.05, 1111.2, -1), (896.05, 1111.2, -1))])
 def test_interpret_pepmass(input_pepmass, expected_results):
     """Test if example inputs are correctly converted"""
-    mz = numpy.array([100, 200.])
-    intensities = numpy.array([0.7, 0.1])
+    mz = np.array([100, 200.])
+    intensities = np.array([0.7, 0.1])
     metadata = {'pepmass': input_pepmass}
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).with_metadata(metadata).build()
 
@@ -28,8 +28,8 @@ def test_interpret_pepmass(input_pepmass, expected_results):
 
 def test_interpret_pepmass_charge_present(caplog):
     """Test if example inputs are correctly converted when entries already exist"""
-    mz = numpy.array([100, 200.])
-    intensities = numpy.array([0.7, 0.1])
+    mz = np.array([100, 200.])
+    intensities = np.array([0.7, 0.1])
     metadata = {'pepmass': (896.05, 1111.2, "2-"),
                 'charge': -1}
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).with_metadata(metadata).build()
@@ -46,8 +46,8 @@ def test_interpret_pepmass_charge_present(caplog):
 
 def test_interpret_pepmass_mz_present(caplog):
     """Test if example inputs are correctly converted when entries already exist"""
-    mz = numpy.array([100, 200.])
-    intensities = numpy.array([0.7, 0.1])
+    mz = np.array([100, 200.])
+    intensities = np.array([0.7, 0.1])
     metadata = {'pepmass': (203, 44, "2-"),
                 'precursor_mz': 202}
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).with_metadata(metadata).build()
@@ -64,8 +64,8 @@ def test_interpret_pepmass_mz_present(caplog):
 
 def test_interpret_pepmass_intensity_present(caplog):
     """Test if example inputs are correctly converted when entries already exist"""
-    mz = numpy.array([100, 200.])
-    intensities = numpy.array([0.7, 0.1])
+    mz = np.array([100, 200.])
+    intensities = np.array([0.7, 0.1])
     metadata = {'pepmass': (203, 44, "2-"), 'precursor_intensity': 100}
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).with_metadata(metadata).build()
 

--- a/tests/test_intersect_mz.py
+++ b/tests/test_intersect_mz.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.similarity import IntersectMz
 from .builder_Spectrum import SpectrumBuilder
@@ -6,11 +6,11 @@ from .builder_Spectrum import SpectrumBuilder
 
 def test_intersect_mz_without_parameters():
     """Compare score with expected value."""
-    intensities = numpy.array([1.0, 1.0, 1.0, 1.0], dtype="float")
+    intensities = np.array([1.0, 1.0, 1.0, 1.0], dtype="float")
     builder = SpectrumBuilder().with_intensities(intensities)
 
-    spectrum_1 = builder.with_mz(numpy.array([100, 200, 300, 500], dtype="float")).build()
-    spectrum_2 = builder.with_mz(numpy.array([100, 200, 290, 499.9], dtype="float")).build()
+    spectrum_1 = builder.with_mz(np.array([100, 200, 300, 500], dtype="float")).build()
+    spectrum_2 = builder.with_mz(np.array([100, 200, 290, 499.9], dtype="float")).build()
 
     similarity_score = IntersectMz()
     score = similarity_score.pair(spectrum_1, spectrum_2)

--- a/tests/test_load_adducts.py
+++ b/tests/test_load_adducts.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from matchms.filtering import load_adducts_dict, load_known_adduct_conversions
 from matchms.filtering.load_adducts import _convert_and_fill_dict
 
@@ -10,10 +10,10 @@ def test_load_adducts_dict():
     assert "[M+2H+Na]3+" in known_adducts, "Expected adduct to be in dictionary"
     assert "[M+CH3COO]-" in known_adducts, "Expected adduct to be in dictionary"
     assert known_adducts["[M+2H+Na]3+"]["charge"] == 3, "Expected different entry"
-    assert numpy.all([(key[0] == "[") for key in known_adducts]), \
+    assert np.all([(key[0] == "[") for key in known_adducts]), \
         "Expected all keys to start with '['."
     assert known_adducts["[M]+"]["charge"] == 1, "Expected different added entry"
-    assert numpy.allclose(known_adducts["[M]-"]["correction_mass"], -1.007276, atol=1e-5), \
+    assert np.allclose(known_adducts["[M]-"]["correction_mass"], -1.007276, atol=1e-5), \
         "Expected different added entry"
 
 
@@ -28,7 +28,7 @@ def test_convert_and_fill_dict():
     assert isinstance(converted_dict["[M]+"], dict), "Expected dictionary"
     assert converted_dict["[M]+"]["charge"] == -1, "Expected charge of -1"
     assert converted_dict["[M]+"]["mass_multiplier"] == 1, "Expected mass_multiplier of 1"
-    assert numpy.allclose(converted_dict["[M]+"]["correction_mass"], -1.007276, atol=1e-5), \
+    assert np.allclose(converted_dict["[M]+"]["correction_mass"], -1.007276, atol=1e-5), \
         "Expected correction_mass to be changed to -1.007276"
 
 

--- a/tests/test_make_charge_int.py
+++ b/tests/test_make_charge_int.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import make_charge_int
 from .builder_Spectrum import SpectrumBuilder
@@ -16,8 +16,8 @@ from .builder_Spectrum import SpectrumBuilder
                                                             ('2-', -2)])
 def test_make_charge_int(input_charge, corrected_charge):
     """Test if example inputs are correctly converted"""
-    mz = numpy.array([100, 200.])
-    intensities = numpy.array([0.7, 0.1])
+    mz = np.array([100, 200.])
+    intensities = np.array([0.7, 0.1])
     metadata = {'charge': input_charge}
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(
         intensities).with_metadata(metadata).build()

--- a/tests/test_make_charge_scalar.py
+++ b/tests/test_make_charge_scalar.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import make_charge_scalar
 from .builder_Spectrum import SpectrumBuilder
@@ -13,8 +13,8 @@ from .builder_Spectrum import SpectrumBuilder
 ])
 def test_make_charge_scalar(input_charge, corrected_charge):
     """Test if example inputs are correctly converted"""
-    mz = numpy.array([100, 200.])
-    intensities = numpy.array([0.7, 0.1])
+    mz = np.array([100, 200.])
+    intensities = np.array([0.7, 0.1])
     metadata = {'charge': input_charge}
     spectrum_in = SpectrumBuilder().with_metadata(
         metadata).with_mz(mz).with_intensities(intensities).build()

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -3,7 +3,7 @@ from contextlib import nullcontext
 from importlib import reload
 from importlib.util import find_spec
 from unittest import mock
-import numpy
+import numpy as np
 import pytest
 import matchms.metadata_utils
 from matchms.metadata_utils import (clean_adduct,
@@ -134,8 +134,8 @@ def test_derive_fingerprint_from_smiles():
     pytest.importorskip("rdkit")
 
     fingerprint = derive_fingerprint_from_smiles("[C+]#C[O-]", "daylight", 16)
-    expected_fingerprint = numpy.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
-    assert numpy.all(fingerprint == expected_fingerprint), "Expected different fingerprint."
+    expected_fingerprint = np.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
+    assert np.all(fingerprint == expected_fingerprint), "Expected different fingerprint."
 
 
 def test_derive_fingerprint_from_inchi():
@@ -143,8 +143,8 @@ def test_derive_fingerprint_from_inchi():
     pytest.importorskip("rdkit")
 
     fingerprint = derive_fingerprint_from_inchi("InChI=1S/C2O/c1-2-3", "daylight", 16)
-    expected_fingerprint = numpy.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
-    assert numpy.all(fingerprint == expected_fingerprint), "Expected different fingerprint."
+    expected_fingerprint = np.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0])
+    assert np.all(fingerprint == expected_fingerprint), "Expected different fingerprint."
 
 
 def test_derive_fingerprint_different_types_from_smiles():
@@ -153,15 +153,15 @@ def test_derive_fingerprint_different_types_from_smiles():
 
     types = ["daylight", "morgan1", "morgan2", "morgan3"]
     expected_fingerprints = [
-        numpy.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0]),
-        numpy.array([0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1]),
-        numpy.array([0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1]),
-        numpy.array([0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1])
+        np.array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0]),
+        np.array([0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1]),
+        np.array([0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1]),
+        np.array([0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1])
     ]
 
     for i, fingerprint_type in enumerate(types):
         fingerprint = derive_fingerprint_from_smiles("[C+]#C[O-]", fingerprint_type, 16)
-        assert numpy.all(fingerprint == expected_fingerprints[i]), "Expected different fingerprint."
+        assert np.all(fingerprint == expected_fingerprints[i]), "Expected different fingerprint."
 
 
 def test_missing_rdkit_module_error(reload_metadata_utils):

--- a/tests/test_normalize_intensities.py
+++ b/tests/test_normalize_intensities.py
@@ -1,11 +1,11 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import add_losses, normalize_intensities
 from .builder_Spectrum import SpectrumBuilder
 
 
 @pytest.mark.parametrize("mz, intensities", [
-    [numpy.array([10, 20, 30, 40], dtype='float'), numpy.array([0, 1, 10, 100], dtype='float')]
+    [np.array([10, 20, 30, 40], dtype='float'), np.array([0, 1, 10, 100], dtype='float')]
 ])
 def test_normalize_intensities(mz, intensities):
     """Test if peak intensities are normalized correctly."""
@@ -14,13 +14,13 @@ def test_normalize_intensities(mz, intensities):
     spectrum = normalize_intensities(spectrum_in)
 
     assert max(spectrum.peaks.intensities) == 1.0, "Expected the spectrum to be scaled to 1.0."
-    assert numpy.array_equal(spectrum.peaks.intensities, intensities/100), "Expected different intensities"
-    assert numpy.array_equal(spectrum.peaks.mz, mz), "Expected different peak mz."
+    assert np.array_equal(spectrum.peaks.intensities, intensities/100), "Expected different intensities"
+    assert np.array_equal(spectrum.peaks.mz, mz), "Expected different peak mz."
 
 
 @pytest.mark.parametrize("mz, intensities, metadata, expected_losses", [
-    [numpy.array([10, 20, 30, 40], dtype='float'), numpy.array([0, 1, 10, 100], dtype='float'),
-     {"precursor_mz": 45.0}, numpy.array([1., 0.1, 0.01, 0.], dtype='float')]
+    [np.array([10, 20, 30, 40], dtype='float'), np.array([0, 1, 10, 100], dtype='float'),
+     {"precursor_mz": 45.0}, np.array([1., 0.1, 0.01, 0.], dtype='float')]
 ])
 def test_normalize_intensities_losses_present(mz, intensities, metadata, expected_losses):
     """Test if also losses (if present) are normalized correctly."""
@@ -31,9 +31,9 @@ def test_normalize_intensities_losses_present(mz, intensities, metadata, expecte
     spectrum = normalize_intensities(spectrum)
 
     assert max(spectrum.peaks.intensities) == 1.0, "Expected the spectrum to be scaled to 1.0."
-    assert numpy.array_equal(spectrum.peaks.intensities, intensities/100), "Expected different intensities"
+    assert np.array_equal(spectrum.peaks.intensities, intensities/100), "Expected different intensities"
     assert max(spectrum.losses.intensities) == 1.0, "Expected the losses to be scaled to 1.0."
-    assert numpy.all(spectrum.losses.intensities == expected_losses), "Expected different loss intensities"
+    assert np.all(spectrum.losses.intensities == expected_losses), "Expected different loss intensities"
 
 
 def test_normalize_intensities_empty_peaks():
@@ -47,8 +47,8 @@ def test_normalize_intensities_empty_peaks():
 
 def test_normalize_intensities_all_zeros(caplog):
     """Test if non-sense intensities are handled correctly."""
-    mz = numpy.array([10, 20, 30], dtype='float')
-    intensities = numpy.array([0, 0, 0], dtype='float')
+    mz = np.array([10, 20, 30], dtype='float')
+    intensities = np.array([0, 0, 0], dtype='float')
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
 
     spectrum = normalize_intensities(spectrum_in)

--- a/tests/test_reduce_to_number_of_peaks.py
+++ b/tests/test_reduce_to_number_of_peaks.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import reduce_to_number_of_peaks
@@ -9,8 +9,8 @@ from .builder_Spectrum import SpectrumBuilder
 
 @pytest.mark.parametrize("metadata", [{}, {"parent_mass": 50}])
 def test_reduce_to_number_of_peaks_no_changes(metadata):
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 1, 10, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(
         intensities).with_metadata(metadata).build()
 
@@ -20,13 +20,13 @@ def test_reduce_to_number_of_peaks_no_changes(metadata):
 
 
 @pytest.mark.parametrize("mz, intensities, metadata, params, expected", [
-    [numpy.array([10, 20, 30, 40, 50], dtype="float"), numpy.array([1, 1, 10, 20, 100], dtype="float"), {},
+    [np.array([10, 20, 30, 40, 50], dtype="float"), np.array([1, 1, 10, 20, 100], dtype="float"), {},
         [1, 4, None], [20., 30., 40., 50.]],
-    [numpy.array([10, 20, 30, 40], dtype="float"), numpy.array([0, 1, 10, 100], dtype="float"), {"parent_mass": 20},
+    [np.array([10, 20, 30, 40], dtype="float"), np.array([0, 1, 10, 100], dtype="float"), {"parent_mass": 20},
         [2, 4, 0.1], [30., 40.]],
-    [numpy.array([10, 20, 30, 40], dtype="float"), numpy.array([0, 1, 10, 100], dtype="float"), {"parent_mass": 20},
+    [np.array([10, 20, 30, 40], dtype="float"), np.array([0, 1, 10, 100], dtype="float"), {"parent_mass": 20},
         [3, 4, 0.1], [20., 30., 40.]],
-    [numpy.array([10, 20, 30, 40, 50, 60], dtype="float"), numpy.array([1, 1, 10, 100, 50, 20], dtype="float"), {"parent_mass": 60},
+    [np.array([10, 20, 30, 40, 50, 60], dtype="float"), np.array([1, 1, 10, 100, 50, 20], dtype="float"), {"parent_mass": 60},
         [3, 4, 0.1], [30., 40., 50., 60.]]
 ])
 def test_reduce_to_number_of_peaks(mz, intensities, metadata, params, expected):
@@ -44,8 +44,8 @@ def test_reduce_to_number_of_peaks(mz, intensities, metadata, params, expected):
 def test_reduce_to_number_of_peaks_set_to_none():
     """Test is spectrum is set to None if not enough peaks."""
     set_matchms_logger_level("INFO")
-    mz = numpy.array([10, 20], dtype="float")
-    intensities = numpy.array([0.5, 1], dtype="float")
+    mz = np.array([10, 20], dtype="float")
+    intensities = np.array([0.5, 1], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).with_metadata({"parent_mass": 50}).build()
 
     with LogCapture() as log:
@@ -60,22 +60,22 @@ def test_reduce_to_number_of_peaks_set_to_none():
 
 def test_reduce_to_number_of_peaks_n_max_4():
     """Test setting n_max parameter."""
-    mz = numpy.array([10, 20, 30, 40, 50], dtype="float")
-    intensities = numpy.array([1, 1, 10, 20, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40, 50], dtype="float")
+    intensities = np.array([1, 1, 10, 20, 100], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
 
     spectrum = reduce_to_number_of_peaks(spectrum_in, n_max=4)
 
-    expected = numpy.array([20, 30, 40, 50], dtype="float")
+    expected = np.array([20, 30, 40, 50], dtype="float")
 
     assert len(spectrum.peaks) == len(expected), "Expected that only 4 peaks remain."
-    numpy.testing.assert_array_equal(spectrum.peaks.mz, expected, err_msg="Expected different peaks to remain.")
+    np.testing.assert_array_equal(spectrum.peaks.mz, expected, err_msg="Expected different peaks to remain.")
 
 
 def test_reduce_to_number_of_peaks_ratio_given_but_no_parent_mass():
     """A ratio_desired given without parent_mass should raise an exception."""
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 1, 10, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(
         intensities).build()
     with pytest.raises(Exception) as msg:
@@ -87,8 +87,8 @@ def test_reduce_to_number_of_peaks_ratio_given_but_no_parent_mass():
 
 def test_reduce_to_number_of_peaks_desired_5_check_sorting():
     """Check if mz and intensities order is sorted correctly """
-    mz = numpy.array([10, 20, 30, 40, 50, 60], dtype="float")
-    intensities = numpy.array([5, 1, 4, 3, 100, 2], dtype="float")
+    mz = np.array([10, 20, 30, 40, 50, 60], dtype="float")
+    intensities = np.array([5, 1, 4, 3, 100, 2], dtype="float")
     metadata = {"parent_mass": 20}
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(
         intensities).with_metadata(metadata).build()

--- a/tests/test_remove_peaks_around_precursor_mz.py
+++ b/tests/test_remove_peaks_around_precursor_mz.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import remove_peaks_around_precursor_mz
 from .builder_Spectrum import SpectrumBuilder
@@ -6,8 +6,8 @@ from .builder_Spectrum import SpectrumBuilder
 
 @pytest.fixture
 def spectrum_in():
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 1, 10, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
     metadata = {"precursor_mz": 60.}
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(
         intensities).with_metadata(metadata).build()

--- a/tests/test_remove_peaks_outside_top_k.py
+++ b/tests/test_remove_peaks_outside_top_k.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import remove_peaks_outside_top_k
 from .builder_Spectrum import SpectrumBuilder
@@ -6,20 +6,20 @@ from .builder_Spectrum import SpectrumBuilder
 
 @pytest.mark.parametrize("peaks, k, mz_window, expected", [
     [
-        [numpy.array([1, 25, 60, 70, 80, 90, 100, 110], dtype="float"), numpy.array(
+        [np.array([1, 25, 60, 70, 80, 90, 100, 110], dtype="float"), np.array(
             [10, 25, 50, 75, 100, 125, 150, 175], dtype="float")],
         6, 50, [25., 60., 70., 80., 90., 100., 110.]
     ], [
-        [numpy.array([1, 25, 60, 70, 80], dtype="float"), numpy.array(
-            [10, 25, 50, 75, 100], dtype="float")], 6, 50, numpy.array([1, 25, 60, 70, 80], dtype="float")
+        [np.array([1, 25, 60, 70, 80], dtype="float"), np.array(
+            [10, 25, 50, 75, 100], dtype="float")], 6, 50, np.array([1, 25, 60, 70, 80], dtype="float")
     ], [
-        [numpy.array([1, 25, 60, 70, 80, 90], dtype="float"), numpy.array(
-            [10, 25, 50, 75, 100, 125], dtype="float")], 6, 50, numpy.array([1, 25, 60, 70, 80, 90], dtype="float")
+        [np.array([1, 25, 60, 70, 80, 90], dtype="float"), np.array(
+            [10, 25, 50, 75, 100, 125], dtype="float")], 6, 50, np.array([1, 25, 60, 70, 80, 90], dtype="float")
     ], [
-        [numpy.array([1, 20, 30, 50, 55, 90, 100, 110], dtype="float"), numpy.array(
+        [np.array([1, 20, 30, 50, 55, 90, 100, 110], dtype="float"), np.array(
             [10, 25, 50, 75, 100, 125, 150, 175], dtype="float")], 3, 50, [50., 55., 90., 100., 110.]
     ], [
-        [numpy.array([1, 10, 30, 40, 50, 60, 70, 80], dtype="float"), numpy.array(
+        [np.array([1, 10, 30, 40, 50, 60, 70, 80], dtype="float"), np.array(
             [10, 25, 50, 75, 100, 125, 150, 175], dtype="float")], 6, 10, [30., 40., 50., 60., 70., 80.]
     ]
 ])
@@ -33,14 +33,14 @@ def test_remove_peaks_outside_top_k(peaks, k, mz_window, expected):
     num_peaks = len(expected)
     assert len(
         spectrum.peaks) == num_peaks, "Expected ${num_peaks} peaks to remain."
-    numpy.testing.assert_array_equal(
+    np.testing.assert_array_equal(
         spectrum.peaks.mz, expected, err_msg="Expected different peaks to remain.")
 
 
 def test_remove_peaks_outside_top_k_no_params_check_sorting():
     """Check sorting of mzs and intensities with default parameters."""
-    mz = numpy.array([100, 270, 300, 400, 500, 600, 700, 710, 720, 1000], dtype="float")
-    intensities = numpy.array([100, 200, 50, 175, 10, 125, 150, 75, 25, 1], dtype="float")
+    mz = np.array([100, 270, 300, 400, 500, 600, 700, 710, 720, 1000], dtype="float")
+    intensities = np.array([100, 200, 50, 175, 10, 125, 150, 75, 25, 1], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
 
     spectrum = remove_peaks_outside_top_k(spectrum_in)

--- a/tests/test_require_minimum_number_of_peaks.py
+++ b/tests/test_require_minimum_number_of_peaks.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import require_minimum_number_of_peaks
 from matchms.typing import SpectrumType
@@ -7,8 +7,8 @@ from .builder_Spectrum import SpectrumBuilder
 
 @pytest.fixture
 def spectrum_in():
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 1, 10, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
     metadata = dict(parent_mass=10)
     return SpectrumBuilder().with_mz(mz).with_intensities(intensities).with_metadata(metadata).build()
 

--- a/tests/test_require_minimum_of_high_peaks.py
+++ b/tests/test_require_minimum_of_high_peaks.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import require_minimum_of_high_peaks
 from .builder_Spectrum import SpectrumBuilder
@@ -6,18 +6,18 @@ from .builder_Spectrum import SpectrumBuilder
 
 @pytest.mark.parametrize("peaks, no_peaks, intensity_percent, expected", [
     [
-        [numpy.array([10, 20, 30, 40], dtype="float"), numpy.array(
+        [np.array([10, 20, 30, 40], dtype="float"), np.array(
             [0, 1, 10, 100], dtype="float")], 2, 2,
-        SpectrumBuilder().with_mz(numpy.array([10, 20, 30, 40], dtype="float")).with_intensities(
-            numpy.array([0, 1, 10, 100], dtype="float")).build()
+        SpectrumBuilder().with_mz(np.array([10, 20, 30, 40], dtype="float")).with_intensities(
+            np.array([0, 1, 10, 100], dtype="float")).build()
     ], [
-        [numpy.array([10, 20, 30, 40], dtype="float"), numpy.array(
+        [np.array([10, 20, 30, 40], dtype="float"), np.array(
             [0, 1, 10, 100], dtype="float")], 5, 2, None
     ], [
-        [numpy.array([10, 20, 30, 40, 50, 60, 70], dtype="float"),
-         numpy.array([0, 1, 10, 25, 50, 75, 100], dtype="float")],
-        2, 10, SpectrumBuilder().with_mz(numpy.array([10, 20, 30, 40, 50, 60, 70], dtype="float")).with_intensities(
-            numpy.array([0, 1, 10, 25, 50, 75, 100], dtype="float")).build()
+        [np.array([10, 20, 30, 40, 50, 60, 70], dtype="float"),
+         np.array([0, 1, 10, 25, 50, 75, 100], dtype="float")],
+        2, 10, SpectrumBuilder().with_mz(np.array([10, 20, 30, 40, 50, 60, 70], dtype="float")).with_intensities(
+            np.array([0, 1, 10, 25, 50, 75, 100], dtype="float")).build()
     ]
 ])
 def test_require_mininum_of_high_peaks(peaks, no_peaks, intensity_percent, expected):
@@ -32,8 +32,8 @@ def test_require_mininum_of_high_peaks(peaks, no_peaks, intensity_percent, expec
 
 def test_if_spectrum_is_cloned():
     """Test if filter is correctly cloning the input spectrum."""
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 1, 10, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
 
     spectrum = require_minimum_of_high_peaks(spectrum_in, no_peaks=2)

--- a/tests/test_require_precursor_below_mz.py
+++ b/tests/test_require_precursor_below_mz.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import require_precursor_below_mz
@@ -57,8 +57,8 @@ def test_with_input_none():
 
 def test_require_precursor_below_mz_no_params():
     """Using default parameterse with precursor mz present."""
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 1, 10, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
     spectrum_in.set("precursor_mz", 60.)
 
@@ -70,8 +70,8 @@ def test_require_precursor_below_mz_no_params():
 def test_require_precursor_below_mz_max_50():
     """Set max_mz to 50."""
     set_matchms_logger_level("INFO")
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 1, 10, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
     spectrum_in.set("precursor_mz", 60.)
 

--- a/tests/test_require_precursor_mz.py
+++ b/tests/test_require_precursor_mz.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering.require_precursor_mz import require_precursor_mz
@@ -54,8 +54,8 @@ def test_require_precursor_mz_with_input_none():
 def test_require_precursor_mz_fail_when_mz_too_small(precursor_mz):
     """Test if spectrum is None when precursor_mz <= minimum_accepted_mz"""
     set_matchms_logger_level("INFO")
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 1, 10, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
     spectrum_in.set("precursor_mz", precursor_mz)
 
@@ -71,8 +71,8 @@ def test_require_precursor_mz_fail_when_mz_too_small(precursor_mz):
 
 def test_require_precursor_mz_fail_because_below_zero():
     """Test if spectrum is None when precursor_mz < 0"""
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([0, 1, 10, 100], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
     spectrum_in = SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
     spectrum_in.set("precursor_mz", -3.5)
 

--- a/tests/test_save_as_json_load_from_json.py
+++ b/tests/test_save_as_json_load_from_json.py
@@ -1,6 +1,6 @@
 import json
 import os
-import numpy
+import numpy as np
 import pytest
 from matchms.exporting import save_as_json
 from matchms.importing import load_from_json
@@ -9,8 +9,8 @@ from tests.builder_Spectrum import SpectrumBuilder
 
 @pytest.fixture
 def builder() -> SpectrumBuilder:
-    mz = numpy.array([100, 200, 300], dtype="float")
-    intensities = numpy.array([10, 10, 500], dtype="float")
+    mz = np.array([100, 200, 300], dtype="float")
+    intensities = np.array([10, 10, 500], dtype="float")
     builder = SpectrumBuilder().with_mz(mz).with_intensities(intensities)
     return builder
 

--- a/tests/test_save_as_mgf.py
+++ b/tests/test_save_as_mgf.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-import numpy
+import numpy as np
 import pytest
 from matchms.exporting import save_as_mgf
 from matchms.importing import load_from_mgf
@@ -17,8 +17,8 @@ def load_test_spectra_file(test_filename):
 def test_save_as_mgf_single_spectrum():
     """Test saving spectrum to .mgf file"""
     spectrum = SpectrumBuilder().with_mz(
-        numpy.array([100, 200, 300], dtype="float")).with_intensities(
-            numpy.array([10, 10, 500], dtype="float")).with_metadata(
+        np.array([100, 200, 300], dtype="float")).with_intensities(
+            np.array([10, 10, 500], dtype="float")).with_metadata(
                 {"charge": -1,
                  "inchi": '"InChI=1S/C6H12"',
                  "pepmass": (100, 10.0),
@@ -44,8 +44,8 @@ def test_save_as_mgf_single_spectrum():
 
 def test_save_as_mgf_spectrum_list():
     """Test saving spectrum list to .mgf file"""
-    mz = numpy.array([100, 200, 300], dtype="float")
-    intensities = numpy.array([10, 10, 500], dtype="float")
+    mz = np.array([100, 200, 300], dtype="float")
+    intensities = np.array([10, 10, 500], dtype="float")
     builder = SpectrumBuilder().with_mz(mz).with_intensities(intensities)
     spectrum1 = builder.with_metadata({"test_field": "test1"},
                                       metadata_harmonization=False).build()
@@ -74,8 +74,8 @@ def test_save_as_mgf_spectrum_list():
                           (None, "n/a", 250)])
 def test_save_load_mgf_consistency(tmpdir, charge, ionmode, parent_mass):
     """Test saving and loading spectrum to .mgf file"""
-    mz = numpy.array([100.1, 200.02, 300.003], dtype="float")
-    intensities = numpy.array([0.01, 0.02, 1.0], dtype="float")
+    mz = np.array([100.1, 200.02, 300.003], dtype="float")
+    intensities = np.array([0.01, 0.02, 1.0], dtype="float")
     metadata = {"precursor_mz": 200.5,
                 "charge": charge,
                 "ionmode": ionmode,

--- a/tests/test_save_as_msp.py
+++ b/tests/test_save_as_msp.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 from typing import List
-import numpy
+import numpy as np
 import pytest
 from matchms import Spectrum
 from matchms.exporting import save_as_msp
@@ -16,8 +16,8 @@ def none_spectrum():
 
 @pytest.fixture
 def spectrum():
-    mz = numpy.array([100, 200, 290, 490, 510], dtype="float")
-    intensities = numpy.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")
+    mz = np.array([100, 200, 290, 490, 510], dtype="float")
+    intensities = np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float")
     return SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
 
 

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-import numpy
+import numpy as np
 import pytest
 from matchms import Scores, calculate_scores
 from matchms.similarity import CosineGreedy, IntersectMz
@@ -10,7 +10,7 @@ from .builder_Spectrum import SpectrumBuilder
 
 class DummySimilarityFunction(BaseSimilarity):
     """Simple dummy score, only contain pair-wise implementation."""
-    score_datatype = [("score", numpy.unicode_, 16), ("len", numpy.int32)]
+    score_datatype = [("score", np.unicode_, 16), ("len", np.int32)]
 
     def __init__(self):
         """constructor"""
@@ -18,12 +18,12 @@ class DummySimilarityFunction(BaseSimilarity):
     def pair(self, reference, query):
         """necessary pair computation method"""
         s = reference + query
-        return numpy.array([(s, len(s))], dtype=self.score_datatype)
+        return np.array([(s, len(s))], dtype=self.score_datatype)
 
 
 class DummySimilarityFunctionParallel(BaseSimilarity):
     """Simple dummy score, contains pair-wise and matrix implementation."""
-    score_datatype = [("score", numpy.unicode_, 16), ("len", "int")]
+    score_datatype = [("score", np.unicode_, 16), ("len", "int")]
 
     def __init__(self):
         """constructor"""
@@ -31,12 +31,12 @@ class DummySimilarityFunctionParallel(BaseSimilarity):
     def pair(self, reference, query):
         """necessary pair computation method"""
         s = reference + query
-        return numpy.array([(s, len(s))], dtype=self.score_datatype)
+        return np.array([(s, len(s))], dtype=self.score_datatype)
 
     def matrix(self, references, queries, is_symmetric: bool = False):
         """additional matrix computation method"""
         shape = len(references), len(queries)
-        s = numpy.empty(shape, dtype=self.score_datatype)
+        s = np.empty(shape, dtype=self.score_datatype)
         for index_reference, reference in enumerate(references):
             for index_query, query in enumerate(queries):
                 rq = reference + query
@@ -57,14 +57,14 @@ def filename(file_format):
 
 def spectra():
     builder = SpectrumBuilder()
-    spectrum_1 = builder.with_mz(numpy.array([100, 150, 200.])).with_intensities(
-        numpy.array([0.7, 0.2, 0.1])).with_metadata({'id': 'spectrum1'}).build()
-    spectrum_2 = builder.with_mz(numpy.array([100, 140, 190.])).with_intensities(
-        numpy.array([0.4, 0.2, 0.1])).with_metadata({'id': 'spectrum2'}).build()
-    spectrum_3 = builder.with_mz(numpy.array([110, 140, 195.])).with_intensities(
-        numpy.array([0.6, 0.2, 0.1])).with_metadata({'id': 'spectrum3'}).build()
-    spectrum_4 = builder.with_mz(numpy.array([100, 150, 200.])).with_intensities(
-        numpy.array([0.6, 0.1, 0.6])).with_metadata({'id': 'spectrum4'}).build()
+    spectrum_1 = builder.with_mz(np.array([100, 150, 200.])).with_intensities(
+        np.array([0.7, 0.2, 0.1])).with_metadata({'id': 'spectrum1'}).build()
+    spectrum_2 = builder.with_mz(np.array([100, 140, 190.])).with_intensities(
+        np.array([0.4, 0.2, 0.1])).with_metadata({'id': 'spectrum2'}).build()
+    spectrum_3 = builder.with_mz(np.array([110, 140, 195.])).with_intensities(
+        np.array([0.6, 0.2, 0.1])).with_metadata({'id': 'spectrum3'}).build()
+    spectrum_4 = builder.with_mz(np.array([100, 150, 200.])).with_intensities(
+        np.array([0.6, 0.1, 0.6])).with_metadata({'id': 'spectrum4'}).build()
 
     return spectrum_1, spectrum_2, spectrum_3, spectrum_4
 
@@ -77,7 +77,7 @@ def test_scores_single_pair():
                     similarity_function=dummy_similarity_function)
     scores.calculate()
     actual = scores.scores[0][0]
-    expected = numpy.array([('AB', 2)], dtype=dummy_similarity_function.score_datatype)
+    expected = np.array([('AB', 2)], dtype=dummy_similarity_function.score_datatype)
     assert actual == expected, "Expected different scores."
 
 
@@ -89,12 +89,12 @@ def test_scores_calculate():
     scores.calculate()
     actual = list(scores)
     expected = [
-        ("r0", "q0", numpy.array([("r0q0", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r0", "q1", numpy.array([("r0q1", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r1", "q0", numpy.array([("r1q0", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r1", "q1", numpy.array([("r1q1", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r2", "q0", numpy.array([("r2q0", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r2", "q1", numpy.array([("r2q1", 4)], dtype=dummy_similarity_function.score_datatype))
+        ("r0", "q0", np.array([("r0q0", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r0", "q1", np.array([("r0q1", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r1", "q0", np.array([("r1q0", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r1", "q1", np.array([("r1q1", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r2", "q0", np.array([("r2q0", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r2", "q1", np.array([("r2q1", 4)], dtype=dummy_similarity_function.score_datatype))
     ]
     assert actual == expected, "Expected different scores."
 
@@ -107,12 +107,12 @@ def test_scores_calculate_parallel():
     scores.calculate()
     actual = list(scores)
     expected = [
-        ("r0", "q0", numpy.array([("r0q0", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r0", "q1", numpy.array([("r0q1", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r1", "q0", numpy.array([("r1q0", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r1", "q1", numpy.array([("r1q1", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r2", "q0", numpy.array([("r2q0", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("r2", "q1", numpy.array([("r2q1", 4)], dtype=dummy_similarity_function.score_datatype))
+        ("r0", "q0", np.array([("r0q0", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r0", "q1", np.array([("r0q1", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r1", "q0", np.array([("r1q0", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r1", "q1", np.array([("r1q1", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r2", "q0", np.array([("r2q0", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("r2", "q1", np.array([("r2q1", 4)], dtype=dummy_similarity_function.score_datatype))
     ]
     assert actual == expected, "Expected different scores."
 
@@ -127,8 +127,8 @@ def test_scores_init_with_list():
 
 def test_scores_init_with_numpy_array():
     dummy_similarity_function = DummySimilarityFunction()
-    scores = Scores(references=numpy.asarray(["r0", "r1", "r2"]),
-                    queries=numpy.asarray(["q0", "q1"]),
+    scores = Scores(references=np.asarray(["r0", "r1", "r2"]),
+                    queries=np.asarray(["q0", "q1"]),
                     similarity_function=dummy_similarity_function)
     assert scores.scores.shape == (3, 2), "Expected different scores shape."
 
@@ -140,7 +140,7 @@ def test_scores_init_with_queries_dict():
                    queries=dict(k0="q0", k1="q1"),
                    similarity_function=dummy_similarity_function)
 
-    assert str(msg.value) == "Expected input argument 'queries' to be list or tuple or numpy.ndarray."
+    assert str(msg.value) == "Expected input argument 'queries' to be list or tuple or np.ndarray."
 
 
 def test_scores_init_with_references_dict():
@@ -150,7 +150,7 @@ def test_scores_init_with_references_dict():
                    queries=["q0", "q1"],
                    similarity_function=dummy_similarity_function)
 
-    assert str(msg.value) == "Expected input argument 'references' to be list or tuple or numpy.ndarray."
+    assert str(msg.value) == "Expected input argument 'references' to be list or tuple or np.ndarray."
 
 
 def test_scores_init_with_tuple():
@@ -169,12 +169,12 @@ def test_scores_next():
 
     actual = list(scores)
     expected = [
-        ("r", "q", numpy.array([("rq", 2)], dtype=dummy_similarity_function.score_datatype)),
-        ("r", "qq", numpy.array([("rqq", 3)], dtype=dummy_similarity_function.score_datatype)),
-        ("rr", "q", numpy.array([("rrq", 3)], dtype=dummy_similarity_function.score_datatype)),
-        ("rr", "qq", numpy.array([("rrqq", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("rrr", "q", numpy.array([("rrrq", 4)], dtype=dummy_similarity_function.score_datatype)),
-        ("rrr", "qq", numpy.array([("rrrqq", 5)], dtype=dummy_similarity_function.score_datatype))
+        ("r", "q", np.array([("rq", 2)], dtype=dummy_similarity_function.score_datatype)),
+        ("r", "qq", np.array([("rqq", 3)], dtype=dummy_similarity_function.score_datatype)),
+        ("rr", "q", np.array([("rrq", 3)], dtype=dummy_similarity_function.score_datatype)),
+        ("rr", "qq", np.array([("rrqq", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("rrr", "q", np.array([("rrrq", 4)], dtype=dummy_similarity_function.score_datatype)),
+        ("rrr", "qq", np.array([("rrrqq", 5)], dtype=dummy_similarity_function.score_datatype))
     ]
     assert actual == expected, "Expected different scores."
 
@@ -203,9 +203,9 @@ def test_scores_by_reference_sorted():
 
     expected_result = [(scores.queries[i], scores.scores[1, i]) for i in [2, 1, 0]]
     assert selected_scores == expected_result, "Expected different scores."
-    scores_only = numpy.array([x[1]["score"] for x in selected_scores])
-    scores_expected = numpy.array([1.0, 0.6129713330865563, 0.1363196353181994])
-    assert numpy.allclose(scores_only, scores_expected, atol=1e-8), \
+    scores_only = np.array([x[1]["score"] for x in selected_scores])
+    scores_expected = np.array([1.0, 0.6129713330865563, 0.1363196353181994])
+    assert np.allclose(scores_only, scores_expected, atol=1e-8), \
         "Expected different sorted scores."
 
 
@@ -238,14 +238,14 @@ def test_scores_by_query():
 def test_scores_by_query_sorted():
     "Test scores_by_query method with sort=True."
     builder = SpectrumBuilder()
-    spectrum_1 = builder.with_mz(numpy.array([100, 150, 200.])).with_intensities(
-        numpy.array([0.7, 0.2, 0.1])).with_metadata({'id': 'spectrum1'}).build()
-    spectrum_2 = builder.with_mz(numpy.array([100, 140, 190.])).with_intensities(
-        numpy.array([0.4, 0.2, 0.1])).with_metadata({'id': 'spectrum2'}).build()
-    spectrum_3 = builder.with_mz(numpy.array([100, 140, 195.])).with_intensities(
-        numpy.array([0.6, 0.2, 0.1])).with_metadata({'id': 'spectrum3'}).build()
-    spectrum_4 = builder.with_mz(numpy.array([100, 150, 200.])).with_intensities(
-        numpy.array([0.6, 0.1, 0.6])).with_metadata({'id': 'spectrum4'}).build()
+    spectrum_1 = builder.with_mz(np.array([100, 150, 200.])).with_intensities(
+        np.array([0.7, 0.2, 0.1])).with_metadata({'id': 'spectrum1'}).build()
+    spectrum_2 = builder.with_mz(np.array([100, 140, 190.])).with_intensities(
+        np.array([0.4, 0.2, 0.1])).with_metadata({'id': 'spectrum2'}).build()
+    spectrum_3 = builder.with_mz(np.array([100, 140, 195.])).with_intensities(
+        np.array([0.6, 0.2, 0.1])).with_metadata({'id': 'spectrum3'}).build()
+    spectrum_4 = builder.with_mz(np.array([100, 150, 200.])).with_intensities(
+        np.array([0.6, 0.1, 0.6])).with_metadata({'id': 'spectrum4'}).build()
 
     references = [spectrum_1, spectrum_2, spectrum_3]
     queries = [spectrum_2, spectrum_3, spectrum_4]

--- a/tests/test_scores_read_write.py
+++ b/tests/test_scores_read_write.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-import numpy
+import numpy as np
 import pytest
 import matchms.similarity
 from matchms import calculate_scores
@@ -36,22 +36,22 @@ def similarity_function(request):
 @pytest.fixture
 def spectra(similarity_function):
     builder = SpectrumBuilder()
-    spectrum_1 = builder.with_mz(numpy.array([100, 150, 200.])) \
-        .with_intensities(numpy.array([0.7, 0.2, 0.1])) \
+    spectrum_1 = builder.with_mz(np.array([100, 150, 200.])) \
+        .with_intensities(np.array([0.7, 0.2, 0.1])) \
         .with_metadata({'id': 'spectrum1', "precursor_mz": 210, "parent_mass": 210, "smiles": "CCC(C)C(C(=O)O)NC(=O)CCl"}) \
         .build()
-    spectrum_2 = builder.with_mz(numpy.array([100, 140, 190.])) \
-        .with_intensities(numpy.array([0.4, 0.2, 0.1])) \
+    spectrum_2 = builder.with_mz(np.array([100, 140, 190.])) \
+        .with_intensities(np.array([0.4, 0.2, 0.1])) \
         .with_metadata({'id': 'spectrum2', "precursor_mz": 200, "parent_mass": 200, "smiles": "CCC(C)C(C(=O)O)NC(=O)CCl"}) \
         .build()
-    spectrum_3 = builder.with_mz(numpy.array([110, 140, 195.])) \
+    spectrum_3 = builder.with_mz(np.array([110, 140, 195.])) \
         .with_intensities(
-        numpy.array([0.6, 0.2, 0.1])) \
+        np.array([0.6, 0.2, 0.1])) \
         .with_metadata({'id': 'spectrum3', "precursor_mz": 205, "parent_mass": 205, "smiles": "C(C(=O)O)(NC(=O)O)S"}) \
         .build()
-    spectrum_4 = builder.with_mz(numpy.array([100, 150, 200.])) \
+    spectrum_4 = builder.with_mz(np.array([100, 150, 200.])) \
         .with_intensities(
-        numpy.array([0.6, 0.1, 0.6])) \
+        np.array([0.6, 0.1, 0.6])) \
         .with_metadata({'id': 'spectrum4', "precursor_mz": 210, "parent_mass": 210, "smiles": "C(C(=O)O)(NC(=O)O)S"}) \
         .build()
 

--- a/tests/test_select_by_intensity.py
+++ b/tests/test_select_by_intensity.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import select_by_intensity
 from .builder_Spectrum import SpectrumBuilder
@@ -6,35 +6,35 @@ from .builder_Spectrum import SpectrumBuilder
 
 @pytest.mark.parametrize("peaks, intensity_from, intensity_to, expected", [
     [
-        [numpy.array([10, 20, 30, 40], dtype="float"),
-         numpy.array([1, 10, 100, 1000], dtype="float")],
+        [np.array([10, 20, 30, 40], dtype="float"),
+         np.array([1, 10, 100, 1000], dtype="float")],
         10, 200,
-        [numpy.array([20, 30], dtype="float"),
-         numpy.array([10, 100], dtype="float")]
+        [np.array([20, 30], dtype="float"),
+         np.array([10, 100], dtype="float")]
     ], [
-       [numpy.array([998, 999, 1000, 1001, 1002], dtype="float"),
-        numpy.array([198, 199, 200, 201, 202], dtype="float")],
+       [np.array([998, 999, 1000, 1001, 1002], dtype="float"),
+        np.array([198, 199, 200, 201, 202], dtype="float")],
         10, 200,
-        [numpy.array([998, 999, 1000], dtype="float"),
-         numpy.array([198, 199, 200], dtype="float")]
+        [np.array([998, 999, 1000], dtype="float"),
+         np.array([198, 199, 200], dtype="float")]
     ], [
-        [numpy.array([10, 20, 30, 40], dtype="float"),
-         numpy.array([1, 10, 100, 1000], dtype="float")],
+        [np.array([10, 20, 30, 40], dtype="float"),
+         np.array([1, 10, 100, 1000], dtype="float")],
         15, 200,
-        [numpy.array([30], dtype="float"),
-         numpy.array([100], dtype="float")]
+        [np.array([30], dtype="float"),
+         np.array([100], dtype="float")]
     ], [
-        [numpy.array([10, 20, 30, 40], dtype="float"),
-         numpy.array([1, 10, 100, 1000], dtype="float")],
+        [np.array([10, 20, 30, 40], dtype="float"),
+         np.array([1, 10, 100, 1000], dtype="float")],
         10, 35,
-        [numpy.array([20], dtype="float"),
-         numpy.array([10], dtype="float")]
+        [np.array([20], dtype="float"),
+         np.array([10], dtype="float")]
     ], [
-        [numpy.array([10, 20, 30, 40], dtype="float"),
-         numpy.array([1, 10, 100, 1000], dtype="float")],
+        [np.array([10, 20, 30, 40], dtype="float"),
+         np.array([1, 10, 100, 1000], dtype="float")],
         15, 135,
-        [numpy.array([30], dtype="float"),
-         numpy.array([100], dtype="float")]
+        [np.array([30], dtype="float"),
+         np.array([100], dtype="float")]
     ]
 ])
 def test_select_by_intensity(peaks, intensity_from, intensity_to, expected):
@@ -43,5 +43,5 @@ def test_select_by_intensity(peaks, intensity_from, intensity_to, expected):
 
     assert spectrum.peaks.mz.size == len(expected[0])
     assert spectrum.peaks.mz.size == spectrum.peaks.intensities.size
-    assert numpy.array_equal(spectrum.peaks.mz, expected[0])
-    assert numpy.array_equal(spectrum.peaks.intensities, expected[1])
+    assert np.array_equal(spectrum.peaks.mz, expected[0])
+    assert np.array_equal(spectrum.peaks.intensities, expected[1])

--- a/tests/test_select_by_mz.py
+++ b/tests/test_select_by_mz.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms.filtering import select_by_mz
 from .builder_Spectrum import SpectrumBuilder
@@ -6,35 +6,35 @@ from .builder_Spectrum import SpectrumBuilder
 
 @pytest.mark.parametrize("peaks, mz_from, mz_to, expected", [
     [
-        [numpy.array([10, 20, 30, 40], dtype="float"),
-         numpy.array([1, 10, 100, 1000], dtype="float")],
+        [np.array([10, 20, 30, 40], dtype="float"),
+         np.array([1, 10, 100, 1000], dtype="float")],
         0, 1000,
-        [numpy.array([10, 20, 30, 40], dtype="float"),
-         numpy.array([1, 10, 100, 1000], dtype="float")]
+        [np.array([10, 20, 30, 40], dtype="float"),
+         np.array([1, 10, 100, 1000], dtype="float")]
     ], [
-        [numpy.array([998, 999, 1000, 1001, 1002], dtype="float"),
-         numpy.array([1, 10, 100, 1000, 10000], dtype="float")],
+        [np.array([998, 999, 1000, 1001, 1002], dtype="float"),
+         np.array([1, 10, 100, 1000, 10000], dtype="float")],
         0, 1000,
-        [numpy.array([998, 999, 1000], dtype="float"),
-         numpy.array([1, 10, 100], dtype="float")]
+        [np.array([998, 999, 1000], dtype="float"),
+         np.array([1, 10, 100], dtype="float")]
     ], [
-        [numpy.array([10, 20, 30, 40], dtype="float"),
-         numpy.array([1, 10, 100, 1000], dtype="float")],
+        [np.array([10, 20, 30, 40], dtype="float"),
+         np.array([1, 10, 100, 1000], dtype="float")],
         15, 1000,
-        [numpy.array([20, 30, 40], dtype="float"),
-         numpy.array([10, 100, 1000], dtype="float")]
+        [np.array([20, 30, 40], dtype="float"),
+         np.array([10, 100, 1000], dtype="float")]
     ], [
-        [numpy.array([10, 20, 30, 40], dtype="float"),
-         numpy.array([1, 10, 100, 1000], dtype="float")],
+        [np.array([10, 20, 30, 40], dtype="float"),
+         np.array([1, 10, 100, 1000], dtype="float")],
         0, 35,
-        [numpy.array([10, 20, 30], dtype="float"),
-         numpy.array([1, 10, 100], dtype="float")]
+        [np.array([10, 20, 30], dtype="float"),
+         np.array([1, 10, 100], dtype="float")]
     ], [
-        [numpy.array([10, 20, 30, 40], dtype="float"),
-         numpy.array([1, 10, 100, 1000], dtype="float")],
+        [np.array([10, 20, 30, 40], dtype="float"),
+         np.array([1, 10, 100, 1000], dtype="float")],
         15, 35,
-        [numpy.array([20, 30], dtype="float"),
-         numpy.array([10, 100], dtype="float")]
+        [np.array([20, 30], dtype="float"),
+         np.array([10, 100], dtype="float")]
     ]
 ])
 def test_select_by_mz(peaks, mz_from, mz_to, expected):
@@ -43,5 +43,5 @@ def test_select_by_mz(peaks, mz_from, mz_to, expected):
 
     assert spectrum.peaks.mz.size == len(expected[0])
     assert spectrum.peaks.mz.size == spectrum.peaks.intensities.size
-    assert numpy.array_equal(spectrum.peaks.mz, expected[0])
-    assert numpy.array_equal(spectrum.peaks.intensities, expected[1])
+    assert np.array_equal(spectrum.peaks.mz, expected[0])
+    assert np.array_equal(spectrum.peaks.intensities, expected[1])

--- a/tests/test_select_by_relative_intensity.py
+++ b/tests/test_select_by_relative_intensity.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms import Spectrum
 from matchms.filtering import select_by_relative_intensity
@@ -7,24 +7,24 @@ from .builder_Spectrum import SpectrumBuilder
 
 @pytest.fixture
 def spectrum_in() -> Spectrum:
-    mz = numpy.array([10, 20, 30, 40], dtype="float")
-    intensities = numpy.array([1, 10, 100, 1000], dtype="float")
+    mz = np.array([10, 20, 30, 40], dtype="float")
+    intensities = np.array([1, 10, 100, 1000], dtype="float")
     return SpectrumBuilder().with_mz(mz).with_intensities(intensities).build()
 
 
 @pytest.mark.parametrize("intensity_from, intensity_to, expected_mz, expected_intensities", [
-    [0, 1, numpy.array([10, 20, 30, 40], dtype="float"), numpy.array([1, 10, 100, 1000], dtype="float")],
-    [0.01, 1, numpy.array([20, 30, 40], dtype="float"), numpy.array([10, 100, 1000], dtype="float")],
-    [0, 0.99, numpy.array([10, 20, 30], dtype="float"), numpy.array([1, 10, 100], dtype="float")],
-    [0.01, 0.99, numpy.array([20, 30], dtype="float"), numpy.array([10, 100], dtype="float")]
+    [0, 1, np.array([10, 20, 30, 40], dtype="float"), np.array([1, 10, 100, 1000], dtype="float")],
+    [0.01, 1, np.array([20, 30, 40], dtype="float"), np.array([10, 100, 1000], dtype="float")],
+    [0, 0.99, np.array([10, 20, 30], dtype="float"), np.array([1, 10, 100], dtype="float")],
+    [0.01, 0.99, np.array([20, 30], dtype="float"), np.array([10, 100], dtype="float")]
 ])
 def test_select_by_relative_intensity(spectrum_in, intensity_from, intensity_to, expected_mz, expected_intensities):
     spectrum = select_by_relative_intensity(spectrum_in, intensity_from=intensity_from, intensity_to=intensity_to)
 
     assert spectrum.peaks.mz.size == len(expected_mz)
     assert spectrum.peaks.mz.size == spectrum.peaks.intensities.size
-    assert numpy.array_equal(spectrum.peaks.mz, expected_mz)
-    assert numpy.array_equal(spectrum.peaks.intensities, expected_intensities)
+    assert np.array_equal(spectrum.peaks.mz, expected_mz)
+    assert np.array_equal(spectrum.peaks.intensities, expected_intensities)
 
 
 def test_select_by_relative_intensity_with_from_parameter_too_small(spectrum_in: Spectrum):

--- a/tests/test_spectrum_builder.py
+++ b/tests/test_spectrum_builder.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import pytest
 from matchms import Spectrum
 from .builder_Spectrum import SpectrumBuilder
@@ -12,8 +12,8 @@ from .builder_Spectrum import SpectrumBuilder
 def test_spectrum_builder_only_metadata(metadata):
     spectrum_1 = SpectrumBuilder().with_metadata(metadata).build()
 
-    spectrum_2 = Spectrum(numpy.array([], dtype="float"),
-                          numpy.array([], dtype="float"),
+    spectrum_2 = Spectrum(np.array([], dtype="float"),
+                          np.array([], dtype="float"),
                           metadata,
                           metadata_harmonization=False)
     assert spectrum_1 == spectrum_2, "Spectra should be identical!"
@@ -26,8 +26,8 @@ def test_spectrum_builder_only_metadata(metadata):
 def test_spectrum_builder_all(mz, intensities, metadata):
     spectrum_1 = SpectrumBuilder().with_mz(mz).with_intensities(intensities).with_metadata(metadata).build()
 
-    spectrum_2 = Spectrum(numpy.array(mz, dtype="float"),
-                          numpy.array(intensities, dtype="float"),
+    spectrum_2 = Spectrum(np.array(mz, dtype="float"),
+                          np.array(intensities, dtype="float"),
                           metadata,
                           metadata_harmonization=False)
     assert spectrum_1 == spectrum_2, "Spectra should be identical!"

--- a/tests/test_spectrum_peak_comments.py
+++ b/tests/test_spectrum_peak_comments.py
@@ -1,15 +1,15 @@
-import numpy
+import numpy as np
 from matchms import Fragments, Spectrum
 from matchms.filtering import normalize_intensities
 
 
 def _create_test_spectrum():
-    intensities = numpy.array([1, 1, 5, 5, 5, 5, 7, 7, 7, 9, 9], dtype="float")
+    intensities = np.array([1, 1, 5, 5, 5, 5, 7, 7, 7, 9, 9], dtype="float")
     return _create_test_spectrum_with_intensities(intensities)
 
 
 def _create_test_spectrum_with_intensities(intensities):
-    mz = numpy.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110], dtype="float")
+    mz = np.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110], dtype="float")
     return Spectrum(mz=mz, intensities=intensities)
 
 
@@ -22,14 +22,14 @@ def test_peak_comments_after_filter():
 
 
 def test_reiterating_peak_comments():
-    mz = numpy.array([100.0003, 100.0004, 100.0005, 110., 200., 300., 400.0176], dtype='float')
-    intensities = numpy.array([1, 2, 3, 4, 5, 6, 7], dtype='float')
+    mz = np.array([100.0003, 100.0004, 100.0005, 110., 200., 300., 400.0176], dtype='float')
+    intensities = np.array([1, 2, 3, 4, 5, 6, 7], dtype='float')
     peak_comments = ["m/z 100.0003", None, "m/z 100.0005", "m/z 110.", "m/z 200.", "m/z 300.", "m/z 400.0176"]
     peak_comments = {mz[i]: peak_comments[i] for i in range(len(mz))}
     spectrum = Spectrum(mz=mz, intensities=intensities,
                         metadata={"peak_comments": peak_comments})
 
-    spectrum.peaks = Fragments(mz=numpy.array([100.0004, 110., 400.018], dtype='float'),
-                               intensities=numpy.array([5, 4, 7], dtype='float'))
+    spectrum.peaks = Fragments(mz=np.array([100.0004, 110., 400.018], dtype='float'),
+                               intensities=np.array([5, 4, 7], dtype='float'))
 
     assert spectrum.peak_comments == {100.0004: "m/z 100.0003; m/z 100.0005", 110.: "m/z 110.", 400.018: "m/z 400.0176"}

--- a/tests/test_spectrum_similarity_functions.py
+++ b/tests/test_spectrum_similarity_functions.py
@@ -1,6 +1,6 @@
 """Test function to collect matching peaks. Run tests both on numba compiled and
 pure Python version."""
-import numpy
+import numpy as np
 import pytest
 from matchms.similarity.spectrum_similarity_functions import (
     collect_peak_pairs, find_matches, score_best_matches)
@@ -14,10 +14,10 @@ def spectra():
     spec2 = builder.with_mz([105, 205.1, 300, 500.1]).with_intensities([0.1, 0.1, 1.0, 1.0]).build()
     return spec1.peaks.to_numpy, spec2.peaks.to_numpy
 
-    # spec1 = numpy.array([[100, 200, 300, 500],
+    # spec1 = np.array([[100, 200, 300, 500],
     #                      [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
-    # spec2 = numpy.array([[105, 205.1, 300, 500.1],
+    # spec2 = np.array([[105, 205.1, 300, 500.1],
     #                      [0.1, 0.1, 1.0, 1.0]], dtype="float").T
 
     # return spec1, spec2
@@ -43,9 +43,9 @@ def test_collect_peak_pairs(numba_compiled, shift, expected_pairs, expected_matc
     matching_pairs = func(spec1, spec2, tolerance=0.2, shift=shift)
 
     if expected_matches is not None:
-        matching_pairs = numpy.array(matching_pairs)
+        matching_pairs = np.array(matching_pairs)
         assert matching_pairs.shape == expected_matches, "Expected different number of matching peaks"
-        assert numpy.allclose(matching_pairs, numpy.array(expected_pairs), atol=1e-8), "Expected different values."
+        assert np.allclose(matching_pairs, np.array(expected_pairs), atol=1e-8), "Expected different values."
     else:
         assert matching_pairs is None, "Expected pairs to be None."
 
@@ -57,8 +57,8 @@ def test_collect_peak_pairs(numba_compiled, shift, expected_pairs, expected_matc
 ])
 def test_find_matches(numba_compiled, shift, expected_matches):
     """Test finding matches with shifted peaks."""
-    spec1_mz = numpy.array([100, 200, 300, 500], dtype="float")
-    spec2_mz = numpy.array([105, 205.1, 300, 304.99, 500.1], dtype="float")
+    spec1_mz = np.array([100, 200, 300, 500], dtype="float")
+    spec2_mz = np.array([105, 205.1, 300, 304.99, 500.1], dtype="float")
 
     func = get_function(numba_compiled, find_matches)
     matches = func(spec1_mz, spec2_mz, tolerance=0.2, shift=shift)
@@ -72,7 +72,7 @@ def test_find_matches(numba_compiled, shift, expected_matches):
                           ([[0., 0., 0.01], [1., 1., 0.01]], (0.009900990099, 2))])
 def test_score_best_matches(numba_compiled, matching_pairs, expected_score, spectra):
     """Test finding expected peak matches for given tolerance."""
-    matching_pairs = numpy.array(matching_pairs)
+    matching_pairs = np.array(matching_pairs)
     spec1, spec2 = spectra
 
     func = get_function(numba_compiled, score_best_matches)

--- a/tests/test_vector_similarity_functions.py
+++ b/tests/test_vector_similarity_functions.py
@@ -1,6 +1,6 @@
 """Test for vector similarity functions. Will run test on both numba compiled
 and fully python-based versions of functions."""
-import numpy
+import numpy as np
 import pytest
 from matchms.similarity.vector_similarity_functions import (
     cosine_similarity, cosine_similarity_matrix, dice_similarity,
@@ -9,20 +9,20 @@ from matchms.similarity.vector_similarity_functions import (
 
 def test_cosine_similarity_compiled():
     """Test cosine similarity score calculation."""
-    vector1 = numpy.array([1, 1, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([1, 1, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = cosine_similarity(vector1, vector1)
     score12 = cosine_similarity(vector1, vector2)
     score22 = cosine_similarity(vector2, vector2)
 
-    assert score12 == 2 / numpy.sqrt(2 * 4), "Expected different score."
+    assert score12 == 2 / np.sqrt(2 * 4), "Expected different score."
     assert score11 == score22 == 1.0, "Expected different score."
 
 
 def test_cosine_similarity_all_zeros_compiled():
     """Test cosine similarity score calculation with empty vector."""
-    vector1 = numpy.array([0, 0, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([0, 0, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = cosine_similarity(vector1, vector1)
     score12 = cosine_similarity(vector1, vector2)
     score22 = cosine_similarity(vector2, vector2)
@@ -33,33 +33,33 @@ def test_cosine_similarity_all_zeros_compiled():
 
 def test_cosine_similarity_matrix_compiled():
     """Test cosine similarity scores calculation."""
-    vectors1 = numpy.array([[1, 1, 0, 0],
+    vectors1 = np.array([[1, 1, 0, 0],
                             [1, 0, 1, 1]])
-    vectors2 = numpy.array([[0, 1, 1, 0],
+    vectors2 = np.array([[0, 1, 1, 0],
                             [0, 0, 1, 1]])
 
     scores = cosine_similarity_matrix(vectors1, vectors2)
-    expected_scores = numpy.array([[0.5, 0.],
+    expected_scores = np.array([[0.5, 0.],
                                    [0.40824829, 0.81649658]])
     assert scores == pytest.approx(expected_scores, 1e-7), "Expected different scores."
 
 
 def test_cosine_similarity():
     """Test cosine similarity score calculation."""
-    vector1 = numpy.array([1, 1, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([1, 1, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = cosine_similarity.py_func(vector1, vector1)
     score12 = cosine_similarity.py_func(vector1, vector2)
     score22 = cosine_similarity.py_func(vector2, vector2)
 
-    assert score12 == 2 / numpy.sqrt(2 * 4), "Expected different score."
+    assert score12 == 2 / np.sqrt(2 * 4), "Expected different score."
     assert score11 == score22 == 1.0, "Expected different score."
 
 
 def test_cosine_similarity_all_zeros():
     """Test cosine similarity score calculation with empty vector."""
-    vector1 = numpy.array([0, 0, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([0, 0, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = cosine_similarity.py_func(vector1, vector1)
     score12 = cosine_similarity.py_func(vector1, vector2)
     score22 = cosine_similarity.py_func(vector2, vector2)
@@ -70,21 +70,21 @@ def test_cosine_similarity_all_zeros():
 
 def test_cosine_similarity_matrix():
     """Test cosine similarity scores calculation."""
-    vectors1 = numpy.array([[1, 1, 0, 0],
+    vectors1 = np.array([[1, 1, 0, 0],
                             [1, 0, 1, 1]])
-    vectors2 = numpy.array([[0, 1, 1, 0],
+    vectors2 = np.array([[0, 1, 1, 0],
                             [0, 0, 1, 1]])
 
     scores = cosine_similarity_matrix.py_func(vectors1, vectors2)
-    expected_scores = numpy.array([[0.5, 0.],
+    expected_scores = np.array([[0.5, 0.],
                                    [0.40824829, 0.81649658]])
     assert scores == pytest.approx(expected_scores, 1e-7), "Expected different scores."
 
 
 def test_dice_similarity_compiled():
     """Test dice similarity score calculation."""
-    vector1 = numpy.array([1, 1, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([1, 1, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = dice_similarity(vector1, vector1)
     score12 = dice_similarity(vector1, vector2)
     score22 = dice_similarity(vector2, vector2)
@@ -95,8 +95,8 @@ def test_dice_similarity_compiled():
 
 def test_dice_similarity_all_zeros_compiled():
     """Test dice similarity score calculation with empty vector."""
-    vector1 = numpy.array([0, 0, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([0, 0, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = dice_similarity(vector1, vector1)
     score12 = dice_similarity(vector1, vector2)
     score22 = dice_similarity(vector2, vector2)
@@ -107,21 +107,21 @@ def test_dice_similarity_all_zeros_compiled():
 
 def test_dice_similarity_matrix_compiled():
     """Test dice similarity scores calculation."""
-    vectors1 = numpy.array([[1, 1, 0, 0],
+    vectors1 = np.array([[1, 1, 0, 0],
                             [0, 0, 1, 1]])
-    vectors2 = numpy.array([[0, 1, 1, 0],
+    vectors2 = np.array([[0, 1, 1, 0],
                             [1, 0, 1, 1]])
 
     scores = dice_similarity_matrix(vectors1, vectors2)
-    expected_scores = numpy.array([[0.5, 0.4],
+    expected_scores = np.array([[0.5, 0.4],
                                    [0.5, 0.8]])
     assert scores == pytest.approx(expected_scores, 1e-7), "Expected different scores."
 
 
 def test_dice_similarity():
     """Test dice similarity score calculation."""
-    vector1 = numpy.array([1, 1, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([1, 1, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = dice_similarity.py_func(vector1, vector1)
     score12 = dice_similarity.py_func(vector1, vector2)
     score22 = dice_similarity.py_func(vector2, vector2)
@@ -132,8 +132,8 @@ def test_dice_similarity():
 
 def test_dice_similarity_all_zeros():
     """Test dice similarity score calculation with empty vector."""
-    vector1 = numpy.array([0, 0, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([0, 0, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = dice_similarity.py_func(vector1, vector1)
     score12 = dice_similarity.py_func(vector1, vector2)
     score22 = dice_similarity.py_func(vector2, vector2)
@@ -144,21 +144,21 @@ def test_dice_similarity_all_zeros():
 
 def test_dice_similarity_matrix():
     """Test dice similarity scores calculation."""
-    vectors1 = numpy.array([[1, 1, 0, 0],
+    vectors1 = np.array([[1, 1, 0, 0],
                             [0, 0, 1, 1]])
-    vectors2 = numpy.array([[0, 1, 1, 0],
+    vectors2 = np.array([[0, 1, 1, 0],
                             [1, 0, 1, 1]])
 
     scores = dice_similarity_matrix.py_func(vectors1, vectors2)
-    expected_scores = numpy.array([[0.5, 0.4],
+    expected_scores = np.array([[0.5, 0.4],
                                    [0.5, 0.8]])
     assert scores == pytest.approx(expected_scores, 1e-7), "Expected different scores."
 
 
 def test_jaccard_index_compiled():
     """Test jaccard similarity score calculation."""
-    vector1 = numpy.array([1, 1, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([1, 1, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = jaccard_index(vector1, vector1)
     score12 = jaccard_index(vector1, vector2)
     score22 = jaccard_index(vector2, vector2)
@@ -169,8 +169,8 @@ def test_jaccard_index_compiled():
 
 def test_jaccard_index_all_zeros_compiled():
     """Test jaccard similarity score calculation with empty vector."""
-    vector1 = numpy.array([0, 0, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([0, 0, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = jaccard_index(vector1, vector1)
     score12 = jaccard_index(vector1, vector2)
     score22 = jaccard_index(vector2, vector2)
@@ -181,21 +181,21 @@ def test_jaccard_index_all_zeros_compiled():
 
 def test_jaccard_similarity_matrix_compiled():
     """Test jaccard similarity scores calculation."""
-    vectors1 = numpy.array([[1, 1, 0, 0],
+    vectors1 = np.array([[1, 1, 0, 0],
                             [0, 0, 1, 1]])
-    vectors2 = numpy.array([[0, 1, 1, 0],
+    vectors2 = np.array([[0, 1, 1, 0],
                             [1, 0, 1, 1]])
 
     scores = jaccard_similarity_matrix(vectors1, vectors2)
-    expected_scores = numpy.array([[1/3, 1/4],
+    expected_scores = np.array([[1/3, 1/4],
                                    [1/3, 2/3]])
     assert scores == pytest.approx(expected_scores, 1e-7), "Expected different scores."
 
 
 def test_jaccard_index():
     """Test jaccard similarity score calculation."""
-    vector1 = numpy.array([1, 1, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([1, 1, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = jaccard_index.py_func(vector1, vector1)
     score12 = jaccard_index.py_func(vector1, vector2)
     score22 = jaccard_index.py_func(vector2, vector2)
@@ -206,8 +206,8 @@ def test_jaccard_index():
 
 def test_jaccard_index_all_zeros():
     """Test jaccard similarity score calculation with empty vector."""
-    vector1 = numpy.array([0, 0, 0, 0])
-    vector2 = numpy.array([1, 1, 1, 1])
+    vector1 = np.array([0, 0, 0, 0])
+    vector2 = np.array([1, 1, 1, 1])
     score11 = jaccard_index.py_func(vector1, vector1)
     score12 = jaccard_index.py_func(vector1, vector2)
     score22 = jaccard_index.py_func(vector2, vector2)
@@ -218,12 +218,12 @@ def test_jaccard_index_all_zeros():
 
 def test_jaccard_similarity_matrix():
     """Test jaccard similarity scores calculation."""
-    vectors1 = numpy.array([[1, 1, 0, 0],
+    vectors1 = np.array([[1, 1, 0, 0],
                             [0, 0, 1, 1]])
-    vectors2 = numpy.array([[0, 1, 1, 0],
+    vectors2 = np.array([[0, 1, 1, 0],
                             [1, 0, 1, 1]])
 
     scores = jaccard_similarity_matrix.py_func(vectors1, vectors2)
-    expected_scores = numpy.array([[1/3, 1/4],
+    expected_scores = np.array([[1/3, 1/4],
                                    [1/3, 2/3]])
     assert scores == pytest.approx(expected_scores, 1e-7), "Expected different scores."


### PR DESCRIPTION
Replace `import numpy` with `import numpy as np` as is the default with Python.

Sorry, this change might annoy some developers!
But accross different branches, forks etc. both versions existed which I wanted to fix with this one-time change.