### PR TITLE
update pipeline to use Processor class

### DIFF
--- a/integration-tests/test_user_workflow.py
+++ b/integration-tests/test_user_workflow.py
@@ -11,8 +11,8 @@ def test_user_workflow():
 
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file
-    pipeline.filter_steps_queries = [
-        ["default_filters"],
+    pipeline.predefined_processing_queries = "basic"
+    pipeline.additional_processing_queries = [
         ["add_parent_mass"],
         ["normalize_intensities"],
         ["select_by_relative_intensity", {"intensity_from": 0.0, "intensity_to": 1.0}],

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -6,11 +6,11 @@ import yaml
 import matchms.filtering as msfilters
 import matchms.similarity as mssimilarity
 from matchms import calculate_scores
-from matchms.SpectrumProcessor import SpectrumProcessor
 from matchms.importing.load_spectra import load_spectra
 from matchms.logging_functions import (add_logging_to_file,
                                        reset_matchms_logger,
                                        set_matchms_logger_level)
+from matchms.SpectrumProcessor import SpectrumProcessor
 
 
 _filter_functions = {key: f for key, f in msfilters.__dict__.items() if callable(f)}

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -3,12 +3,10 @@ import os
 from collections import OrderedDict
 from datetime import datetime
 import yaml
-from tqdm import tqdm
 import matchms.filtering as msfilters
 import matchms.similarity as mssimilarity
 from matchms import calculate_scores
 from matchms.SpectrumProcessor import SpectrumProcessor
-from matchms.SpectrumProcessor import PREDEFINED_PIPELINES
 from matchms.importing.load_spectra import load_spectra
 from matchms.logging_functions import (add_logging_to_file,
                                        reset_matchms_logger,

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -111,24 +111,26 @@ class Pipeline:
             self.workflow["logging"] = {}
         if self.logging_level is None:
             self.logging_level = "WARNING"
-        self._initialize_spectrum_processors()
+        self.write_to_logfile("--- Processing pipeline: ---")
+        self._initialize_spectrum_processor_queries()
+        if self.is_symmetric is False:
+            self._initialize_spectrum_processor_refs()
 
-    def _initialize_spectrum_processors(self):
+    def _initialize_spectrum_processor_queries(self):
         self.processing_queries = SpectrumProcessor(self.workflow.get("predefined_processing_queries", None))
         for step in self.additional_processing_queries:
             if isinstance(step, (tuple, list)) and len(step) == 1:
                 step = step[0]
             self.processing_queries.add_filter(step)
-        self.write_to_logfile("--- Processing pipeline: ---")
         self.write_to_logfile(self.processing_queries.__str__())
 
-        if self.is_symmetric is False:
-            self.processing_refs = SpectrumProcessor(self.workflow.get("predefined_processing_refs", None))
-            for step in self.additional_processing_refs:
-                if isinstance(step, (tuple, list)) and len(step) == 1:
-                    step = step[0]
-                self.processing_refs.add_filter(step)
-            self.write_to_logfile(self.processing_refs.__str__())
+    def _initialize_spectrum_processor_refs(self):
+        self.processing_refs = SpectrumProcessor(self.workflow.get("predefined_processing_refs", None))
+        for step in self.additional_processing_refs:
+            if isinstance(step, (tuple, list)) and len(step) == 1:
+                step = step[0]
+            self.processing_refs.add_filter(step)
+        self.write_to_logfile(self.processing_refs.__str__())
 
     def import_workflow_from_yaml(self, config_file):
         """Define Pipeline workflow based on config file.
@@ -355,6 +357,7 @@ class Pipeline:
     @predefined_processing_queries.setter
     def predefined_processing_queries(self, files):
         self.workflow["predefined_processing_queries"] = files
+        self._initialize_spectrum_processor_queries()
 
     @property
     def predefined_processing_refs(self):
@@ -363,6 +366,7 @@ class Pipeline:
     @predefined_processing_refs.setter
     def predefined_processing_refs(self, files):
         self.workflow["predefined_processing_refs"] = files
+        self._initialize_spectrum_processor_refs()
 
     @property
     def additional_processing_queries(self):
@@ -371,6 +375,7 @@ class Pipeline:
     @additional_processing_queries.setter
     def additional_processing_queries(self, files):
         self.workflow["additional_processing_queries"] = files
+        self._initialize_spectrum_processor_queries()
 
     @property
     def additional_processing_refs(self):
@@ -379,6 +384,7 @@ class Pipeline:
     @additional_processing_refs.setter
     def additional_processing_refs(self, files):
         self.workflow["additional_processing_refs"] = files
+        self._initialize_spectrum_processor_refs()
 
     @property
     def score_computations(self):

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -7,6 +7,8 @@ from tqdm import tqdm
 import matchms.filtering as msfilters
 import matchms.similarity as mssimilarity
 from matchms import calculate_scores
+from matchms.SpectrumProcessor import SpectrumProcessor
+from matchms.SpectrumProcessor import PREDEFINED_PIPELINES
 from matchms.importing.load_spectra import load_spectra
 from matchms.logging_functions import (add_logging_to_file,
                                        reset_matchms_logger,
@@ -43,8 +45,8 @@ class Pipeline:
 
         pipeline = Pipeline()
         pipeline.query_files = "spectrums_file.msp"
-        pipeline.filter_steps_queries = [
-            ["default_filters"],
+        pipeline.predefined_processing_queries = "basic"
+        pipeline.additional_processing_queries = [
             ["add_parent_mass"],
             ["normalize_intensities"],
             ["select_by_relative_intensity", {"intensity_from": 0.0, "intensity_to": 1.0}],
@@ -95,18 +97,38 @@ class Pipeline:
             self.workflow = OrderedDict()
             self.workflow["importing"] = {"queries": None,
                                           "references": None}
-            self.workflow["filtering_queries"] = ["default_filters"]
-            self.workflow["filtering_refs"] = ["default_filters"]
+            self.workflow["predefined_processing_queries"] = "default"
+            self.workflow["predefined_processing_refs"] = "default"
+            self.workflow["additional_processing_queries"] = []
+            self.workflow["additional_processing_refs"] = []
             self.workflow["score_computations"] = []
         else:
             with open(config_file, 'r', encoding="utf-8") as file:
                 self.workflow = ordered_load(file, yaml.SafeLoader)
-            if self.workflow["filtering_refs"] == "filtering_queries":
-                self.workflow["filtering_refs"] = self.workflow["filtering_queries"]
+            if self.workflow["additional_processing_refs"] == "processing_queries":
+                self.workflow["additional_processing_refs"] = self.workflow["additional_processing_queries"]
         if "logging" not in self.workflow:
             self.workflow["logging"] = {}
         if self.logging_level is None:
             self.logging_level = "WARNING"
+        self._initialize_spectrum_processors()
+
+    def _initialize_spectrum_processors(self):
+        self.processing_queries = SpectrumProcessor(self.workflow.get("predefined_processing_queries", None))
+        for step in self.additional_processing_queries:
+            if isinstance(step, (tuple, list)) and len(step) == 1:
+                step = step[0]
+            self.processing_queries.add_filter(step)
+        self.write_to_logfile("--- Processing pipeline: ---")
+        self.write_to_logfile(self.processing_queries.__str__())
+
+        if self.is_symmetric is False:
+            self.processing_refs = SpectrumProcessor(self.workflow.get("predefined_processing_refs", None))
+            for step in self.additional_processing_refs:
+                if isinstance(step, (tuple, list)) and len(step) == 1:
+                    step = step[0]
+                self.processing_refs.add_filter(step)
+            self.write_to_logfile(self.processing_refs.__str__())
 
     def import_workflow_from_yaml(self, config_file):
         """Define Pipeline workflow based on config file.
@@ -132,25 +154,22 @@ class Pipeline:
         # Processing
         self.write_to_logfile("--- Processing spectra ---")
         self.write_to_logfile(f"Time: {str(datetime.now())}")
-        for step in self.filter_steps_queries:
-            self.write_to_logfile(f"-- Processing step: {step} --")
-        for i in tqdm(range(len(self.spectrums_queries)),
-                             disable=(not self.progress_bar),
-                             desc="Processing query spectrums"):
-            spectrum = self.spectrums_queries[i]
-            for step in self.filter_steps_queries:
-                spectrum = self.apply_filter(spectrum, step)
-            self.spectrums_queries[i] = spectrum
-        self.spectrums_queries = [s for s in self.spectrums_queries if s is not None]
+        # Process query spectra
+        spectrums, report = self.processing_queries.process_spectrums(
+            self.spectrums_queries,
+            create_report=True,
+            progress_bar=self.progress_bar)
+        self.spectrums_queries = spectrums
+        self.write_to_logfile(report.__str__())
+        # Process reference spectra (if necessary)
         if self.is_symmetric is False:
-            for i in tqdm(range(len(self.spectrums_references)),
-                                 disable=(not self.progress_bar),
-                                 desc="Processing reference spectrums"):
-                spectrum = self.spectrums_references[i]
-                for step in self.filter_steps_refs:
-                    spectrum = self.apply_filter(spectrum, step)
-                self.spectrums_references[i] = spectrum
-            self.spectrums_references = [s for s in self.spectrums_references if s is not None]
+            self.spectrums_references, report = self.processing_refs.process_spectrums(
+                self.spectrums_references,
+                create_report=True,
+                progress_bar=self.progress_bar)
+            self.write_to_logfile(report.__str__())
+        else:
+            self.spectrums_references = self.spectrums_queries
 
         # Score computation and masking
         self.write_to_logfile("--- Computing scores ---")
@@ -286,22 +305,6 @@ class Pipeline:
                 spectrums_references += list(load_spectra(reference_file))
             self.spectrums_references += spectrums_references
 
-    def apply_filter(self, spectrum, filter_step):
-        """Apply the given matchms filter to a spectrum.
-        """
-        if not isinstance(filter_step, list):
-            filter_step = [filter_step]
-        if isinstance(filter_step[0], str):
-            filter_function = _filter_functions[filter_step[0]]
-        elif callable(filter_step[0]):
-            filter_function = filter_step[0]
-        else:
-            raise TypeError("Unknown filter type. Should be known filter name or function.")
-        if len(filter_step) > 1:
-            filter_params = filter_step[1]
-            return filter_function(spectrum, **filter_params)
-        return filter_function(spectrum)
-
     def create_workflow_config_file(self, filename):
         """Save the current pipeline workflow as a yaml file.
         This file allows to reconstruct the current workflow or can be adapted as desired.
@@ -346,20 +349,36 @@ class Pipeline:
         self.workflow["logging"]["logging_level"] = log_level
 
     @property
-    def filter_steps_queries(self):
-        return self.workflow.get("filtering_queries")
+    def predefined_processing_queries(self):
+        return self.workflow.get("predefined_processing_queries")
 
-    @filter_steps_queries.setter
-    def filter_steps_queries(self, files):
-        self.workflow["filtering_queries"] = files
+    @predefined_processing_queries.setter
+    def predefined_processing_queries(self, files):
+        self.workflow["predefined_processing_queries"] = files
 
     @property
-    def filter_steps_refs(self):
-        return self.workflow.get("filtering_refs")
+    def predefined_processing_refs(self):
+        return self.workflow.get("predefined_processing_refs")
 
-    @filter_steps_refs.setter
-    def filter_steps_refs(self, filter_list):
-        self.workflow["filtering_refs"] = filter_list
+    @predefined_processing_refs.setter
+    def predefined_processing_refs(self, files):
+        self.workflow["predefined_processing_refs"] = files
+
+    @property
+    def additional_processing_queries(self):
+        return self.workflow.get("additional_processing_queries")
+
+    @additional_processing_queries.setter
+    def additional_processing_queries(self, files):
+        self.workflow["additional_processing_queries"] = files
+
+    @property
+    def additional_processing_refs(self):
+        return self.workflow.get("additional_processing_refs")
+
+    @additional_processing_refs.setter
+    def additional_processing_refs(self, files):
+        self.workflow["additional_processing_refs"] = files
 
     @property
     def score_computations(self):

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -13,7 +13,6 @@ from matchms.logging_functions import (add_logging_to_file,
 from matchms.SpectrumProcessor import SpectrumProcessor
 
 
-_filter_functions = {key: f for key, f in msfilters.__dict__.items() if callable(f)}
 _masking_functions = ["filter_by_range"]
 _score_functions = {key.lower(): f for key, f in mssimilarity.__dict__.items() if callable(f)}
 logger = logging.getLogger("matchms")

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -3,7 +3,6 @@ import os
 from collections import OrderedDict
 from datetime import datetime
 import yaml
-import matchms.filtering as msfilters
 import matchms.similarity as mssimilarity
 from matchms import calculate_scores
 from matchms.importing.load_spectra import load_spectra

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import partial
-from typing import List, Optional, Tuple
+from typing import Optional
 import numpy as np
 import pandas as pd
 from tqdm import tqdm

--- a/tests/filtering/test_spectrum_processor.py
+++ b/tests/filtering/test_spectrum_processor.py
@@ -39,7 +39,6 @@ def test_filter_sorting_and_output():
         'harmonize_undefined_smiles',
         'repair_inchi_inchikey_smiles',
         'repair_parent_mass_match_smiles_wrapper',
-        'require_correct_ionmode',
         'normalize_intensities'
         ]
     actual_filters = [x.__name__ for x in processing.filters]

--- a/tests/filtering/test_spectrum_processor.py
+++ b/tests/filtering/test_spectrum_processor.py
@@ -166,7 +166,7 @@ def test_add_filter_with_custom(spectrums):
     processor.add_filter((nonsense_inchikey_multiple, {"number": 2}))
     filters = processor.filters
     assert filters[-1].__name__ == "nonsense_inchikey_multiple"
-    spectrums, report = processor.process_spectrums(spectrums, create_report=True)
+    spectrums, _ = processor.process_spectrums(spectrums, create_report=True)
     assert spectrums[0].get("inchikey") == "NONSENSENONSENSE", "Custom filter not executed properly"
 
 
@@ -176,5 +176,5 @@ def test_add_filter_with_matchms_filter(spectrums):
                          {"ion_mode_to_keep": "both"}))
     filters = processor.filters
     assert filters[-1].__name__ == "require_correct_ionmode"
-    spectrums, report = processor.process_spectrums(spectrums, create_report=True)
+    spectrums, _ = processor.process_spectrums(spectrums, create_report=True)
     assert spectrums == []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -50,7 +50,7 @@ def test_pipeline_symmetric():
 def test_pipeline_symmetric_filters():
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
-    pipeline.predefined_filters = "basic"
+    pipeline.predefined_processing_queries = "basic"
     pipeline.additional_processing_queries = [[select_by_mz, {"mz_from": 0, "mz_to": 1000}]]
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    ["modifiedcosine", {"tolerance": 10.0}]]
@@ -183,17 +183,15 @@ def test_FingerprintSimilarity_pipeline():
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
     pipeline.reference_files = spectrums_file_msp
-    filter_steps = [
-        ["default_filters"],
-        ["add_fingerprint"]
-    ]
-    pipeline.filter_steps_queries = filter_steps
-    pipeline.filter_steps_refs = filter_steps
+    pipeline.predefined_processing_queries = "basic"
+    pipeline.additional_processing_queries = ["add_fingerprint"]
+    pipeline.predefined_processing_refs = "basic"
+    pipeline.additional_processing_refs = ["add_fingerprint"]
     pipeline.score_computations = [
         ["metadatamatch", {"field": "precursor_mz", "matching_type": "difference", "tolerance": 50}],
         ["fingerprintsimilarity", {"similarity_measure": "jaccard"}]
     ]    
     pipeline.run()
-
+    assert len(pipeline.spectrums_queries[0].get("fingerprint")) == 2048
     assert pipeline.scores.scores.shape == (5, 5, 2)
     assert pipeline.scores.score_names == ('MetadataMatch', 'FingerprintSimilarity')

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -44,19 +44,20 @@ def test_pipeline_symmetric():
     expected = np.array([[1., 0.30384404],
                          [0.30384404, 1.]])
     assert np.allclose(all_scores["ModifiedCosine_score"][3:, 3:], expected)
-    assert np.all(all_scores["ModifiedCosine_score"].diagonal() == 1), "Diagonal should all be 1.0"
+    assert np.allclose(all_scores["ModifiedCosine_score"].diagonal(), 1), "Diagonal should all be 1.0"
 
 
 def test_pipeline_symmetric_filters():
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
-    pipeline.filter_steps_queries = [["default_filters"],
-                                     [select_by_mz, {"mz_from": 0, "mz_to": 1000}]]
+    pipeline.predefined_filters = "basic"
+    pipeline.additional_processing_queries = [[select_by_mz, {"mz_from": 0, "mz_to": 1000}]]
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    ["modifiedcosine", {"tolerance": 10.0}]]
     pipeline.run()
 
     assert len(pipeline.spectrums_queries) == 5
+    assert pipeline.spectrums_queries[0].metadata == pipeline.spectrums_references[0].metadata
     assert pipeline.spectrums_queries[0] == pipeline.spectrums_references[0]
     assert pipeline.is_symmetric is True
     assert pipeline.scores.scores.shape == (5, 5, 3)
@@ -65,7 +66,7 @@ def test_pipeline_symmetric_filters():
     expected = np.array([[1., 0.30384404],
                          [0.30384404, 1.]])
     assert np.allclose(all_scores["ModifiedCosine_score"][3:, 3:], expected)
-    assert np.all(all_scores["ModifiedCosine_score"].diagonal() == 1), "Diagonal should all be 1.0"
+    assert np.allclose(all_scores["ModifiedCosine_score"].diagonal(), 1), "Diagonal should all be 1.0"
 
 
 def test_pipeline_symmetric_masking():
@@ -85,7 +86,7 @@ def test_pipeline_symmetric_masking():
     expected = np.array([[1., 0.30384404],
                          [0.30384404, 1.]])
     assert np.allclose(all_scores["ModifiedCosine_score"][3:, 3:], expected)
-    assert np.all(all_scores["ModifiedCosine_score"].diagonal() == 1), "Diagonal should all be 1.0"
+    assert np.allclose(all_scores["ModifiedCosine_score"].diagonal(), 1), "Diagonal should all be 1.0"
 
 
 def test_pipeline_symmetric_custom_score():
@@ -104,7 +105,7 @@ def test_pipeline_symmetric_custom_score():
     expected = np.array([[1., 0.30384404],
                          [0.30384404, 1.]])
     assert np.allclose(all_scores["ModifiedCosine_score"][3:, 3:], expected)
-    assert np.all(all_scores["ModifiedCosine_score"].diagonal() == 1), "Diagonal should all be 1.0"
+    assert np.allclose(all_scores["ModifiedCosine_score"].diagonal(), 1), "Diagonal should all be 1.0"
 
 
 def test_pipeline_non_symmetric():
@@ -132,6 +133,7 @@ def test_pipeline_non_symmetric():
 def test_pipeline_from_yaml():
     config_file = os.path.join(module_root, "tests", "test_pipeline.yaml")
     pipeline = Pipeline(config_file)
+    assert pipeline.predefined_processing_queries == "default"
     pipeline.run()
     assert len(pipeline.spectrums_queries) == 5
     assert pipeline.spectrums_queries[0] == pipeline.spectrums_references[0]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -31,6 +31,7 @@ def test_pipeline_initial_check_unknown_step():
 def test_pipeline_symmetric():
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
+    pipeline.predefined_processing_queries = "basic"
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    ["modifiedcosine", {"tolerance": 10.0}]]
     pipeline.run()
@@ -72,6 +73,7 @@ def test_pipeline_symmetric_filters():
 def test_pipeline_symmetric_masking():
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
+    pipeline.predefined_processing_queries = "basic"
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    ["modifiedcosine", {"tolerance": 10.0}],
                                    ["filter_by_range", {"low": 0.3, "above_operator": '>='}]]
@@ -92,6 +94,7 @@ def test_pipeline_symmetric_masking():
 def test_pipeline_symmetric_custom_score():
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
+    pipeline.predefined_processing_queries = "basic"
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    [ModifiedCosine, {"tolerance": 10.0}]]
     pipeline.run()
@@ -112,6 +115,8 @@ def test_pipeline_non_symmetric():
     """Test importing from multiple files and different inputs for query and references."""
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
+    pipeline.predefined_processing_queries = "basic"
+    pipeline.predefined_processing_refs = "basic"
     pipeline.reference_files = [spectrums_file_msp, spectrums_file_msp]
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    ["modifiedcosine", {"tolerance": 10.0}]]
@@ -131,6 +136,7 @@ def test_pipeline_non_symmetric():
 
 
 def test_pipeline_from_yaml():
+    pytest.importorskip("rdkit")
     config_file = os.path.join(module_root, "tests", "test_pipeline.yaml")
     pipeline = Pipeline(config_file)
     assert pipeline.predefined_processing_queries == "default"
@@ -147,6 +153,7 @@ def test_pipeline_from_yaml():
 
 
 def test_pipeline_to_and_from_yaml(tmp_path):
+    pytest.importorskip("rdkit")
     config_file = os.path.join(tmp_path, "test_pipeline.yaml")
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
@@ -164,6 +171,7 @@ def test_pipeline_to_and_from_yaml(tmp_path):
 
 
 def test_pipeline_logging(tmp_path):
+    pytest.importorskip("rdkit")
     pipeline = Pipeline()
     pipeline.query_files = spectrums_file_msp
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],

--- a/tests/test_pipeline.yaml
+++ b/tests/test_pipeline.yaml
@@ -4,12 +4,13 @@
 importing:
   queries: ./tests/testdata/massbank_five_spectra.msp
   references:
-filtering_queries:
-- - default_filters
+predefined_processing_queries: default
+predefined_processing_refs: default
+additional_processing_queries:
 - - normalize_intensities
 - - select_by_intensity
   - intensity_from: 0.001
-filtering_refs: filtering_queries
+additional_processing_refs: processing_queries
 score_computations:
 - - precursormzmatch
   - tolerance: 120.0

--- a/tests/test_scoring_method_consistency.py
+++ b/tests/test_scoring_method_consistency.py
@@ -85,9 +85,11 @@ def test_consistency_scoring_and_pipeline(spectrums, similarity_measure):
     # Run pipeline
     pipeline = Pipeline()
     pipeline.query_files = json_file
-    pipeline.filter_steps_queries = [["default_filters"],
-                                      ["add_parent_mass"],
-                                      ["normalize_intensities"]]
+    pipeline.predefined_processing_queries = "basic"
+    pipeline.additional_processing_queries = [
+        ["add_parent_mass"],
+        ["normalize_intensities"]
+        ]
     pipeline.score_computations = [similarity_measure]
     pipeline.run()
 


### PR DESCRIPTION
Now also use the `SpectrumProcessor` class in our `Pipeline`.
Some tests still failing because the switch to the new "default" processing includes rdkit-related steps. Will be fixes with recent switch to poetry.