### PR TITLE
Improve derive adduct from name

### DIFF
--- a/matchms/filtering/filter_order_and_default_pipelines.py
+++ b/matchms/filtering/filter_order_and_default_pipelines.py
@@ -13,8 +13,6 @@ ALL_FILTERS = [msfilters.make_charge_int,
                msfilters.add_retention_time,
                msfilters.derive_ionmode,
                msfilters.correct_charge,
-               # msfilters.derive_adduct_from_name,  # run again? Or improve those filters?
-               # msfilters.derive_formula_from_name,  # run again? Or improve those filters?
                msfilters.require_precursor_mz,
                msfilters.harmonize_undefined_inchikey,
                msfilters.harmonize_undefined_inchi,

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -1,17 +1,16 @@
 import logging
 import re
 from typing import List, Optional
-from matchms.typing import SpectrumType
 from ..filter_utils.load_known_adducts import load_known_adducts
 from .clean_adduct import _clean_adduct
 from matchms.filtering.filter_utils.interpret_unknown_adduct import get_multiplier_and_mass_from_adduct
-
+from matchms.Spectrum import Spectrum
 
 logger = logging.getLogger("matchms")
 
 
-def derive_adduct_from_name(spectrum_in: SpectrumType,
-                            remove_adduct_from_name: bool = True) -> SpectrumType:
+def derive_adduct_from_name(spectrum_in: Spectrum,
+                            remove_adduct_from_name: bool = True) -> Optional[Spectrum]:
     """Find adduct in compound name and add to metadata (if not present yet).
 
     Method to interpret the given compound name to find the adduct.

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -1,8 +1,10 @@
 import logging
 import re
+from typing import List, Optional
 from matchms.typing import SpectrumType
 from ..filter_utils.load_known_adducts import load_known_adducts
 from .clean_adduct import _clean_adduct
+from matchms.filtering.filter_utils.interpret_unknown_adduct import get_multiplier_and_mass_from_adduct
 
 
 logger = logging.getLogger("matchms")
@@ -26,34 +28,56 @@ def derive_adduct_from_name(spectrum_in: SpectrumType,
 
     spectrum = spectrum_in.clone()
 
-    if spectrum.get("compound_name", None) is not None:
-        name = spectrum.get("compound_name")
-    else:
-        assert spectrum.get("name", None) in [None, ""], ("Found 'name' but not 'compound_name' in metadata",
-                                                          "Apply 'add_compound_name' filter first.")
+    compound_name = spectrum.get("compound_name", None)
+    if compound_name is None:
+        if spectrum.get("name", None) not in [None, ""]:
+            logger.warning("Found 'name' but not 'compound_name' in metadata",
+                           "Apply 'add_compound_name' filter first.")
         return spectrum
-
     # Detect adduct in compound name
-    adduct_from_name = None
-    name_split = name.split(" ")
-    for name_part in name_split[::-1][:2]:
+    parts_that_look_like_adduct = []
+    name_split = compound_name.split(" ")
+    for name_part in name_split:
         if _looks_like_adduct(name_part):
-            adduct_from_name = name_part
-            break
+            # Some adducts occur more than once. So they are all removed.
+            parts_that_look_like_adduct.append(name_part)
 
-    if adduct_from_name and remove_adduct_from_name:
-        name_adduct_removed = " ".join([x for x in name_split if x != adduct_from_name])
+    if remove_adduct_from_name and len(parts_that_look_like_adduct) > 0:
+        name_adduct_removed = " ".join([x for x in name_split if x not in parts_that_look_like_adduct])
         name_adduct_removed = name_adduct_removed.strip("; ")
         spectrum.set("compound_name", name_adduct_removed)
-        logger.info("Removed adduct %s from compound name.", adduct_from_name)
+        logger.info("Removed adduct %s from compound name.", parts_that_look_like_adduct)
 
-    # Add found adduct to metadata (if not present yet)
-    if adduct_from_name and not _looks_like_adduct(spectrum.get("adduct")):
-        adduct_cleaned = _clean_adduct(adduct_from_name)
-        spectrum.set("adduct", adduct_cleaned)
-        logger.info("Added adduct %s from the compound name to metadata.", spectrum.get('adduct'))
+    if len(parts_that_look_like_adduct) > 0 and not _looks_like_adduct(spectrum.get("adduct")):
+        best_adduct = _select_best_adduct(parts_that_look_like_adduct)
+        if best_adduct:
+            # Add found adduct to metadata (if not present yet)
+            spectrum.set("adduct", best_adduct)
+            logger.info("Added adduct %s from the compound name to metadata.", spectrum.get('adduct'))
 
     return spectrum
+
+
+def _select_best_adduct(list_of_adducts: List[str]) -> Optional[str]:
+    """Selects an adduct that can actually be interpreted (complete with charge and known elements)"""
+    unique_cleaned_adducts = list({_clean_adduct(adduct) for adduct in list_of_adducts})
+    if len(unique_cleaned_adducts) == 1:
+        return unique_cleaned_adducts[0]
+
+    completely_correct_adduct = []
+    for adduct in unique_cleaned_adducts:
+        multiplier, correction_mass = get_multiplier_and_mass_from_adduct(adduct)
+        # check if both multiplier and correction mass are not None
+        if multiplier and correction_mass:
+            completely_correct_adduct.append(adduct)
+    if len(completely_correct_adduct) == 0:
+        return None
+    if len(completely_correct_adduct) == 1:
+        return completely_correct_adduct[0]
+    else:
+        logger.warning("Two potential adducts were found in the compound name that are both valid adducts. "
+                       "The first adduct is used. The adducts found are: %s", completely_correct_adduct)
+        return completely_correct_adduct[0]
 
 
 def _looks_like_adduct(adduct):

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -1,10 +1,12 @@
 import logging
 import re
 from typing import List, Optional
+from matchms.filtering.filter_utils.interpret_unknown_adduct import \
+    get_multiplier_and_mass_from_adduct
+from matchms.Spectrum import Spectrum
 from ..filter_utils.load_known_adducts import load_known_adducts
 from .clean_adduct import _clean_adduct
-from matchms.filtering.filter_utils.interpret_unknown_adduct import get_multiplier_and_mass_from_adduct
-from matchms.Spectrum import Spectrum
+
 
 logger = logging.getLogger("matchms")
 

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -32,7 +32,7 @@ def derive_adduct_from_name(spectrum_in: Spectrum,
     compound_name = spectrum.get("compound_name", None)
     if compound_name is None:
         if spectrum.get("name", None) not in [None, ""]:
-            logger.warning("Found 'name' but not 'compound_name' in metadata",
+            logger.warning("Found 'name' but not 'compound_name' in metadata"
                            "Apply 'add_compound_name' filter first.")
         return spectrum
     # Detect adduct in compound name
@@ -75,10 +75,9 @@ def _select_best_adduct(list_of_adducts: List[str]) -> Optional[str]:
         return None
     if len(completely_correct_adduct) == 1:
         return completely_correct_adduct[0]
-    else:
-        logger.warning("Two potential adducts were found in the compound name that are both valid adducts. "
-                       "The first adduct is used. The adducts found are: %s", completely_correct_adduct)
-        return completely_correct_adduct[0]
+    logger.warning("Two potential adducts were found in the compound name that are both valid adducts. "
+                   "The first adduct is used. The adducts found are: %s", completely_correct_adduct)
+    return completely_correct_adduct[0]
 
 
 def _looks_like_adduct(adduct):

--- a/tests/filtering/test_all_filter_order.py
+++ b/tests/filtering/test_all_filter_order.py
@@ -29,7 +29,10 @@ ANNOTATION_REPARATIONS = [msfilters.repair_inchi_inchikey_smiles, msfilters.deri
     [ANNOTATION_REPARATIONS + [msfilters.add_parent_mass],
      [msfilters.derive_smiles_from_pubchem_compound_name_search, ]],
     # The parent mass is based on the adduct, so adduct filters should be performed first
-    [[msfilters.clean_adduct, msfilters.derive_adduct_from_name], [msfilters.add_parent_mass]]
+    [[msfilters.clean_adduct, msfilters.derive_adduct_from_name], [msfilters.add_parent_mass]],
+    # The adduct filter removes all occurances while derive formula from name only removes when it is at the end
+    # of compound name. Removing adducts therefore has to happen first.
+    [[msfilters.derive_adduct_from_name], [msfilters.derive_formula_from_name]],
 ])
 def test_all_filter_order(early_filters: List[Callable], later_filters: List[Callable]):
     """Tests if early_filter is run before later_filter"""

--- a/tests/filtering/test_derive_adduct_from_name.py
+++ b/tests/filtering/test_derive_adduct_from_name.py
@@ -14,9 +14,11 @@ from ..builder_Spectrum import SpectrumBuilder
     [{"compound_name": "peptideXYZ [M+H+K]", "adduct": "M+H"}, True, "M+H", "peptideXYZ", "[M+H+K]"],
     [{"compound_name": "peptideXYZ [M+H+K]"}, False, "[M+H+K]", "peptideXYZ [M+H+K]", None],
     [{"Name": "peptideXYZ [M+H+K]", "adduct": "M+H"}, True, "M+H", "peptideXYZ", "[M+H+K]"],
+    [{"compound_name": "peptideXYZ [M+H+K] C16H12"}, True, "[M+H+K]", "peptideXYZ C16H12", "[M+H+K]"],
     [{"name": ""}, True, None, "", None]
 ])
-def test_derive_adduct_from_name_parametrized(metadata, remove_adduct_from_name, expected_adduct, expected_name, removed_adduct):
+def test_derive_adduct_from_name_parametrized(metadata, remove_adduct_from_name,
+                                              expected_adduct, expected_name, removed_adduct):
     set_matchms_logger_level("INFO")
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
 
@@ -28,12 +30,32 @@ def test_derive_adduct_from_name_parametrized(metadata, remove_adduct_from_name,
 
     expected_log = []
     if spectrum.get("compound_name") != spectrum_in.get("compound_name"):
-        expected_log.append(('matchms', 'INFO', f'Removed adduct {removed_adduct} from compound name.'))
+        expected_log.append(('matchms', 'INFO', f"Removed adduct ['{removed_adduct}'] from compound name."))
     if spectrum.get("adduct") != spectrum_in.get("adduct"):
         expected_log.append(('matchms', 'INFO', f'Added adduct {expected_adduct} from the compound name to metadata.'))
 
     log.check(*expected_log)
     reset_matchms_logger()
+
+
+@pytest.mark.parametrize("metadata, expected_adduct, expected_name", [
+    # Test removing two adducts and selecting the interpretable one
+    [{"compound_name": "peptideXYZ [M+H+K] C16H12 [M+H+K]2+"}, "[M+H+K]2+", "peptideXYZ C16H12"],
+    # Test removing two adducts and not adding if not interpretable
+    [{"compound_name": "peptideXYZ [M+H+K] C16H12 [M+2H+K]"}, None, "peptideXYZ C16H12"],
+    # Test removing two adducts and check that clean adduct is run (to recover known adducts)
+    [{"compound_name": "peptideXYZ [M+H+K] C16H12 [M+H]"}, "[M+H]+", "peptideXYZ C16H12"]
+
+])
+def test_derive_adduct_from_name_multiple_adducts_in_name(metadata,
+                                                          expected_adduct, expected_name):
+    set_matchms_logger_level("INFO")
+    spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
+
+    spectrum = derive_adduct_from_name(spectrum_in, remove_adduct_from_name=True)
+
+    assert spectrum.get("adduct") == expected_adduct, "Expected different adduct."
+    assert spectrum.get("compound_name") == expected_name, "Expected different cleaned name."
 
 
 def test_empty_spectrum():


### PR DESCRIPTION
Some compound names had multiple adducts in the name. These were previously not removed. Now improve_derive_adduct_form_name does remove every occurance of an adduct and adds only an adduct if it can actually be interpreted to retrieve a mass_multiplier and a charge. 

@florian-huber Did I miss any type of common input for which this approach would not work well? 