### PR TITLE
Fixed use of FingerprintSimilarity in Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+- Fixed pipeline filter [#414](https://github.com/matchms/matchms/pull/414)
+
+### Fixed
+
 ## [0.19.0] - 2023-05-10
 
 ### Added

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -139,18 +139,22 @@ class Pipeline:
         self.write_to_logfile(f"Time: {str(datetime.now())}")
         for step in self.filter_steps_queries:
             self.write_to_logfile(f"-- Processing step: {step} --")
-        for spectrum in tqdm(self.spectrums_queries,
+        for i in tqdm(range(len(self.spectrums_queries)),
                              disable=(not self.progress_bar),
                              desc="Processing query spectrums"):
+            spectrum = self.spectrums_queries[i]
             for step in self.filter_steps_queries:
                 spectrum = self.apply_filter(spectrum, step)
-            self.spectrums_queries = [s for s in self.spectrums_queries if s is not None]
+            self.spectrums_queries[i] = spectrum
+        self.spectrums_queries = [s for s in self.spectrums_queries if s is not None]
         if self.is_symmetric is False:
-            for spectrum in tqdm(self.spectrums_references,
+            for i in tqdm(range(len(self.spectrums_references)),
                                  disable=(not self.progress_bar),
                                  desc="Processing reference spectrums"):
+                spectrum = self.spectrums_references[i]
                 for step in self.filter_steps_refs:
                     spectrum = self.apply_filter(spectrum, step)
+                self.spectrums_references[i] = spectrum
             self.spectrums_references = [s for s in self.spectrums_references if s is not None]
 
         # Score computation and masking

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -177,6 +177,7 @@ def test_pipeline_logging(tmp_path):
     
 
 def test_FingerprintSimilarity_pipeline():
+    pytest.importorskip("rdkit")
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
     pipeline.reference_files = spectrums_file_msp

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -175,3 +175,22 @@ def test_pipeline_logging(tmp_path):
         firstline = f.readline().rstrip()
     assert "Start running matchms pipeline" in firstline
     
+
+def test_FingerprintSimilarity_pipeline():
+    pipeline = Pipeline()
+    pipeline.query_files = spectrums_file_msp
+    pipeline.reference_files = spectrums_file_msp
+    filter_steps = [
+        ["default_filters"],
+        ["add_fingerprint"]
+    ]
+    pipeline.filter_steps_queries = filter_steps
+    pipeline.filter_steps_refs = filter_steps
+    pipeline.score_computations = [
+        ["metadatamatch", {"field": "precursor_mz", "matching_type": "difference", "tolerance": 50}],
+        ["fingerprintsimilarity", {"similarity_measure": "jaccard"}]
+    ]    
+    pipeline.run()
+
+    assert pipeline.scores.scores.shape == (5, 5, 2)
+    assert pipeline.scores.score_names == ('MetadataMatch', 'FingerprintSimilarity')


### PR DESCRIPTION
This PR includes the following:

- Fixed pipeline filter, as previously changes by filters were not propagated to the "spectrums_queries" and "spectrums_references" #390
-  Added test for the use of FingerprintSimilarity in Pipeline
- updated changelog

closes #390 