### PR TITLE
Configure SonarCloud CI to scan PRs from forks

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -49,12 +49,6 @@ jobs:
             xunit-result.xml
       - name: Check whether import statements are used consistently
         run: isort . --check-only --diff
-      - name: SonarCloud Scan
-        if: github.repository == 'matchms/matchms'
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   build_pypi:
     name: Test pypi build
@@ -217,8 +211,3 @@ jobs:
           path: |
             coverage.xml
             xunit-result.xml
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Check style against standards using prospector
         shell: bash -l {0}
         run: prospector -o grouped -o pylint:pylint-report.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coverage-report-pip
+          path: |
+            coverage.xml
+            xunit-result.xml
       - name: Check whether import statements are used consistently
         run: isort . --check-only --diff
       - name: SonarCloud Scan
@@ -102,7 +108,7 @@ jobs:
         python-version: ['3.7', '3.8', '3.9']
         exclude:
           - os: ubuntu-latest
-            python-version: 3.8 # or 3.9 when #240 is fully solved 
+            python-version: 3.8 # or 3.9 when #240 is fully solved
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -211,6 +211,12 @@ jobs:
           pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml
       - name: Correct coverage paths
         run: sed -i "s+$PWD/++g" coverage.xml
+      - uses: actions/upload-artifact@v2
+        with:
+          name: coverage-report-conda
+          path: |
+            coverage.xml
+            xunit-result.xml
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -41,12 +41,23 @@ jobs:
       - name: Check style against standards using prospector
         shell: bash -l {0}
         run: prospector -o grouped -o pylint:pylint-report.txt
+      - name: Store PR metadata in json file
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          jq -n --arg pr_number "$PR_NUMBER"\
+                --arg head_ref "$HEAD_REF"\
+                --arg base_ref "$BASE_REF"\
+            '{"pr_number": $pr_number, "head_ref": $head_ref, "base_ref": $base_ref}' > pr_metadata.json
       - uses: actions/upload-artifact@v2
         with:
-          name: coverage-report-pip
+          name: sonarcloud-data-pip
           path: |
             coverage.xml
             xunit-result.xml
+            pr_metadata.json
       - name: Check whether import statements are used consistently
         run: isort . --check-only --diff
 

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -216,9 +216,20 @@ jobs:
           pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml
       - name: Correct coverage paths
         run: sed -i "s+$PWD/++g" coverage.xml
+      - name: Store PR metadata in json file
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          jq -n --arg pr_number "$PR_NUMBER"\
+                --arg head_ref "$HEAD_REF"\
+                --arg base_ref "$BASE_REF"\
+            '{"pr_number": $pr_number, "head_ref": $head_ref, "base_ref": $base_ref}' > pr_metadata.json
       - uses: actions/upload-artifact@v2
         with:
-          name: coverage-report-conda
+          name: sonarcloud-data-conda
           path: |
             coverage.xml
             xunit-result.xml
+            pr_metadata.json

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -21,7 +21,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: CI_build.yml
-          name: coverage-report
+          name: coverage-report-pip
           path: ${{ github.workspace }}
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -34,6 +34,7 @@ jobs:
             -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
             -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
             -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+
   sonarcloud-conda:
     name: SonarCloud Scan on conda build
     runs-on: ubuntu-latest

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -17,9 +17,12 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
-      - name: Fetch coverage report
-        uses: actions/download-artifact@v2
-        # TODO: download coverage.xml from artifacts
+      - name: Fetch coverage report from artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: CI_build.yml
+          name: coverage-report
+          path: ${{ github.workspace }}
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -1,0 +1,27 @@
+name: SonarCloud Scan
+
+on:
+  workflow_run:
+    workflows: ["CI Build"]
+    types:
+      - completed
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: Fetch coverage report
+        uses: actions/download-artifact@v2
+        # TODO: download coverage.xml from artifacts
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -21,8 +21,13 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: CI_build.yml
-          name: coverage-report-pip
+          name: sonarcloud-data-pip
           path: ${{ github.workspace }}
+      - name: Get PR metadata from json
+        run: |
+            echo "PR_NUMBER=$(jq -r '.pr_number' pr_metadata.json)" >> $GITHUB_ENV
+            echo "HEAD_REF=$(jq -r '.head_ref' pr_metadata.json)" >> $GITHUB_ENV
+            echo "BASE_REF=$(jq -r '.base_ref' pr_metadata.json)" >> $GITHUB_ENV
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:
@@ -31,9 +36,9 @@ jobs:
         with:
           args: >
             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
-            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
-            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+            -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
+            -Dsonar.pullrequest.branch=${{ env.HEAD_REF }}
+            -Dsonar.pullrequest.base=${{ env.BASE_REF }}
 
   sonarcloud-conda:
     name: SonarCloud Scan on conda build

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -7,8 +7,8 @@ on:
       - completed
 
 jobs:
-  sonarcloud:
-    name: SonarCloud
+  sonarcloud-pip:
+    name: SonarCloud Scan on pip build
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     steps:
@@ -22,6 +22,33 @@ jobs:
         with:
           workflow: CI_build.yml
           name: coverage-report-pip
+          path: ${{ github.workspace }}
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+  sonarcloud-conda:
+    name: SonarCloud Scan on conda build
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: Fetch coverage report from artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: CI_build.yml
+          name: coverage-report-conda
           path: ${{ github.workspace }}
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -28,3 +28,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}

--- a/.github/workflows/SonarCloud.yml
+++ b/.github/workflows/SonarCloud.yml
@@ -54,8 +54,13 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: CI_build.yml
-          name: coverage-report-conda
+          name: sonarcloud-data-conda
           path: ${{ github.workspace }}
+      - name: Get PR metadata from json
+        run: |
+            echo "PR_NUMBER=$(jq -r '.pr_number' pr_metadata.json)" >> $GITHUB_ENV
+            echo "HEAD_REF=$(jq -r '.head_ref' pr_metadata.json)" >> $GITHUB_ENV
+            echo "BASE_REF=$(jq -r '.base_ref' pr_metadata.json)" >> $GITHUB_ENV
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:
@@ -64,6 +69,6 @@ jobs:
         with:
           args: >
             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
-            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
-            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+            -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
+            -Dsonar.pullrequest.branch=${{ env.HEAD_REF }}
+            -Dsonar.pullrequest.base=${{ env.BASE_REF }}


### PR DESCRIPTION
### Problem
The current implementation of SonarCloud job in the `CI Build` workflow disallows running scans on PRs from forks. The CI fails because it runs in an **unprivileged** mode and has no access to the secrets. 

### Workaround
Split build and scan jobs into two separate workflows **unprivileged** build and **privileged** scan:
   1. The build workflow (`CI_build.yml`) is triggered with `push` and `pull_request` events, which run in **unprivileged** mode and thus have no access to secrets. The workflow generates coverage data and PR metadata and stores it as an artifact for the following workflow.
   2. The `SonarCloud.yml` workflow uses the [`workflow_run`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) trigger and runs upon the successful finish of the build workflow. `workflow_run` event is **privileged** and thus has access to the secrets, but it will only run the CI actions from the **default** branch of the repo where it's executed, thus disallowing gaining access to secrets via changing the CI code. The workflow will fetch coverage data and PR metadata from the build workflow and run SonarCloud scan.

### Sources
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
https://community.sonarsource.com/t/how-to-use-sonarcloud-with-a-forked-repository-on-github/7363/30