### PR TITLE
Add default settings to processing steps

### DIFF
--- a/matchms/Pipeline.py
+++ b/matchms/Pipeline.py
@@ -214,24 +214,25 @@ class Pipeline:
         self.__workflow = workflow
         self.check_workflow()
 
-        self.write_to_logfile("--- Processing pipeline: ---")
         self._initialize_spectrum_processor_queries()
         if self.is_symmetric is False:
             self._initialize_spectrum_processor_references()
 
     def _initialize_spectrum_processor_queries(self):
         """Initialize spectrum processing workflow for the query spectra."""
+        self.write_to_logfile("--- Processing pipeline query spectra: ---")
         self.processing_queries = initialize_spectrum_processor(
             None,
             self.__workflow["query_filters"]
             )
-
         self.write_to_logfile(str(self.processing_queries))
         if self.processing_queries.processing_steps != self.__workflow["query_filters"]:
             logger.warning("The order of the filters has been changed compared to the Yaml file.")
 
     def _initialize_spectrum_processor_references(self):
         """Initialize spectrum processing workflow for the reference spectra."""
+        self.write_to_logfile("--- Processing pipeline reference spectra: ---")
+
         self.processing_references = initialize_spectrum_processor(
             None,
             self.__workflow["reference_filters"]

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -221,6 +221,7 @@ def get_parameter_settings(func):
         return None
     return parameter_settings
 
+
 # List all filters in a functionally working order
 ALL_FILTERS = [msfilters.make_charge_int,
                msfilters.add_compound_name,

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import partial
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 from tqdm import tqdm

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -198,11 +198,13 @@ class SpectrumProcessor:
 def check_all_parameters_given(func):
     """Asserts that all added parameters for a function are given (except spectrum_in)"""
     signature = inspect.signature(func)
-    parameters_without_value = 0
+    parameters_without_value = []
     for parameter, value in signature.parameters.items():
         if value.default is inspect.Parameter.empty:
-            parameters_without_value += 1
-    assert parameters_without_value == 1, f"More than one parameter of the function {func.__name__} is not specified"
+            parameters_without_value.append(parameter)
+    assert len(parameters_without_value) == 1, \
+        f"More than one parameter of the function {func.__name__} is not specified, " \
+        f"the parameters not specified are {parameters_without_value}"
 
 
 def get_parameter_settings(func):

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -262,7 +262,6 @@ DEFAULT_FILTERS = BASIC_FILTERS \
        "harmonize_undefined_inchi",
        "harmonize_undefined_smiles",
        "repair_inchi_inchikey_smiles",
-       "repair_parent_mass_match_smiles_wrapper",
        "normalize_intensities",
     ]
 FULLY_ANNOTATED_PROCESSING = DEFAULT_FILTERS \

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -172,12 +172,12 @@ class SpectrumProcessor:
     @property
     def processing_steps(self):
         filter_list = []
-        for filter in self.filters:
-            if isinstance(filter, partial):
-                filter_params = filter.keywords
-                filter_list.append((filter.__name__, filter_params))
+        for filter_step in self.filters:
+            if isinstance(filter_step, partial):
+                filter_params = filter_step.keywords
+                filter_list.append((filter_step.__name__, filter_params))
             else:
-                filter_list.append(filter.__name__)
+                filter_list.append(filter_step.__name__)
         return filter_list
 
     def __str__(self):

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -198,11 +198,11 @@ class SpectrumProcessor:
 def check_all_parameters_given(func):
     """Asserts that all added parameters for a function are given (except spectrum_in)"""
     signature = inspect.signature(func)
+    parameters_without_value = 0
     for parameter, value in signature.parameters.items():
-        # Skip the spectrum_in parameters
-        if "spectrum" not in parameter:
-            assert value.default is not inspect.Parameter.empty, \
-                f"The parameter {parameter} in the function {func.__name__} was not given"
+        if value.default is inspect.Parameter.empty:
+            parameters_without_value += 1
+    assert parameters_without_value == 1, f"More than one parameter of the function {func.__name__} is not specified"
 
 
 def get_parameter_settings(func):

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -30,8 +30,8 @@ class SpectrumProcessor:
                 raise ValueError("Predefined pipeline parameter should be a string")
             if predefined_pipeline not in PREDEFINED_PIPELINES:
                 raise ValueError(f"Unknown processing pipeline '{predefined_pipeline}'. Available pipelines: {list(PREDEFINED_PIPELINES.keys())}")
-            for fname in PREDEFINED_PIPELINES[predefined_pipeline]:
-                self.add_matchms_filter(fname)
+            for filter_name in PREDEFINED_PIPELINES[predefined_pipeline]:
+                self.add_matchms_filter(filter_name)
 
     def add_filter(self, filter_function: Union[Tuple[str], str]):
         """Add a filter to the processing pipeline. Takes both matchms filter names (and parameters)

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -44,7 +44,7 @@ class SpectrumProcessor:
         else:
             self.add_custom_filter(filter_function[0], filter_function[1])
 
-    def add_matchms_filter(self, filter_spec: Union[Tuple[str], str]):
+    def add_matchms_filter(self, filter_spec: Union[Tuple[str, Dict[str, any]], str]):
         """
         Add a filter to the processing pipeline.
 

--- a/matchms/SpectrumProcessor.py
+++ b/matchms/SpectrumProcessor.py
@@ -171,11 +171,27 @@ class SpectrumProcessor:
 
     @property
     def processing_steps(self):
-        return [x.__name__ for x in self.filters]
+        filter_list = []
+        for filter in self.filters:
+            if isinstance(filter, partial):
+                filter_params = filter.keywords
+                filter_list.append((filter.__name__, filter_params))
+            else:
+                filter_list.append(filter.__name__)
+        return filter_list
 
     def __str__(self):
-        summary_string = "SpectrumProcessor\nProcessing steps:\n - "
-        return summary_string + "\n - ".join(self.processing_steps)
+        summary_string = "SpectrumProcessor\nProcessing steps:"
+        for processing_step in self.processing_steps:
+            if isinstance(processing_step, str):
+                summary_string += "\n- " + processing_step
+            elif isinstance(processing_step, tuple):
+                filter_name = processing_step[0]
+                summary_string += "\n- - " + filter_name
+                filter_params = processing_step[1]
+                for filter_param in filter_params:
+                    summary_string += "\n  - " + str(filter_param)
+        return summary_string
 
 
 # List all filters in a functionally working order

--- a/tests/filtering/test_spectrum_processor.py
+++ b/tests/filtering/test_spectrum_processor.py
@@ -24,24 +24,23 @@ def spectrums():
 
 def test_filter_sorting_and_output():
     processing = SpectrumProcessor("default")
-    expected_filters = [
-        'make_charge_int',
-        'add_compound_name',
-        'derive_adduct_from_name',
-        'derive_formula_from_name',
-        'clean_compound_name',
-        'interpret_pepmass',
-        'add_precursor_mz',
-        'derive_ionmode',
-        'correct_charge',
-        'require_precursor_mz',
-        'add_parent_mass',
-        'harmonize_undefined_inchikey',
-        'harmonize_undefined_inchi',
-        'harmonize_undefined_smiles',
-        'repair_inchi_inchikey_smiles',
-        'normalize_intensities'
-        ]
+    expected_filters = ['make_charge_int',
+                        'add_compound_name',
+                        ('derive_adduct_from_name', {'remove_adduct_from_name': True}),
+                        ('derive_formula_from_name', {'remove_formula_from_name': True}),
+                        'clean_compound_name',
+                        'interpret_pepmass',
+                        'add_precursor_mz',
+                        'derive_ionmode',
+                        'correct_charge',
+                        ('require_precursor_mz', {'minimum_accepted_mz': 10.0}),
+                        ('add_parent_mass',
+                         {'estimate_from_adduct': True, 'overwrite_existing_entry': False}),
+                        ('harmonize_undefined_inchikey', {'aliases': None, 'undefined': ''}),
+                        ('harmonize_undefined_inchi', {'aliases': None, 'undefined': ''}),
+                        ('harmonize_undefined_smiles', {'aliases': None, 'undefined': ''}),
+                        'repair_inchi_inchikey_smiles',
+                        'normalize_intensities']
     actual_filters = [x.__name__ for x in processing.filters]
     assert actual_filters == expected_filters
     # 2nd way to access the filter names via processing_steps attribute:
@@ -50,8 +49,8 @@ def test_filter_sorting_and_output():
 
 def test_string_output():
     processing = SpectrumProcessor("minimal")
-    expected_str = "SpectrumProcessor\nProcessing steps:\n- make_charge_int\n- interpret_pepmass"\
-        "\n- derive_ionmode\n- correct_charge"
+    expected_str = "SpectrumProcessor\nProcessing steps:\n- make_charge_int\n- interpret_pepmass" \
+                   "\n- derive_ionmode\n- correct_charge"
     assert str(processing) == expected_str
 
 
@@ -64,7 +63,7 @@ def test_add_matchms_filter(metadata, expected):
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
     processor = SpectrumProcessor("minimal")
     processor.add_matchms_filter(("require_correct_ionmode",
-                                 {"ion_mode_to_keep": "both"}))
+                                  {"ion_mode_to_keep": "both"}))
     spectrum = processor.process_spectrum(spectrum_in)
     if expected is None:
         assert spectrum is None
@@ -174,7 +173,7 @@ def test_add_filter_with_custom(spectrums):
 def test_add_filter_with_matchms_filter(spectrums):
     processor = SpectrumProcessor("minimal")
     processor.add_filter(("require_correct_ionmode",
-                         {"ion_mode_to_keep": "both"}))
+                          {"ion_mode_to_keep": "both"}))
     filters = processor.filters
     assert filters[-1].__name__ == "require_correct_ionmode"
     spectrums, _ = processor.process_spectrums(spectrums, create_report=True)
@@ -186,6 +185,7 @@ def test_all_filters_is_complete():
 
     This is important, since performing tests in the wrong order can make some filters useless.
     """
+
     def get_functions_from_file(file_path):
         """Gets all python functions in a file"""
         with open(file_path, 'r', encoding="utf-8") as file:

--- a/tests/filtering/test_spectrum_processor.py
+++ b/tests/filtering/test_spectrum_processor.py
@@ -60,6 +60,13 @@ def test_overwrite_default_settings(filter_step, expected):
     assert processor.processing_steps == expected_filters
 
 
+def test_incomplete_parameters():
+    """Test if an error is raised when running an incomplete command"""
+    with pytest.raises(AssertionError):
+        processor = SpectrumProcessor(None)
+        processor.add_filter("require_correct_ionmode")
+
+
 def test_string_output():
     processing = SpectrumProcessor("minimal")
     expected_str = "SpectrumProcessor\nProcessing steps:\n- make_charge_int\n- interpret_pepmass" \

--- a/tests/filtering/test_spectrum_processor.py
+++ b/tests/filtering/test_spectrum_processor.py
@@ -40,7 +40,6 @@ def test_filter_sorting_and_output():
         'harmonize_undefined_inchi',
         'harmonize_undefined_smiles',
         'repair_inchi_inchikey_smiles',
-        'repair_parent_mass_match_smiles_wrapper',
         'normalize_intensities'
         ]
     actual_filters = [x.__name__ for x in processing.filters]
@@ -51,8 +50,8 @@ def test_filter_sorting_and_output():
 
 def test_string_output():
     processing = SpectrumProcessor("minimal")
-    expected_str = "SpectrumProcessor\nProcessing steps:\n - make_charge_int\n - interpret_pepmass"\
-        "\n - derive_ionmode\n - correct_charge"
+    expected_str = "SpectrumProcessor\nProcessing steps:\n- make_charge_int\n- interpret_pepmass"\
+        "\n- derive_ionmode\n- correct_charge"
     assert str(processing) == expected_str
 
 

--- a/tests/filtering/test_spectrum_processor.py
+++ b/tests/filtering/test_spectrum_processor.py
@@ -41,10 +41,23 @@ def test_filter_sorting_and_output():
                         ('harmonize_undefined_smiles', {'aliases': None, 'undefined': ''}),
                         'repair_inchi_inchikey_smiles',
                         'normalize_intensities']
-    actual_filters = [x.__name__ for x in processing.filters]
-    assert actual_filters == expected_filters
-    # 2nd way to access the filter names via processing_steps attribute:
     assert processing.processing_steps == expected_filters
+
+
+@pytest.mark.parametrize("filter_step, expected", [
+    [("add_parent_mass", {'estimate_from_adduct': False}),
+     ('add_parent_mass', {'estimate_from_adduct': False, 'overwrite_existing_entry': False})],
+    ["derive_adduct_from_name",
+     ('derive_adduct_from_name', {'remove_adduct_from_name': True})],
+    [("require_correct_ionmode", {"ion_mode_to_keep": "both"}),
+     ("require_correct_ionmode", {"ion_mode_to_keep": "both"})],
+])
+def test_overwrite_default_settings(filter_step, expected):
+    """Test if both default settings and set settings are returned in processing steps"""
+    processor = SpectrumProcessor(None)
+    processor.add_filter(filter_step)
+    expected_filters = [expected]
+    assert processor.processing_steps == expected_filters
 
 
 def test_string_output():


### PR DESCRIPTION
Fixes #494 
Any default settings of functions are not shown in the yaml file. This is bad for reproducibility, since changing any default settings in a filter function will currently result in a different pipeline running.

Instead we will now automatically get the default filter settings combined with the defined parameters from each filter and returning them in properties. (this will be used to create yaml files and printing the log file)