### PR TITLE
Fix adduct missing charge

### DIFF
--- a/matchms/data/known_adduct_conversions.csv
+++ b/matchms/data/known_adduct_conversions.csv
@@ -5,6 +5,7 @@ input_adduct,corrected_adduct
 [M-2H2O+H],[M-2H2O+H]+
 [M+H-2H2O],[M-2H2O+H]+
 [M+H-2H2O]+,[M-2H2O+H]+
+[M-H+2Na],[M-H+2Na]+
 [M+H+Na],[M+H+Na]2+
 [M+H-NH3],[M+H-NH3]+
 [M-H+2Na]+,[M+2Na-H]+
@@ -16,6 +17,7 @@ input_adduct,corrected_adduct
 [M+K],[M+K]+
 [2M+H],[2M+H]+
 [2M+Na],[2M+Na]+
+[M+2Na],[M+2Na]2+
 [2M+K],[2M+K]+
 [M+NH4],[M+NH4]+
 [M-H],[M-H]-
@@ -23,12 +25,15 @@ input_adduct,corrected_adduct
 [M-H-H2O]-,[M-H2O-H]-
 [M-H-H2O],[M-H2O-H]-
 [M+H-CH3NH2],[M+H-CH3NH2]+
+[2M-2H+Na],[2M-2H+Na]-
+[M+HCOO],[M+HCOO]-
 [M+Cl],[M+Cl]-
 [M+Br],[M+Br]-
 [3M-H],[3M-H]-
 [2M-H],[2M-H]-
 [M+CH3COO],[M+CH3COO]-
 [M+FA-H],[M+FA-H]-
+[2M+FA-H],[2M+FA-H]-
 [M+OAc],[M+OAc]-
 [M+Oac],[M+OAc]-
 [M+Oac]-,[M+OAc]-
@@ -38,3 +43,5 @@ input_adduct,corrected_adduct
 [M-H]-/[M-Ser],[M-H]-
 [M+CH3COOH-H],[M+CH3COO]-
 [M-H1],[M-H]-
+[M-e],[M-e]-
+[M-2H],[M-2H]2-

--- a/matchms/filtering/filter_utils/interpret_unknown_adduct.py
+++ b/matchms/filtering/filter_utils/interpret_unknown_adduct.py
@@ -157,6 +157,7 @@ def get_charge_of_adduct(adduct) -> Optional[int]:
         return None
     charge = charge[0]
     if len(charge) == 1:
+        # The charge is + or -
         charge_size = "1"
         charge_sign = charge
     elif len(charge) == 2:

--- a/matchms/filtering/metadata_processing/clean_adduct.py
+++ b/matchms/filtering/metadata_processing/clean_adduct.py
@@ -1,8 +1,9 @@
 import logging
 import re
+from matchms.filtering.filter_utils.interpret_unknown_adduct import \
+    get_charge_of_adduct
 from matchms.filtering.filter_utils.load_known_adducts import \
     load_known_adduct_conversions
-from matchms.filtering.filter_utils.interpret_unknown_adduct import get_charge_of_adduct
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/clean_adduct.py
+++ b/matchms/filtering/metadata_processing/clean_adduct.py
@@ -2,6 +2,7 @@ import logging
 import re
 from matchms.filtering.filter_utils.load_known_adducts import \
     load_known_adduct_conversions
+from matchms.filtering.filter_utils.interpret_unknown_adduct import get_charge_of_adduct
 
 
 logger = logging.getLogger("matchms")
@@ -18,16 +19,32 @@ def clean_adduct(spectrum_in):
     """
     if spectrum_in is None:
         return None
+    adduct = spectrum_in.get("adduct")
+    if adduct is None:
+        return spectrum_in
     spectrum = spectrum_in.clone()
-    adduct = spectrum.get("adduct")
-    cleaned_adduct = _clean_adduct(adduct)
+
+    cleaned_adduct = _clean_adduct(adduct, spectrum.get('charge'))
+
+    if spectrum.get("charge"):
+        if spectrum.get("charge") != get_charge_of_adduct(cleaned_adduct):
+            logger.warning("The charge in the adduct: %s and the given charge: %s do not match",
+                           adduct, spectrum.get("charge"))
+    else:
+        # set charge to adduct
+        charge_from_adduct = get_charge_of_adduct(cleaned_adduct)
+        if charge_from_adduct:
+            logger.info("Unknown charge was derived from adduct: %s, now charge is %s",
+                        cleaned_adduct, charge_from_adduct)
+            spectrum.set("charge", charge_from_adduct)
+
     if adduct != cleaned_adduct:
         spectrum.set("adduct", cleaned_adduct)
         logger.info("The adduct %d was set to %s", adduct, cleaned_adduct)
     return spectrum
 
 
-def _clean_adduct(adduct: str) -> str:
+def _clean_adduct(adduct: str, charge=None) -> str:
     """Clean adduct and make it consistent in style.
     Will transform adduct strings of type 'M+H+' to '[M+H]+'.
 
@@ -36,40 +53,74 @@ def _clean_adduct(adduct: str) -> str:
     adduct
         Input adduct string to be cleaned/edited.
     """
+    if not isinstance(adduct, str):
+        return adduct
+
+    adduct = adduct.strip().replace("\n", "").replace("*", "")
+    adduct = adduct.replace("++", "2+").replace("--", "2-")
+
+    if not adduct.startswith("["):
+        adduct = _add_missing_brackets_to_adduct(adduct)
+    if adduct.endswith("]"):
+        charge = _convert_int_charge_to_str(charge)
+        if charge:
+            adduct += charge
+    return _convert_known_adduct(adduct)
+
+
+def _add_missing_brackets_to_adduct(adduct):
+    """Adds missing brackets to an adduct and moves the charge outside. """
     def _get_adduct_charge(adduct):
+        # Remove parts that can confuse the charge extraction. Because they end with a number and the ] is missing.
+        for mol_part in ["CH2", "CH3", "NH3", "NH4", "O2"]:
+            if mol_part in adduct:
+                adduct = adduct.split(mol_part)[-1]
         regex_charges = r"[1-3]{0,1}[+-]{1,2}$"
         match = re.search(regex_charges, adduct)
         if match:
             return match.group(0)
         return match
 
-    def _adduct_conversion(adduct):
-        """Convert adduct if conversion rule is known"""
-        adduct_conversions = load_known_adduct_conversions()
-        if adduct in adduct_conversions:
-            return adduct_conversions[adduct]
-        return adduct
-
-    if not isinstance(adduct, str):
-        return adduct
-
-    adduct = adduct.strip().replace("\n", "").replace("*", "")
-    adduct = adduct.replace("++", "2+").replace("--", "2-")
-    if adduct.startswith("["):
-        return _adduct_conversion(adduct)
-
+    if not adduct.startswith("["):
+        adduct = "[" + adduct
     if adduct.endswith("]"):
-        return _adduct_conversion("[" + adduct)
+        return adduct
 
-    adduct_core = "[" + adduct
-    # Remove parts that can confuse the charge extraction
-    for mol_part in ["CH2", "CH3", "NH3", "NH4", "O2"]:
-        if mol_part in adduct:
-            adduct = adduct.split(mol_part)[-1]
     adduct_charge = _get_adduct_charge(adduct)
 
     if adduct_charge is None:
-        return _adduct_conversion(adduct_core + "]")
+        return adduct + "]"
+    return adduct[:-len(adduct_charge)] + "]" + adduct_charge
 
-    adduct_cleaned = adduct_core[:-len(adduct_charge)] + "]" + adduct_charge
-    return _adduct_conversion(adduct_cleaned)
+
+def _convert_int_charge_to_str(charge):
+    """Converts integer to str format of charge
+
+    e.g.:
+    1 -> +
+    -1 -> -
+    2 -> 2+
+    -2 -> 2-
+    """
+    if charge is None:
+        return None
+    if not isinstance(charge, int):
+        logger.warning("Charge is not given as int. Apply 'make_charge_int' filter first.")
+        return None
+    if charge == 0:
+        return None
+    if charge < 0:
+        sign = "-"
+    else:
+        sign = "+"
+    if charge in (-1, 1):
+        return sign
+    return str(abs(charge)) + sign
+
+
+def _convert_known_adduct(adduct):
+    """Convert adduct if conversion rule is known"""
+    adduct_conversions = load_known_adduct_conversions()
+    if adduct in adduct_conversions:
+        return adduct_conversions[adduct]
+    return adduct

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -30,8 +30,6 @@ def derive_ionmode(spectrum_in: SpectrumType) -> SpectrumType:
     spectrum = spectrum_in.clone()
 
     ionmode = spectrum.get("ionmode")
-    if ionmode:
-        assert ionmode == ionmode.lower(), "Ionmode field not harmonized."
     if ionmode in ["positive", "negative"]:
         return spectrum
 

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -44,7 +44,7 @@ def derive_ionmode(spectrum_in: SpectrumType) -> SpectrumType:
     if adduct in list(known_adducts["adduct"]):
         ionmode = known_adducts.loc[known_adducts["adduct"] == adduct, "ionmode"].values[0]
     else:
-        ionmode = "n/a"
+        ionmode = None
 
     spectrum.set("ionmode", ionmode)
     logger.info("Set ionmode to %s.", ionmode)

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -29,20 +29,21 @@ def derive_ionmode(spectrum_in: SpectrumType) -> SpectrumType:
 
     spectrum = spectrum_in.clone()
 
-    # Load lists of known adducts
-    known_adducts = load_known_adducts()
-
-    adduct = spectrum.get("adduct", None)
-    # Harmonize adduct string
-    if adduct:
-        adduct = _clean_adduct(adduct)
-
     ionmode = spectrum.get("ionmode")
     if ionmode:
         assert ionmode == ionmode.lower(), ("Ionmode field not harmonized.",
                                             "Apply 'make_ionmode_lowercase' filter first.")
     if ionmode in ["positive", "negative"]:
         return spectrum
+
+    adduct = spectrum.get("adduct", None)
+    # Harmonize adduct string
+    if not adduct:
+        return spectrum
+    adduct = _clean_adduct(adduct)
+
+    # Load lists of known adducts
+    known_adducts = load_known_adducts()
     # Try completing missing or incorrect ionmodes
     if adduct in list(known_adducts["adduct"]):
         ionmode = known_adducts.loc[known_adducts["adduct"] == adduct, "ionmode"].values[0]

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -38,9 +38,8 @@ def derive_ionmode(spectrum_in: SpectrumType) -> SpectrumType:
 
     adduct = spectrum.get("adduct", None)
     # Harmonize adduct string
-    if not adduct:
-        return spectrum
-    adduct = _clean_adduct(adduct)
+    if adduct:
+        adduct = _clean_adduct(adduct)
 
     # Load lists of known adducts
     known_adducts = load_known_adducts()
@@ -52,5 +51,4 @@ def derive_ionmode(spectrum_in: SpectrumType) -> SpectrumType:
 
     spectrum.set("ionmode", ionmode)
     logger.info("Set ionmode to %s.", ionmode)
-
     return spectrum

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -31,8 +31,7 @@ def derive_ionmode(spectrum_in: SpectrumType) -> SpectrumType:
 
     ionmode = spectrum.get("ionmode")
     if ionmode:
-        assert ionmode == ionmode.lower(), ("Ionmode field not harmonized.",
-                                            "Apply 'make_ionmode_lowercase' filter first.")
+        assert ionmode == ionmode.lower(), "Ionmode field not harmonized."
     if ionmode in ["positive", "negative"]:
         return spectrum
 

--- a/tests/filtering/test_all_filter_order.py
+++ b/tests/filtering/test_all_filter_order.py
@@ -33,6 +33,8 @@ ANNOTATION_REPARATIONS = [msfilters.repair_inchi_inchikey_smiles, msfilters.deri
     # The adduct filter removes all occurances while derive formula from name only removes when it is at the end
     # of compound name. Removing adducts therefore has to happen first.
     [[msfilters.derive_adduct_from_name], [msfilters.derive_formula_from_name]],
+    [[msfilters.make_charge_int, msfilters.correct_charge, ], [msfilters.clean_adduct]],
+    [[msfilters.derive_adduct_from_name, ], [msfilters.clean_adduct]]
 ])
 def test_all_filter_order(early_filters: List[Callable], later_filters: List[Callable]):
     """Tests if early_filter is run before later_filter"""

--- a/tests/filtering/test_derive_adduct_from_name.py
+++ b/tests/filtering/test_derive_adduct_from_name.py
@@ -17,7 +17,7 @@ from ..builder_Spectrum import SpectrumBuilder
     [{"compound_name": "peptideXYZ [M+H+K] C16H12"}, True, "[M+H+K]", "peptideXYZ C16H12", "[M+H+K]"],
     [{"name": ""}, True, None, "", None]
 ])
-def test_derive_adduct_from_name_parametrized(metadata, remove_adduct_from_name,
+def test_derive_adduct_from_name_parametrized(metadata: dict, remove_adduct_from_name: bool,
                                               expected_adduct, expected_name, removed_adduct):
     set_matchms_logger_level("INFO")
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
@@ -49,7 +49,6 @@ def test_derive_adduct_from_name_parametrized(metadata, remove_adduct_from_name,
 ])
 def test_derive_adduct_from_name_multiple_adducts_in_name(metadata,
                                                           expected_adduct, expected_name):
-    set_matchms_logger_level("INFO")
     spectrum_in = SpectrumBuilder().with_metadata(metadata).build()
 
     spectrum = derive_adduct_from_name(spectrum_in, remove_adduct_from_name=True)

--- a/tests/filtering/test_repair_adduct/test_clean_adduct.py
+++ b/tests/filtering/test_repair_adduct/test_clean_adduct.py
@@ -1,5 +1,6 @@
 import pytest
-from matchms.filtering.metadata_processing.clean_adduct import clean_adduct, _convert_int_charge_to_str, _add_missing_brackets_to_adduct
+from matchms.filtering.metadata_processing.clean_adduct import (
+    _add_missing_brackets_to_adduct, _convert_int_charge_to_str, clean_adduct)
 from tests.builder_Spectrum import SpectrumBuilder
 
 

--- a/tests/filtering/test_repair_adduct/test_clean_adduct.py
+++ b/tests/filtering/test_repair_adduct/test_clean_adduct.py
@@ -1,5 +1,5 @@
 import pytest
-from matchms.filtering.metadata_processing.clean_adduct import clean_adduct
+from matchms.filtering.metadata_processing.clean_adduct import clean_adduct, _convert_int_charge_to_str, _add_missing_brackets_to_adduct
 from tests.builder_Spectrum import SpectrumBuilder
 
 
@@ -18,3 +18,44 @@ def test_clean_adduct(input_adduct, expected_adduct):
     spectrum_in = SpectrumBuilder().with_metadata({"adduct": input_adduct}).build()
     spectrum_out = clean_adduct(spectrum_in)
     assert spectrum_out.get("adduct") == expected_adduct
+
+
+@pytest.mark.parametrize("input_charge, expected_charge",
+                         [(1, "+"),
+                          (2, "2+"),
+                          (-1, "-"),
+                          (+2, "2+"),
+                          (-2, "2-"),
+                          (None, None),
+                          ("None", None),
+                          ])
+def test_convert_int_charge_to_str(input_charge, expected_charge):
+    assert _convert_int_charge_to_str(input_charge) == expected_charge
+
+
+@pytest.mark.parametrize("input_adduct, expected_adduct",
+                         [("M+", "[M]+"),
+                          ("M+CH3COO-", "[M+CH3COO]-"),
+                          ("M+CH3COO", "[M+CH3COO]"),
+                          ("M-CH3-", "[M-CH3]-"),
+                          ("[2M+Na]", "[2M+Na]"),
+                          ("2M+Na", "[2M+Na]"),
+                          ("M+NH3+", "[M+NH3]+"),
+                          ("M-H2O+2H2+", "[M-H2O+2H]2+")])
+def test_add_missing_brackets_to_adduct(input_adduct, expected_adduct):
+    assert _add_missing_brackets_to_adduct(input_adduct) == expected_adduct
+
+
+@pytest.mark.parametrize("input_adduct, charge, expected_adduct, expected_charge",
+                         [("M", 1, "[M]+", 1),
+                          ("M", -1, "[M]-", -1),
+                          ("[M]+", None, "[M]+", 1),
+                          ("M+", None, "[M]+", 1),
+                          ("M-H2O+2H2-", None, "[M-H2O+2H]2+", -2),
+                          (None, 1, None, 1)])
+def test_clean_adduct_with_charge(input_adduct, charge, expected_adduct, expected_charge):
+    spectrum_in = SpectrumBuilder().with_metadata({"adduct": input_adduct,
+                                                   "charge": charge}).build()
+    spectrum_out = clean_adduct(spectrum_in)
+    assert spectrum_out.get("adduct") == expected_adduct
+    assert spectrum_out.get("charge") == expected_charge

--- a/tests/filtering/test_repair_adduct/test_clean_adduct.py
+++ b/tests/filtering/test_repair_adduct/test_clean_adduct.py
@@ -52,7 +52,8 @@ def test_add_missing_brackets_to_adduct(input_adduct, expected_adduct):
                           ("M", -1, "[M]-", -1),
                           ("[M]+", None, "[M]+", 1),
                           ("M+", None, "[M]+", 1),
-                          ("M-H2O+2H2-", None, "[M-H2O+2H]2+", -2),
+                          ("M-H2O+2H2-", None, "[M-H2O+2H]2-", -2),
+                          ("M-H2O+2H2+", None, "[M-H2O+2H]2+", 2),
                           (None, 1, None, 1)])
 def test_clean_adduct_with_charge(input_adduct, charge, expected_adduct, expected_charge):
     spectrum_in = SpectrumBuilder().with_metadata({"adduct": input_adduct,


### PR DESCRIPTION
Still many adducts are not recognized since they do not have a charge e.g. [M+H+Na] would not be used, since the charge is unknown. Before some of these were repaired, because we stored common adduct types. In addition now the charge stored in spectrum.get("charge") is used to repair an adduct that misses the overall charge. 