### PR TITLE
Remove file names from yaml

### DIFF
--- a/integration-tests/test_user_workflow.py
+++ b/integration-tests/test_user_workflow.py
@@ -17,8 +17,7 @@ def test_user_workflow():
                                score_computations=[["cosinegreedy",  {"tolerance": 0.3}]])
     pipeline = Pipeline(workflow)
     spectrums_file = os.path.join(module_root, "tests", "testdata", "pesticides.mgf")
-    pipeline.query_files = spectrums_file
-    pipeline.run()
+    pipeline.run(spectrums_file)
 
     scores = pipeline.scores
 

--- a/integration-tests/test_user_workflow.py
+++ b/integration-tests/test_user_workflow.py
@@ -8,9 +8,7 @@ from matchms.similarity import CosineGreedy
 
 def test_user_workflow():
     module_root = os.path.join(os.path.dirname(__file__), "..")
-    spectrums_file = os.path.join(module_root, "tests", "testdata", "pesticides.mgf")
-    workflow = create_workflow(query_file_name=spectrums_file,
-                               predefined_processing_queries="basic",
+    workflow = create_workflow(predefined_processing_queries="basic",
                                additional_filters_queries=[["add_parent_mass"],
                                                            ["normalize_intensities"],
                                                            ["select_by_relative_intensity", {"intensity_from": 0.0, "intensity_to": 1.0}],
@@ -18,6 +16,8 @@ def test_user_workflow():
                                                            ["require_minimum_number_of_peaks", {"n_required": 5}]],
                                score_computations=[["cosinegreedy",  {"tolerance": 0.3}]])
     pipeline = Pipeline(workflow)
+    spectrums_file = os.path.join(module_root, "tests", "testdata", "pesticides.mgf")
+    pipeline.query_files = spectrums_file
     pipeline.run()
 
     scores = pipeline.scores

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -147,8 +147,6 @@ class Pipeline:
         progress_bar
             Default is True. Set to False if no progress bar should be displayed.
         """
-        self.query_files = None
-        self.reference_files = None
         self._spectrums_queries = None
         self._spectrums_references = None
         self.is_symmetric = False
@@ -198,7 +196,7 @@ class Pipeline:
         if self.logging_level is None:
             self.logging_level = "WARNING"
 
-    def run(self):
+    def run(self, query_files, reference_files = None):
         """Execute the defined Pipeline workflow.
 
         This method will execute all steps of the workflow.
@@ -210,8 +208,8 @@ class Pipeline:
         self.write_to_logfile("--- Start running matchms pipeline. ---")
         self.write_to_logfile(f"Start time: {str(datetime.now())}")
         self.check_pipeline()
-        self.import_data(self.query_files,
-                         self.reference_files)
+        self.import_data(query_files,
+                         reference_files)
 
         # Processing
         self.write_to_logfile("--- Processing spectra ---")
@@ -295,18 +293,6 @@ class Pipeline:
         """Check if pipeline seems OK before running.
         Aim is to avoid pipeline crashing after long computation.
         """
-        def check_files_exist(filenames):
-            assert filenames is not None
-            if isinstance(filenames, str):
-                filenames = [filenames]
-            for filename in filenames:
-                assert os.path.exists(filename), f"File {filename} not found."
-
-        # Check if all files exist
-        check_files_exist(self.query_files)
-        if self.reference_files is not None:
-            check_files_exist(self.reference_files)
-
         # Check if all score compuation steps exist
         for computation in self.score_computations:
             if not isinstance(computation, list):
@@ -351,6 +337,18 @@ class Pipeline:
             List of files, or single filename, containing the reference spectra.
             If set to None (default) then all query spectra will be compared to each other.
         """
+        def check_files_exist(filenames):
+            assert filenames is not None
+            if isinstance(filenames, str):
+                filenames = [filenames]
+            for filename in filenames:
+                assert os.path.exists(filename), f"File {filename} not found."
+
+        # Check if all files exist
+        check_files_exist(query_files)
+        if reference_files is not None:
+            check_files_exist(reference_files)
+
         if isinstance(query_files, str):
             query_files = [query_files]
         if isinstance(reference_files, str):

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -359,8 +359,8 @@ class Pipeline:
         spectrums_queries = []
         for query_file in query_files:
             spectrums_queries += list(load_spectra(query_file))
+        self._spectrums_queries = spectrums_queries
         self.write_to_logfile(f"Loaded query spectra from {query_files}")
-        self.spectrums_queries += spectrums_queries
         if reference_files is None:
             self.is_symmetric = True
             self._spectrums_references = self._spectrums_queries
@@ -369,7 +369,7 @@ class Pipeline:
             spectrums_references = []
             for reference_file in reference_files:
                 spectrums_references += list(load_spectra(reference_file))
-            self._spectrums_references += spectrums_references
+            self._spectrums_references = spectrums_references
             self.write_to_logfile(f"Loaded reference spectra from {reference_files}")
 
 

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -210,7 +210,6 @@ class Pipeline:
         self.write_to_logfile("--- Start running matchms pipeline. ---")
         self.write_to_logfile(f"Start time: {str(datetime.now())}")
         self.check_pipeline()
-        self.write_to_logfile("--- Importing data ---")
         self.import_data(self.query_files,
                          self.reference_files)
 
@@ -356,18 +355,23 @@ class Pipeline:
             query_files = [query_files]
         if isinstance(reference_files, str):
             reference_files = [reference_files]
+        self.write_to_logfile("--- Importing data ---")
         spectrums_queries = []
         for query_file in query_files:
             spectrums_queries += list(load_spectra(query_file))
+        self.write_to_logfile(f"Loaded query spectra from {query_files}")
         self.spectrums_queries += spectrums_queries
         if reference_files is None:
             self.is_symmetric = True
             self.spectrums_references = self.spectrums_queries
+            self.write_to_logfile(f"Reference spectra are equal to the query spectra (is_symmetric = True)")
         else:
             spectrums_references = []
             for reference_file in reference_files:
                 spectrums_references += list(load_spectra(reference_file))
             self.spectrums_references += spectrums_references
+            self.write_to_logfile(f"Loaded reference spectra from {reference_files}")
+
 
     # Getter & Setters
     @property

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -354,11 +354,16 @@ class Pipeline:
         if isinstance(reference_files, str):
             reference_files = [reference_files]
         self.write_to_logfile("--- Importing data ---")
+
+        # import query spectra
         spectrums_queries = []
         for query_file in query_files:
             spectrums_queries += list(load_spectra(query_file))
         self._spectrums_queries = spectrums_queries
         self.write_to_logfile(f"Loaded query spectra from {query_files}")
+        self.write_to_logfile(f"Loaded {len(self._spectrums_queries)} query spectra")
+
+        # import reference spectra
         if reference_files is None:
             self.is_symmetric = True
             self._spectrums_references = self._spectrums_queries
@@ -369,7 +374,7 @@ class Pipeline:
                 spectrums_references += list(load_spectra(reference_file))
             self._spectrums_references = spectrums_references
             self.write_to_logfile(f"Loaded reference spectra from {reference_files}")
-
+            self.write_to_logfile(f"Loaded {len(self._spectrums_references)} reference spectra")
 
     # Getter & Setters
     @property

--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -362,7 +362,7 @@ class Pipeline:
         if reference_files is None:
             self.is_symmetric = True
             self._spectrums_references = self._spectrums_queries
-            self.write_to_logfile(f"Reference spectra are equal to the query spectra (is_symmetric = True)")
+            self.write_to_logfile("Reference spectra are equal to the query spectra (is_symmetric = True)")
         else:
             spectrums_references = []
             for reference_file in reference_files:
@@ -403,4 +403,3 @@ class Pipeline:
     @property
     def spectrums_references(self):
         return self._spectrums_references
-

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,31 +14,28 @@ spectrums_file_msp = os.path.join(module_root, "tests", "testdata", "massbank_fi
 def test_pipeline_initial_check_missing_file():
     workflow = create_workflow()
     pipeline = Pipeline(workflow)
-    pipeline.query_files = "non_existing_file.msp"
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}]]
     with pytest.raises(AssertionError) as msg:
-        pipeline.run()
+        pipeline.run("non_existing_file.msp")
     assert "not found" in str(msg.value)
 
 
 def test_pipeline_initial_check_unknown_step():
     workflow = create_workflow()
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
     pipeline.score_computations = [["precursormzOOPSmatch",  {"tolerance": 120.0}]]
     with pytest.raises(ValueError) as msg:
-        pipeline.run()
+        pipeline.run(spectrums_file_msp)
     assert "Unknown score computation:" in str(msg.value)
 
 
 def test_pipeline_symmetric():
     workflow = create_workflow()
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
     pipeline.predefined_processing_queries = "basic"
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    ["modifiedcosine", {"tolerance": 10.0}]]
-    pipeline.run()
+    pipeline.run(spectrums_file_msp)
 
     assert len(pipeline.spectrums_queries) == 5
     assert pipeline.spectrums_queries[0] == pipeline.spectrums_references[0]
@@ -55,12 +52,11 @@ def test_pipeline_symmetric():
 def test_pipeline_symmetric_filters():
     workflow = create_workflow()
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
     pipeline.predefined_processing_queries = "basic"
     pipeline.additional_processing_queries = [[select_by_mz, {"mz_from": 0, "mz_to": 1000}]]
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    ["modifiedcosine", {"tolerance": 10.0}]]
-    pipeline.run()
+    pipeline.run(spectrums_file_msp)
 
     assert len(pipeline.spectrums_queries) == 5
     assert pipeline.spectrums_queries[0].metadata == pipeline.spectrums_references[0].metadata
@@ -78,12 +74,11 @@ def test_pipeline_symmetric_filters():
 def test_pipeline_symmetric_masking():
     workflow = create_workflow()
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
     pipeline.predefined_processing_queries = "basic"
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    ["modifiedcosine", {"tolerance": 10.0}],
                                    ["filter_by_range", {"low": 0.3, "above_operator": '>='}]]
-    pipeline.run()
+    pipeline.run(spectrums_file_msp)
 
     assert len(pipeline.spectrums_queries) == 5
     assert pipeline.spectrums_queries[0] == pipeline.spectrums_references[0]
@@ -100,11 +95,10 @@ def test_pipeline_symmetric_masking():
 def test_pipeline_symmetric_custom_score():
     workflow = create_workflow()
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
     pipeline.predefined_processing_queries = "basic"
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    [ModifiedCosine, {"tolerance": 10.0}]]
-    pipeline.run()
+    pipeline.run(spectrums_file_msp)
 
     assert len(pipeline.spectrums_queries) == 5
     assert pipeline.spectrums_queries[0] == pipeline.spectrums_references[0]
@@ -122,13 +116,11 @@ def test_pipeline_non_symmetric():
     """Test importing from multiple files and different inputs for query and references."""
     workflow = create_workflow()
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
     pipeline.predefined_processing_queries = "basic"
     pipeline.predefined_processing_references = "basic"
-    pipeline.reference_files = [spectrums_file_msp, spectrums_file_msp]
     pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
                                    ["modifiedcosine", {"tolerance": 10.0}]]
-    pipeline.run()
+    pipeline.run(spectrums_file_msp, [spectrums_file_msp, spectrums_file_msp])
 
     assert len(pipeline.spectrums_queries) == 5
     assert len(pipeline.spectrums_references) == 10
@@ -148,8 +140,7 @@ def test_pipeline_from_yaml():
     config_file = os.path.join(module_root, "tests", "test_pipeline.yaml")
     workflow = load_in_workflow_from_yaml_file(config_file)
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
-    pipeline.run()
+    pipeline.run(spectrums_file_msp)
     assert len(pipeline.spectrums_queries) == 5
     assert pipeline.spectrums_queries[0] == pipeline.spectrums_references[0]
     assert pipeline.is_symmetric is True
@@ -170,15 +161,13 @@ def test_pipeline_to_and_from_yaml(tmp_path):
     assert os.path.exists(config_file)
 
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
-    pipeline.run()
+    pipeline.run(spectrums_file_msp)
     scores_run1 = pipeline.scores
 
     # Load again
     workflow = load_in_workflow_from_yaml_file(config_file)
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
-    pipeline.run()
+    pipeline.run(spectrums_file_msp)
     assert pipeline.scores.scores == scores_run1.scores
 
 
@@ -186,12 +175,9 @@ def test_pipeline_logging(tmp_path):
     pytest.importorskip("rdkit")
     workflow = create_workflow()
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
-    pipeline.score_computations = [["precursormzmatch",  {"tolerance": 120.0}],
-                                   [ModifiedCosine, {"tolerance": 10.0}]]
     logfile = os.path.join(tmp_path, "testlog.log")
     pipeline.logging_file = logfile
-    pipeline.run()
+    pipeline.run(spectrums_file_msp)
 
     assert os.path.exists(logfile)
     with open(logfile, "r", encoding="utf-8") as f:
@@ -209,9 +195,7 @@ def test_FingerprintSimilarity_pipeline():
                                                    ["fingerprintsimilarity", {"similarity_measure": "jaccard"}]],
                                )
     pipeline = Pipeline(workflow)
-    pipeline.query_files = spectrums_file_msp
-    pipeline.reference_files = spectrums_file_msp
-    pipeline.run()
+    pipeline.run(spectrums_file_msp, spectrums_file_msp)
     assert len(pipeline.spectrums_queries[0].get("fingerprint")) == 2048
     assert pipeline.scores.scores.shape == (5, 5, 2)
     assert pipeline.scores.score_names == ('MetadataMatch', 'FingerprintSimilarity')

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -148,6 +148,7 @@ def test_pipeline_from_yaml():
     config_file = os.path.join(module_root, "tests", "test_pipeline.yaml")
     workflow = load_in_workflow_from_yaml_file(config_file)
     pipeline = Pipeline(workflow)
+    pipeline.query_files = spectrums_file_msp
     pipeline.run()
     assert len(pipeline.spectrums_queries) == 5
     assert pipeline.spectrums_queries[0] == pipeline.spectrums_references[0]
@@ -165,17 +166,18 @@ def test_pipeline_to_and_from_yaml(tmp_path):
     config_file = os.path.join(tmp_path, "test_pipeline.yaml")
 
     workflow = create_workflow(config_file, score_computations=[["precursormzmatch",  {"tolerance": 120.0}],
-                                                                ["modifiedcosine", {"tolerance": 10.0}]],
-                               query_file_name=spectrums_file_msp)
+                                                                ["modifiedcosine", {"tolerance": 10.0}]])
     assert os.path.exists(config_file)
 
     pipeline = Pipeline(workflow)
+    pipeline.query_files = spectrums_file_msp
     pipeline.run()
     scores_run1 = pipeline.scores
 
     # Load again
     workflow = load_in_workflow_from_yaml_file(config_file)
     pipeline = Pipeline(workflow)
+    pipeline.query_files = spectrums_file_msp
     pipeline.run()
     assert pipeline.scores.scores == scores_run1.scores
 
@@ -203,12 +205,12 @@ def test_FingerprintSimilarity_pipeline():
                                additional_filters_queries=["add_fingerprint"],
                                predefined_processing_reference="basic",
                                additional_filters_references=["add_fingerprint"],
-                               query_file_name=spectrums_file_msp,
-                               reference_file_name=spectrums_file_msp,
                                score_computations=[["metadatamatch", {"field": "precursor_mz", "matching_type": "difference", "tolerance": 50}],
                                                    ["fingerprintsimilarity", {"similarity_measure": "jaccard"}]],
                                )
     pipeline = Pipeline(workflow)
+    pipeline.query_files = spectrums_file_msp
+    pipeline.reference_files = spectrums_file_msp
     pipeline.run()
     assert len(pipeline.spectrums_queries[0].get("fingerprint")) == 2048
     assert pipeline.scores.scores.shape == (5, 5, 2)

--- a/tests/test_pipeline.yaml
+++ b/tests/test_pipeline.yaml
@@ -1,9 +1,6 @@
 # Matchms pipeline config file
 # Change and adapt fields where necessary
 # ====================
-importing:
-  queries: ./tests/testdata/massbank_five_spectra.msp
-  references:
 query_filters:
 - - make_charge_int
 - - interpret_pepmass

--- a/tests/test_scoring_method_consistency.py
+++ b/tests/test_scoring_method_consistency.py
@@ -89,8 +89,7 @@ def test_consistency_scoring_and_pipeline(spectrums, similarity_measure):
                                score_computations=[similarity_measure]
                                )
     pipeline = Pipeline(workflow)
-    pipeline.query_files = json_file
-    pipeline.run()
+    pipeline.run(json_file)
 
     if computed_scores_matrix.dtype.names is None:
         assert np.allclose(pipeline.scores.to_array(), computed_scores_matrix)

--- a/tests/test_scoring_method_consistency.py
+++ b/tests/test_scoring_method_consistency.py
@@ -84,12 +84,12 @@ def test_consistency_scoring_and_pipeline(spectrums, similarity_measure):
     computed_scores_matrix = scoring_method.matrix(spectrums, spectrums)
 
     # Run pipeline
-    workflow = create_workflow(query_file_name=json_file,
-                               predefined_processing_queries="basic",
+    workflow = create_workflow(predefined_processing_queries="basic",
                                additional_filters_queries=[["add_parent_mass"], ["normalize_intensities"]],
                                score_computations=[similarity_measure]
                                )
     pipeline = Pipeline(workflow)
+    pipeline.query_files = json_file
     pipeline.run()
 
     if computed_scores_matrix.dtype.names is None:


### PR DESCRIPTION
Currently the yaml file stores the query and reference files.
This is not intuitive to me when sharing pipelines, since a path will always be different. To me it would make more sense to have a pipeline file store all the steps, but specifying the query files and reference files in the python script were Pipeline is defined. Instead the log file should store the query file and reference file location. 

- [x] Remove spectrum files from yaml file
- [x] Add spectrum files to logging
- [x] Specify file names in run, instead of as Pipeline attributes

(Docstring will be updated, once the final setup is selected)