### PR TITLE
logging level adjustments

### DIFF
--- a/matchms/filtering/metadata_processing/add_compound_name.py
+++ b/matchms/filtering/metadata_processing/add_compound_name.py
@@ -21,6 +21,6 @@ def add_compound_name(spectrum_in: SpectrumType) -> SpectrumType:
             spectrum.set("compound_name", spectrum.get("title"))
             return spectrum
 
-        logger.warning("No compound name found in metadata.")
+        logger.info("No compound name found in metadata.")
 
     return spectrum

--- a/tests/filtering/test_add_compound_name.py
+++ b/tests/filtering/test_add_compound_name.py
@@ -1,7 +1,8 @@
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import add_compound_name
-from matchms.logging_functions import reset_matchms_logger, set_matchms_logger_level
+from matchms.logging_functions import (reset_matchms_logger,
+                                       set_matchms_logger_level)
 from ..builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/filtering/test_add_compound_name.py
+++ b/tests/filtering/test_add_compound_name.py
@@ -5,7 +5,7 @@ from matchms.logging_functions import reset_matchms_logger, set_matchms_logger_l
 from ..builder_Spectrum import SpectrumBuilder
 
 
-set_matchms_logger_level("info")
+set_matchms_logger_level("INFO")
 
 
 @pytest.mark.parametrize("metadata, expected, check_log", [

--- a/tests/filtering/test_add_compound_name.py
+++ b/tests/filtering/test_add_compound_name.py
@@ -1,8 +1,11 @@
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import add_compound_name
-from matchms.logging_functions import reset_matchms_logger
+from matchms.logging_functions import reset_matchms_logger, set_matchms_logger_level
 from ..builder_Spectrum import SpectrumBuilder
+
+
+set_matchms_logger_level("info")
 
 
 @pytest.mark.parametrize("metadata, expected, check_log", [
@@ -19,7 +22,7 @@ def test_add_compound_name(metadata, expected, check_log):
     assert spectrum.get(
         "compound_name") == expected, "Expected no compound name."
     if check_log:
-        log.check(('matchms', 'WARNING', 'No compound name found in metadata.'))
+        log.check(('matchms', 'INFO', 'No compound name found in metadata.'))
         reset_matchms_logger()
 
 
@@ -27,4 +30,4 @@ def test_empty_spectrum():
     spectrum_in = None
     spectrum = add_compound_name(spectrum_in)
 
-    assert spectrum is None, "Expected differnt handling of None spectrum."
+    assert spectrum is None, "Expected different handling of None spectrum."

--- a/tests/filtering/test_add_compound_name.py
+++ b/tests/filtering/test_add_compound_name.py
@@ -5,15 +5,13 @@ from matchms.logging_functions import reset_matchms_logger, set_matchms_logger_l
 from ..builder_Spectrum import SpectrumBuilder
 
 
-set_matchms_logger_level("INFO")
-
-
 @pytest.mark.parametrize("metadata, expected, check_log", [
     [{"name": "Testospectrum"}, "Testospectrum", False],
     [{"title": "Testospectrum"}, "Testospectrum", False],
     [{"othername": "Testospectrum"}, None, True]
 ])
 def test_add_compound_name(metadata, expected, check_log):
+    set_matchms_logger_level("INFO")
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
 
     with LogCapture() as log:
@@ -23,7 +21,7 @@ def test_add_compound_name(metadata, expected, check_log):
         "compound_name") == expected, "Expected no compound name."
     if check_log:
         log.check(('matchms', 'INFO', 'No compound name found in metadata.'))
-        reset_matchms_logger()
+    reset_matchms_logger()
 
 
 def test_empty_spectrum():


### PR DESCRIPTION
Whenever people work with unknown / not annotated data they will see warnings saying "No compound name found" all the time... although that is not really a warning sign in many cases. So I "downgraded" it to info-level.