### PR TITLE
Consider move to Python 3.8 and higher

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -124,17 +124,16 @@ jobs:
         run: |
           which python
           python --version
-      - name: Install dev dependencies
-        shell: bash -l {0}
+      - name: Install dependencies (includinv dev + chemistry)
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev,chemistry]
       - name: Show pip list
-        shell: bash -l {0}
-        run: pip list
+        run: |
+          pip list
       - name: Run tests
-        shell: bash -l {0}
-        run: pytest
+        run: |
+          pytest
 
 
   test_with_conda:

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -110,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         exclude:
           - os: ubuntu-latest
             python-version: 3.9

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -67,10 +67,10 @@ jobs:
     needs: first_check
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Python info
         run: |
           which python
@@ -110,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10']
         exclude:
           - os: ubuntu-latest
             python-version: 3.9

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build package and create dev environment
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
+          pip install -e .[dev,chemistry]
       - name: Show pip list
         run: |
           pip list
@@ -116,42 +116,19 @@ jobs:
             python-version: 3.9
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
         with:
-          fetch-depth: "0"
-      - name: Create conda environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-      - name: Show conda config
-        shell: bash -l {0}
-        run: |
-          conda info
-          conda list
-          conda config --show-sources
-          conda config --show
-          conda env list
       - name: Python info
-        shell: bash -l {0}
         run: |
           which python
           python --version
-      - name: Show environment variables
-        shell: bash -l {0}
-        run: |
-          env | sort
-      - name: Install conda dependencies
-        shell: bash -l {0}
-        run: |
-          conda install -c conda-forge rdkit
       - name: Install dev dependencies
         shell: bash -l {0}
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
-      - name: Show conda list
-        shell: bash -l {0}
-        run: conda list
+          pip install -e .[dev,chemistry]
       - name: Show pip list
         shell: bash -l {0}
         run: pip list


### PR DESCRIPTION
- CI runs for Python 3.8, 3.9, 3.10
- since `rdkit` is now on pypi, tests for full functionality including rdkit now run faster when using pip instead of conda.

Remaining open question: drop Python 3.7 ? yes/no?

Fixes #395 