### PR TITLE
Removed filter_by_range non-inplace version

### DIFF
--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -176,12 +176,12 @@ class Pipeline:
         """
         if len(computation) == 1:
             name = self.scores.score_names[-1]
-            self.scores.filter_by_range(inplace=True, name=name)
+            self.scores.filter_by_range(name=name)
         elif "name" not in computation[1]:
             name = self.scores.scores.score_names[-1]
-            self.scores.filter_by_range(inplace=True, name=name, **computation[1])
+            self.scores.filter_by_range(name=name, **computation[1])
         else:
-            self.scores.filter_by_range(inplace=True, **computation[1])
+            self.scores.filter_by_range(**computation[1])
 
     def _apply_similarity_measure(self, computation, i):
         """Run score computations for all listed methods and on all loaded and processed spectra.

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -325,14 +325,11 @@ class Scores:
     def scores(self):
         return self._scores
 
-    def filter_by_range(self, inplace=False, **kwargs):
+    def filter_by_range(self, **kwargs):
         """Remove all scores for which the score `name` is outside the given range.
 
         Parameters
         ----------
-        inplace
-            Default is False in which case a filtered scores object will be returned.
-            Set to True to change the scores array in-place.
         kwargs
             See "Keyword arguments" section below.
 
@@ -352,10 +349,8 @@ class Scores:
             Define operator to be used to compare against `high`. Default is '<'.
             Possible choices are '>', '<', '>=', '<='.
         """
-        if inplace is True:
-            self._scores = self._scores.filter_by_range(**kwargs)
-            return None
-        return self._scores.filter_by_range(**kwargs)
+        self._scores = self._scores.filter_by_range(**kwargs)
+        return None
 
     def to_array(self, name=None) -> np.ndarray:
         """Scores as numpy array

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -350,7 +350,6 @@ class Scores:
             Possible choices are '>', '<', '>=', '<='.
         """
         self._scores = self._scores.filter_by_range(**kwargs)
-        return None
 
     def to_array(self, name=None) -> np.ndarray:
         """Scores as numpy array


### PR DESCRIPTION
This PR includes the following:

- removed the non-inplace version of the function filter_by_range #417 

closes #417 