### PR TITLE
Add individual filters in yaml

### DIFF
--- a/tests/test_pipeline.yaml
+++ b/tests/test_pipeline.yaml
@@ -4,13 +4,27 @@
 importing:
   queries: ./tests/testdata/massbank_five_spectra.msp
   references:
-predefined_processing_queries: default
-predefined_processing_references: default
-additional_processing_queries:
+query_filters:
+- - make_charge_int
+- - interpret_pepmass
+- - derive_ionmode
+- - correct_charge
+- - add_compound_name
+- - derive_adduct_from_name
+- - derive_formula_from_name
+- - clean_compound_name
+- - add_precursor_mz
+- - require_precursor_mz
+- - add_parent_mass
+- - harmonize_undefined_inchikey
+- - harmonize_undefined_inchi
+- - harmonize_undefined_smiles
+- - repair_inchi_inchikey_smiles
+- - repair_parent_mass_match_smiles_wrapper
 - - normalize_intensities
 - - select_by_intensity
   - intensity_from: 0.001
-additional_processing_references: processing_queries
+reference_filters: processing_queries
 score_computations:
 - - precursormzmatch
   - tolerance: 120.0


### PR DESCRIPTION
Solves #478 

Instead of storing "default" in the pipeline we will store the actual filters called in the order they are run in a yaml file. 

This makes it possible to run a yaml file of an older version of matchms (with different default filters) and still getting the same results. 
It also gives me a quick check that the default filters actually do what I expect them to do as an user, without having to dive into the matchms code.