### PR TITLE
Add uneffective filters to report

### DIFF
--- a/matchms/filtering/SpectrumProcessor.py
+++ b/matchms/filtering/SpectrumProcessor.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 from collections import defaultdict
 from functools import partial
-from typing import Callable, Dict, Optional, Tuple, Union, List
+from typing import Callable, Dict, List, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 from tqdm import tqdm

--- a/matchms/filtering/SpectrumProcessor.py
+++ b/matchms/filtering/SpectrumProcessor.py
@@ -291,7 +291,7 @@ class ProcessingReport:
         # Add filters that did not do any changes:
         for filter_name in self.filter_names:
             if filter_name not in processing_report["filter"].values:
-                processing_report.loc[len(processing_report)] = [filter_name, 0, 0, 0]
+                processing_report.loc[len(processing_report)] = {"filter": filter_name}
 
         processing_report = processing_report.set_index("filter").fillna(0)
         return processing_report.astype(int)

--- a/tests/filtering/test_spectrum_processor.py
+++ b/tests/filtering/test_spectrum_processor.py
@@ -147,10 +147,12 @@ def test_filter_spectrums_report(spectrums):
     assert report.counter_number_processed == 3
     assert report.counter_changed_metadata == {'make_charge_int': 2, 'interpret_pepmass': 3, 'derive_ionmode': 3}
     report_df = report.to_dataframe()
-    assert np.all(report_df.loc[["require_minimum_number_of_peaks", "interpret_pepmass", "add_losses"]].values == np.array(
+    assert np.all(report_df.loc[["require_minimum_number_of_peaks", "interpret_pepmass",
+                                 "add_losses", "correct_charge"]].values == np.array(
         [[1, 0, 0],
          [0, 3, 0],
-         [0, 0, 2]]))
+         [0, 0, 2],
+         [0, 0, 0]]))
 
 
 def test_processing_report_class(spectrums):


### PR DESCRIPTION
Previously the ProcessingReport did not show any filter steps that did not alter any spectra, but this can be useful to quickly spot mistakes in the pipeline or to remove unnecessary filters, so this PR adds them. 