### PR TITLE
Fix adduct masses (include electron mass where missing)

### DIFF
--- a/matchms/data/known_adducts_table.csv
+++ b/matchms/data/known_adducts_table.csv
@@ -1,7 +1,7 @@
 ﻿adduct,ionmode,charge,mass_multiplier,correction_mass
 [M+3H]3+,positive,3,0.33,1.007276
 [M+2H+Na]3+,positive,3,0.33,8.33459
-[M+H+2Na]3+,positive,3,0.33,15.662453
+[M+H+2Na]3+,positive,3,0.33,15.661906
 [M+3Na]3+,positive,3,0.33,22.989218
 [M+2H]2+,positive,2,0.5,1.007276
 [M+H+NH4]2+,positive,2,0.5,9.52055

--- a/matchms/data/known_adducts_table.csv
+++ b/matchms/data/known_adducts_table.csv
@@ -35,7 +35,7 @@
 [2M+ACN+Na]+,positive,1,2,64.015765
 [M-3H]3-,negative,-3,0.333333333,-1.007276
 [M-2H]2-,negative,-2,0.5,-1.007276
-[M-H2O-H]-,negative,-1,1,-19.01839
+[M-H2O-H]-,negative,-1,1,-19.017841
 [M-H]-,negative,-1,1,-1.007276
 [M+Na-2H]-,negative,-1,1,20.974666
 [M+Cl]-,negative,-1,1,34.969402


### PR DESCRIPTION
This should close #374 .
In other than the two cases, my other calculations were not always exactly the same as the current values, but that looked more like rounding errors in a 6 digit and I had no time to dig deeper here.