### PR TITLE
Fixed reading peak_comments in json reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+- Updated reiterate_peak_comments function to convert the peak_comments keys to float [#437](https://github.com/matchms/matchms/pull/437)
+
+### Fixed
+
 ## [0.20.0] - 2023-05-30
 
 ### Added

--- a/matchms/Spectrum.py
+++ b/matchms/Spectrum.py
@@ -237,6 +237,11 @@ class Spectrum:
         if not isinstance(self.get("peak_comments", None), dict):
             return None
 
+        self._metadata["peak_comments"] = {
+            float(key) if isinstance(key, str) else key: value
+            for key, value in self.metadata["peak_comments"].items()
+        }
+
         mz_tolerance = self._peak_comments_mz_tolerance
 
         def _append_new_comment(key):


### PR DESCRIPTION
This PR includes the following:

- Updated reiterate_peak_comments function to convert the peak_comments keys to float #415 (the issue was the keys being the str type)

closes #415 