### PR TITLE
Move yaml file creation and loading outside Pipeline.py

### DIFF
--- a/integration-tests/test_user_workflow.py
+++ b/integration-tests/test_user_workflow.py
@@ -9,18 +9,15 @@ from matchms.similarity import CosineGreedy
 def test_user_workflow():
     module_root = os.path.join(os.path.dirname(__file__), "..")
     spectrums_file = os.path.join(module_root, "tests", "testdata", "pesticides.mgf")
-    workflow = create_workflow()
+    workflow = create_workflow(query_file_name=spectrums_file,
+                               predefined_processing_queries="basic",
+                               additional_filters_queries=[["add_parent_mass"],
+                                                           ["normalize_intensities"],
+                                                           ["select_by_relative_intensity", {"intensity_from": 0.0, "intensity_to": 1.0}],
+                                                           ["select_by_mz", {"mz_from": 0, "mz_to": 1000}],
+                                                           ["require_minimum_number_of_peaks", {"n_required": 5}]],
+                               score_computations=[["cosinegreedy",  {"tolerance": 0.3}]])
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file
-    pipeline.predefined_processing_queries = "basic"
-    pipeline.additional_processing_queries = [
-        ["add_parent_mass"],
-        ["normalize_intensities"],
-        ["select_by_relative_intensity", {"intensity_from": 0.0, "intensity_to": 1.0}],
-        ["select_by_mz", {"mz_from": 0, "mz_to": 1000}],
-        ["require_minimum_number_of_peaks", {"n_required": 5}]
-    ]
-    pipeline.score_computations = [["cosinegreedy",  {"tolerance": 0.3}]]
     pipeline.run()
 
     scores = pipeline.scores

--- a/integration-tests/test_user_workflow.py
+++ b/integration-tests/test_user_workflow.py
@@ -2,14 +2,15 @@ import os
 import numpy as np
 import pytest
 from matchms import Pipeline
+from matchms.Pipeline import create_workflow
 from matchms.similarity import CosineGreedy
 
 
 def test_user_workflow():
     module_root = os.path.join(os.path.dirname(__file__), "..")
     spectrums_file = os.path.join(module_root, "tests", "testdata", "pesticides.mgf")
-
-    pipeline = Pipeline()
+    workflow = create_workflow()
+    pipeline = Pipeline(workflow)
     pipeline.query_files = spectrums_file
     pipeline.predefined_processing_queries = "basic"
     pipeline.additional_processing_queries = [

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -17,6 +17,65 @@ _score_functions = {key.lower(): f for key, f in mssimilarity.__dict__.items() i
 logger = logging.getLogger("matchms")
 
 
+def create_workflow(yaml_file_name = None,
+                    predefined_processing_queries="default",
+                    predefined_processing_reference="default",
+                    additional_filters_queries=(),
+                    additional_filters_references=(),
+                    score_computations=(),
+                    query_file_name=None,
+                    reference_file_name=None,
+                    ):
+    workflow = OrderedDict()
+    workflow["importing"] = {"queries": query_file_name,
+                             "references": reference_file_name}
+    workflow["predefined_processing_queries"] = predefined_processing_queries
+    workflow["predefined_processing_references"] = predefined_processing_reference
+    workflow["additional_processing_queries"] = additional_filters_queries
+    workflow["additional_processing_references"] = additional_filters_references
+    workflow["score_computations"] = score_computations
+    if yaml_file_name is not None:
+        with open(yaml_file_name, 'w', encoding="utf-8") as file:
+            file.write("# Matchms pipeline config file \n")
+            file.write("# Change and adapt fields where necessary \n")
+            file.write("# " + 20 * "=" + " \n")
+            ordered_dump(workflow, file)
+    return workflow
+
+
+def load_in_workflow_from_yaml_file(yaml_file):
+    with open(yaml_file, 'r', encoding="utf-8") as file:
+        workflow = ordered_load(file, yaml.SafeLoader)
+    return workflow
+
+
+def ordered_load(stream, loader=yaml.SafeLoader, object_pairs_hook=OrderedDict):
+    """ Code from https://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts
+    """
+    class OrderedLoader(loader):
+        pass
+
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return object_pairs_hook(loader.construct_pairs(node))
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+    return yaml.load(stream, OrderedLoader)
+
+
+def ordered_dump(data, stream=None, dumper=yaml.SafeDumper, **kwds):
+    class OrderedDumper(dumper):
+        pass
+
+    def _dict_representer(dumper, data):
+        return dumper.represent_mapping(
+            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+            data.items())
+    OrderedDumper.add_representer(OrderedDict, _dict_representer)
+    return yaml.dump(data, stream, OrderedDumper, **kwds)
+
+
 class Pipeline:
     """Central pipeline class.
 
@@ -71,7 +130,7 @@ class Pipeline:
                                        ["filter_by_range", {"name": "Spec2Vec", "low": 0.3}]]
 
     """
-    def __init__(self, config_file=None, progress_bar=True):
+    def __init__(self, workflow, progress_bar=True):
         """
         Parameters
         ----------
@@ -84,7 +143,12 @@ class Pipeline:
         self.spectrums_queries = []
         self.spectrums_references = []
         self.is_symmetric = False
-        self.import_workflow_from_yaml(config_file)
+        self.workflow = workflow
+        self.complete_workflow()
+        self.write_to_logfile("--- Processing pipeline: ---")
+        self._initialize_spectrum_processor_queries()
+        if self.is_symmetric is False:
+            self._initialize_spectrum_processor_references()
         self.scores = None
         self.progress_bar = progress_bar
 
@@ -104,31 +168,14 @@ class Pipeline:
             )
         self.write_to_logfile(str(self.processing_references))
 
-    def import_workflow_from_yaml(self, config_file):
+    def complete_workflow(self):
         """Define Pipeline workflow based on a yaml file (config_file).
         """
-        if config_file is None:
-            self.workflow = OrderedDict()
-            self.workflow["importing"] = {"queries": None,
-                                          "references": None}
-            self.workflow["predefined_processing_queries"] = "default"
-            self.workflow["predefined_processing_references"] = "default"
-            self.workflow["additional_processing_queries"] = []
-            self.workflow["additional_processing_references"] = []
-            self.workflow["score_computations"] = []
-        else:
-            with open(config_file, 'r', encoding="utf-8") as file:
-                self.workflow = ordered_load(file, yaml.SafeLoader)
-            if self.workflow["additional_processing_references"] == "processing_queries":
-                self.workflow["additional_processing_references"] = self.workflow["additional_processing_queries"]
+        #todo add a check if all the fields are given that are needed.
         if "logging" not in self.workflow:
             self.workflow["logging"] = {}
         if self.logging_level is None:
             self.logging_level = "WARNING"
-        self.write_to_logfile("--- Processing pipeline: ---")
-        self._initialize_spectrum_processor_queries()
-        if self.is_symmetric is False:
-            self._initialize_spectrum_processor_references()
 
     def run(self):
         """Execute the defined Pipeline workflow.
@@ -300,15 +347,6 @@ class Pipeline:
                 spectrums_references += list(load_spectra(reference_file))
             self.spectrums_references += spectrums_references
 
-    def create_workflow_config_file(self, filename):
-        """Save the current pipeline workflow as a yaml file.
-        This file allows to reconstruct the current workflow or can be adapted as desired.
-        """
-        with open(filename, 'w', encoding="utf-8") as file:
-            file.write("# Matchms pipeline config file \n")
-            file.write("# Change and adapt fields where necessary \n")
-            file.write("# " + 20 * "=" + " \n")
-            ordered_dump(self.workflow, file)
 
     # Getter & Setters
     @property
@@ -386,33 +424,6 @@ class Pipeline:
     @score_computations.setter
     def score_computations(self, computations_list):
         self.workflow["score_computations"] = computations_list
-
-
-def ordered_load(stream, loader=yaml.SafeLoader, object_pairs_hook=OrderedDict):
-    """ Code from https://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts
-    """
-    class OrderedLoader(loader):
-        pass
-
-    def construct_mapping(loader, node):
-        loader.flatten_mapping(node)
-        return object_pairs_hook(loader.construct_pairs(node))
-    OrderedLoader.add_constructor(
-        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-        construct_mapping)
-    return yaml.load(stream, OrderedLoader)
-
-
-def ordered_dump(data, stream=None, dumper=yaml.SafeDumper, **kwds):
-    class OrderedDumper(dumper):
-        pass
-
-    def _dict_representer(dumper, data):
-        return dumper.represent_mapping(
-            yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-            data.items())
-    OrderedDumper.add_representer(OrderedDict, _dict_representer)
-    return yaml.dump(data, stream, OrderedDumper, **kwds)
 
 
 def initialize_spectrum_processor(predefined_workflow, additional_filters):

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -131,14 +131,13 @@ class Pipeline:
                                        ["filter_by_range", {"name": "Spec2Vec", "low": 0.3}]]
 
     """
-    def __init__(self, workflow, progress_bar=True):
+    def __init__(self, workflow: OrderedDict, progress_bar=True):
         """
         Parameters
         ----------
-        config_file
-            Filename of config file (yaml file) to define pipeline. Default is None
-            in which case the pipeline should be defined via a Python script.
-        progress_bar
+        workflow:
+            Contains an orderedDict containing the workflow settings. Can be created using create_workflow.
+        progress_bar:
             Default is True. Set to False if no progress bar should be displayed.
         """
         self.spectrums_queries = []

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -385,42 +385,6 @@ class Pipeline:
         self.workflow["logging"]["logging_level"] = log_level
 
     @property
-    def predefined_processing_queries(self):
-        return self.workflow.get("predefined_processing_queries")
-
-    @predefined_processing_queries.setter
-    def predefined_processing_queries(self, files):
-        self.workflow["predefined_processing_queries"] = files
-        self._initialize_spectrum_processor_queries()
-
-    @property
-    def predefined_processing_references(self):
-        return self.workflow.get("predefined_processing_references")
-
-    @predefined_processing_references.setter
-    def predefined_processing_references(self, files):
-        self.workflow["predefined_processing_references"] = files
-        self._initialize_spectrum_processor_references()
-
-    @property
-    def additional_processing_queries(self):
-        return self.workflow.get("additional_processing_queries")
-
-    @additional_processing_queries.setter
-    def additional_processing_queries(self, files):
-        self.workflow["additional_processing_queries"] = files
-        self._initialize_spectrum_processor_queries()
-
-    @property
-    def additional_processing_references(self):
-        return self.workflow.get("additional_processing_references")
-
-    @additional_processing_references.setter
-    def additional_processing_references(self, files):
-        self.workflow["additional_processing_references"] = files
-        self._initialize_spectrum_processor_references()
-
-    @property
     def score_computations(self):
         return self.workflow.get("score_computations")
 

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -17,7 +17,7 @@ _score_functions = {key.lower(): f for key, f in mssimilarity.__dict__.items() i
 logger = logging.getLogger("matchms")
 
 
-def create_workflow(yaml_file_name = None,
+def create_workflow(yaml_file_name=None,
                     predefined_processing_queries="default",
                     predefined_processing_reference="default",
                     additional_filters_queries=(),
@@ -26,6 +26,7 @@ def create_workflow(yaml_file_name = None,
                     query_file_name=None,
                     reference_file_name=None,
                     ):
+    # pylint: disable=too-many-arguments
     workflow = OrderedDict()
     workflow["importing"] = {"queries": query_file_name,
                              "references": reference_file_name}

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -172,6 +172,8 @@ class Pipeline:
         """Define Pipeline workflow based on a yaml file (config_file).
         """
         #todo add a check if all the fields are given that are needed.
+        if self.workflow["additional_processing_references"] == "processing_queries":
+            self.workflow["additional_processing_references"] = self.workflow["additional_processing_queries"]
         if "logging" not in self.workflow:
             self.workflow["logging"] = {}
         if self.logging_level is None:

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -156,16 +156,16 @@ class Pipeline:
     def _initialize_spectrum_processor_queries(self):
         """Initialize spectrum processing workflow for the query spectra."""
         self.processing_queries = initialize_spectrum_processor(
-            self.predefined_processing_queries,
-            self.additional_processing_queries
+            self.workflow["predefined_processing_queries"],
+            self.workflow["additional_processing_queries"]
             )
         self.write_to_logfile(str(self.processing_queries))
 
     def _initialize_spectrum_processor_references(self):
         """Initialize spectrum processing workflow for the reference spectra."""
         self.processing_references = initialize_spectrum_processor(
-            self.predefined_processing_references,
-            self.additional_processing_references
+            self.workflow["predefined_processing_references"],
+            self.workflow["additional_processing_references"]
             )
         self.write_to_logfile(str(self.processing_references))
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -148,7 +148,6 @@ def test_pipeline_from_yaml():
     config_file = os.path.join(module_root, "tests", "test_pipeline.yaml")
     workflow = load_in_workflow_from_yaml_file(config_file)
     pipeline = Pipeline(workflow)
-    assert pipeline.predefined_processing_queries == "default"
     pipeline.run()
     assert len(pipeline.spectrums_queries) == 5
     assert pipeline.spectrums_queries[0] == pipeline.spectrums_references[0]
@@ -200,18 +199,16 @@ def test_pipeline_logging(tmp_path):
 
 def test_FingerprintSimilarity_pipeline():
     pytest.importorskip("rdkit")
-    workflow = create_workflow()
+    workflow = create_workflow(predefined_processing_queries="basic",
+                               additional_filters_queries=["add_fingerprint"],
+                               predefined_processing_reference="basic",
+                               additional_filters_references=["add_fingerprint"],
+                               query_file_name=spectrums_file_msp,
+                               reference_file_name=spectrums_file_msp,
+                               score_computations=[["metadatamatch", {"field": "precursor_mz", "matching_type": "difference", "tolerance": 50}],
+                                                   ["fingerprintsimilarity", {"similarity_measure": "jaccard"}]],
+                               )
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
-    pipeline.reference_files = spectrums_file_msp
-    pipeline.predefined_processing_queries = "basic"
-    pipeline.additional_processing_queries = ["add_fingerprint"]
-    pipeline.predefined_processing_references = "basic"
-    pipeline.additional_processing_references = ["add_fingerprint"]
-    pipeline.score_computations = [
-        ["metadatamatch", {"field": "precursor_mz", "matching_type": "difference", "tolerance": 50}],
-        ["fingerprintsimilarity", {"similarity_measure": "jaccard"}]
-    ]
     pipeline.run()
     assert len(pipeline.spectrums_queries[0].get("fingerprint")) == 2048
     assert pipeline.scores.scores.shape == (5, 5, 2)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import pytest
 from matchms import Pipeline
+from matchms.Pipeline import load_in_workflow_from_yaml_file
 from matchms.filtering import select_by_mz
 from matchms.Pipeline import create_workflow, load_in_workflow_from_yaml_file
 from matchms.similarity import ModifiedCosine
@@ -146,7 +147,8 @@ def test_pipeline_non_symmetric():
 def test_pipeline_from_yaml():
     pytest.importorskip("rdkit")
     config_file = os.path.join(module_root, "tests", "test_pipeline.yaml")
-    pipeline = Pipeline(config_file)
+    workflow = load_in_workflow_from_yaml_file(config_file)
+    pipeline = Pipeline(workflow)
     assert pipeline.predefined_processing_queries == "default"
     pipeline.run()
     assert len(pipeline.spectrums_queries) == 5

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,7 +2,6 @@ import os
 import numpy as np
 import pytest
 from matchms import Pipeline
-from matchms.Pipeline import load_in_workflow_from_yaml_file
 from matchms.filtering import select_by_mz
 from matchms.Pipeline import create_workflow, load_in_workflow_from_yaml_file
 from matchms.similarity import ModifiedCosine

--- a/tests/test_scoring_method_consistency.py
+++ b/tests/test_scoring_method_consistency.py
@@ -13,6 +13,7 @@ import matchms.filtering as msfilter
 import matchms.similarity as mssimilarity
 from matchms import Pipeline
 from matchms.importing import load_from_json
+from matchms.Pipeline import create_workflow
 
 
 module_root = os.path.dirname(__file__)
@@ -83,7 +84,8 @@ def test_consistency_scoring_and_pipeline(spectrums, similarity_measure):
     computed_scores_matrix = scoring_method.matrix(spectrums, spectrums)
 
     # Run pipeline
-    pipeline = Pipeline()
+    workflow = create_workflow()
+    pipeline = Pipeline(workflow)
     pipeline.query_files = json_file
     pipeline.predefined_processing_queries = "basic"
     pipeline.additional_processing_queries = [

--- a/tests/test_scoring_method_consistency.py
+++ b/tests/test_scoring_method_consistency.py
@@ -84,15 +84,12 @@ def test_consistency_scoring_and_pipeline(spectrums, similarity_measure):
     computed_scores_matrix = scoring_method.matrix(spectrums, spectrums)
 
     # Run pipeline
-    workflow = create_workflow()
+    workflow = create_workflow(query_file_name=json_file,
+                               predefined_processing_queries="basic",
+                               additional_filters_queries=[["add_parent_mass"], ["normalize_intensities"]],
+                               score_computations=[similarity_measure]
+                               )
     pipeline = Pipeline(workflow)
-    pipeline.query_files = json_file
-    pipeline.predefined_processing_queries = "basic"
-    pipeline.additional_processing_queries = [
-        ["add_parent_mass"],
-        ["normalize_intensities"]
-        ]
-    pipeline.score_computations = [similarity_measure]
     pipeline.run()
 
     if computed_scores_matrix.dtype.names is None:


### PR DESCRIPTION
This should solve #475 
The PR's #482 #481 #480 build further onto this PR. 

Pipeline became quite a complicated class. I wanted to implement some changes to the way the yaml file was stored, but this was a bit challenging due to the fact that yaml file/workflow is used although Pipeline, making it harder to make changes.

As a solution the yaml file creation is moved outside of Pipeline. 

These changes will remove the option to modify an already existing Pipeline object. So you cannot run Pipeline and after add some steps and than run again. I think this was unwanted behaviour anyway, since this can result in having a difference between your Yaml file and the actual pipeline that was run, which is unwanted. 