### PR TITLE
Convert filtering functions to classes

### DIFF
--- a/matchms/Metadata.py
+++ b/matchms/Metadata.py
@@ -1,13 +1,13 @@
 from collections.abc import Mapping
 import numpy as np
 from pickydict import PickyDict
-from .filtering.metadata_processing.add_precursor_mz import \
-    _add_precursor_mz_metadata
+from .filtering.filters.add_precursor_mz import \
+    AddPrecursorMz
 from .filtering.metadata_processing.add_retention import _add_retention
-from .filtering.metadata_processing.interpret_pepmass import \
-    _interpret_pepmass_metadata
-from .filtering.metadata_processing.make_charge_int import \
-    _convert_charge_to_int
+from .filtering.filters.interpret_pepmass import \
+    InterpretPepmass
+from .filtering.filters.make_charge_int import \
+    MakeChargeInt
 from .utils import load_export_key_conversions, load_known_key_conversions
 
 
@@ -99,8 +99,8 @@ class Metadata:
         This includes harmonizing entries for ionmode, retention time and index,
         charge, as well as the removal of invalid entried ("", "NA", "N/A", "NaN").
         """
-        metadata_filtered = _interpret_pepmass_metadata(self.data)
-        metadata_filtered = _add_precursor_mz_metadata(metadata_filtered)
+        metadata_filtered = InterpretPepmass._interpret_pepmass_metadata(self.data)
+        metadata_filtered = AddPrecursorMz._add_precursor_mz_metadata(metadata_filtered)
 
         if metadata_filtered.get("ionmode"):
             metadata_filtered["ionmode"] = self.get("ionmode").lower()
@@ -115,7 +115,7 @@ class Metadata:
             metadata_filtered["parent"] = float(metadata_filtered.get("parent"))
 
         charge = metadata_filtered.get("charge")
-        charge_int = _convert_charge_to_int(charge)
+        charge_int = MakeChargeInt._convert_charge_to_int(charge)
         if not isinstance(charge, int) and charge_int is not None:
             metadata_filtered["charge"] = charge_int
 

--- a/matchms/filtering/filter_utils/derive_precursor_mz_and_parent_mass.py
+++ b/matchms/filtering/filter_utils/derive_precursor_mz_and_parent_mass.py
@@ -5,7 +5,7 @@ from matchms.filtering.filter_utils.interpret_unknown_adduct import \
     get_multiplier_and_mass_from_adduct
 from matchms.filtering.filter_utils.load_known_adducts import \
     load_known_adducts
-from matchms.filtering.metadata_processing.clean_adduct import _clean_adduct
+from matchms.filtering.filters.clean_adduct import CleanAdduct
 from matchms.typing import SpectrumType
 
 
@@ -83,7 +83,7 @@ def _get_multiplier_and_correction_mass_from_adduct(adduct: str) -> Tuple[int, f
     Returns:
         Tuple[int, float]: Charge multiplier and correction mass needed to calculate the precursor mz from this adduct.
     """
-    adduct = _clean_adduct(adduct)
+    adduct = CleanAdduct._clean_adduct(adduct)
     known_adducts = load_known_adducts()
 
     if adduct in list(known_adducts["adduct"]):

--- a/matchms/filtering/filters/add_compound_name.py
+++ b/matchms/filtering/filters/add_compound_name.py
@@ -1,0 +1,21 @@
+import logging
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+
+class AddCompoundName(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        if spectrum.get("compound_name", None) is None:
+            if isinstance(spectrum.get("name", None), str):
+                spectrum.set("compound_name", spectrum.get("name"))
+                return spectrum
+
+            if isinstance(spectrum.get("title", None), str):
+                spectrum.set("compound_name", spectrum.get("title"))
+                return spectrum
+
+            logger.info("No compound name found in metadata.")
+
+        return spectrum

--- a/matchms/filtering/filters/add_fingerprint.py
+++ b/matchms/filtering/filters/add_fingerprint.py
@@ -1,0 +1,34 @@
+import logging
+import numpy as np
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from ...metadata_utils import (derive_fingerprint_from_inchi,
+                               derive_fingerprint_from_smiles)
+
+
+logger = logging.getLogger("matchms")
+
+
+class AddFingerprint(BaseSpectrumFilter):
+    def __init__(self, fingerprint_type: str = "daylight", nbits: int = 2048):
+        self.fingerprint_type = fingerprint_type
+        self.nbits = nbits
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        if spectrum.get("smiles", None):
+            fingerprint = derive_fingerprint_from_smiles(spectrum.get("smiles"),
+                                                         self.fingerprint_type, self.nbits)
+            if isinstance(fingerprint, np.ndarray) and fingerprint.sum() > 0:
+                spectrum.set("fingerprint", fingerprint)
+                return spectrum
+
+        # Second try to get fingerprint from inchi
+        if spectrum.get("inchi", None):
+            fingerprint = derive_fingerprint_from_inchi(spectrum.get("inchi"),
+                                                        self.fingerprint_type, self.nbits)
+            if isinstance(fingerprint, np.ndarray) and fingerprint.sum() > 0:
+                spectrum.set("fingerprint", fingerprint)
+                return spectrum
+
+        logger.info("No fingerprint was added (name: %s).", spectrum.get("compound_name"))
+        return spectrum

--- a/matchms/filtering/filters/add_losses.py
+++ b/matchms/filtering/filters/add_losses.py
@@ -1,0 +1,32 @@
+import logging
+import numpy as np
+from matchms.Fragments import Fragments
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class AddLosses(BaseSpectrumFilter):
+    def __init__(self, loss_mz_from=0.0, loss_mz_to=1000.0):
+        self.loss_mz_from = loss_mz_from
+        self.loss_mz_to = loss_mz_to
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        precursor_mz = spectrum.get("precursor_mz", None)
+        if precursor_mz:
+            assert isinstance(precursor_mz, (float, int)), ("Expected 'precursor_mz' to be a scalar number.",
+                                                            "Consider applying 'add_precursor_mz' filter first.")
+            peaks_mz, peaks_intensities = spectrum.peaks.mz, spectrum.peaks.intensities
+            losses_mz = (precursor_mz - peaks_mz)[::-1]
+            losses_intensities = peaks_intensities[::-1]
+            # Add losses which are within given boundaries
+            mask = np.where((losses_mz >= self.loss_mz_from)
+                               & (losses_mz <= self.loss_mz_to))
+            spectrum.losses = Fragments(mz=losses_mz[mask],
+                                        intensities=losses_intensities[mask])
+        else:
+            logger.warning("No precursor_mz found. Consider applying 'add_precursor_mz' filter first.")
+
+        return spectrum

--- a/matchms/filtering/filters/add_parent_mass.py
+++ b/matchms/filtering/filters/add_parent_mass.py
@@ -1,0 +1,61 @@
+import logging
+from matchms.filtering.filter_utils.derive_precursor_mz_and_parent_mass import \
+    derive_parent_mass_from_precursor_mz
+from matchms.typing import SpectrumType
+from ...utils import get_first_common_element
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+_default_key = "parent_mass"
+_accepted_keys = ["parentmass", "exact_mass"]
+_accepted_types = (float, str, int)
+_accepted_missing_entries = ["", "N/A", "NA", "n/a"]
+
+
+class AddParentMass(BaseSpectrumFilter):
+    def __init__(self, estimate_from_adduct: bool = True, overwrite_existing_entry: bool = False):
+        self.estimate_from_adduct = estimate_from_adduct
+        self.overwrite_existing_entry = overwrite_existing_entry
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        parent_mass = self._get_parent_mass(spectrum.metadata)
+        if parent_mass is not None and not self.overwrite_existing_entry:
+            spectrum.set("parent_mass", parent_mass)
+            return spectrum
+
+        parent_mass = derive_parent_mass_from_precursor_mz(spectrum, self.estimate_from_adduct)
+
+        if parent_mass is None:
+            logger.warning("Not sufficient spectrum metadata to derive parent mass.")
+        else:
+            spectrum.set("parent_mass", float(parent_mass))
+        return spectrum
+
+    def _get_parent_mass(self, metadata):
+        parent_mass_key = get_first_common_element([_default_key] + _accepted_keys,
+                                                   metadata.keys())
+        parent_mass = metadata.get(parent_mass_key)
+        parent_mass = self._convert_entry_to_num(parent_mass)
+        if parent_mass not in _accepted_missing_entries:
+            return parent_mass
+        return None
+
+    def _convert_entry_to_num(self, entry):
+        """Convert precursor_mz to number if possible. Otherwise return None."""
+        if entry is None:
+            return None
+        if isinstance(entry, str) and entry in _accepted_missing_entries:
+            return None
+        if not isinstance(entry, _accepted_types):
+            logger.warning("Found parent_mass of undefined type.")
+            return None
+        if isinstance(entry, str):
+            try:
+                return float(entry.strip())
+            except ValueError:
+                logger.warning("%s can't be converted to float.", entry)
+                return None
+        return entry

--- a/matchms/filtering/filters/add_precursor_mz.py
+++ b/matchms/filtering/filters/add_precursor_mz.py
@@ -1,0 +1,59 @@
+import logging
+from matchms.utils import get_first_common_element
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+
+
+_default_key = "precursor_mz"
+_accepted_keys = ["precursormz", "precursor_mass"]
+_accepted_types = (float, str, int)
+_accepted_missing_entries = ["", "N/A", "NA", "n/a"]
+
+
+class AddPrecursorMz(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        metadata_updated = AddPrecursorMz._add_precursor_mz_metadata(spectrum.metadata)
+        spectrum.metadata = metadata_updated
+        return spectrum
+
+    def _convert_precursor_mz(precursor_mz):
+        """Convert precursor_mz to number if possible. Otherwise return None."""
+        if precursor_mz is None:
+            return None
+        if isinstance(precursor_mz, str) and precursor_mz in _accepted_missing_entries:
+            return None
+        if not isinstance(precursor_mz, _accepted_types):
+            logger.warning("Found precursor_mz of undefined type.")
+            return None
+        if isinstance(precursor_mz, str):
+            try:
+                return float(precursor_mz.strip())
+            except ValueError:
+                logger.warning("%s can't be converted to float.", precursor_mz)
+                return None
+        return precursor_mz
+
+    def _add_precursor_mz_metadata(metadata):
+        precursor_mz_key = get_first_common_element([_default_key] + _accepted_keys,
+                                                    metadata.keys())
+        precursor_mz = metadata.get(precursor_mz_key)
+        precursor_mz = AddPrecursorMz._convert_precursor_mz(precursor_mz)
+        if isinstance(precursor_mz, (float, int)):
+            metadata["precursor_mz"] = float(precursor_mz)
+            for key in _accepted_keys:
+                metadata.pop(key, None)
+            return metadata
+
+        pepmass = metadata.get("pepmass", None)
+        if pepmass is not None and AddPrecursorMz._convert_precursor_mz(pepmass[0]) is not None:
+            metadata["precursor_mz"] = pepmass[0]
+            logger.warning("Added precursor_mz entry based on field 'pepmass'."
+                           "Consider running 'interpret_pepmass() filter first.")
+            return metadata
+
+        logger.warning("No precursor_mz found in metadata.")
+        metadata.pop("precursor_mz", None)
+        return metadata

--- a/matchms/filtering/filters/base_spectrum_filter.py
+++ b/matchms/filtering/filters/base_spectrum_filter.py
@@ -1,0 +1,19 @@
+from abc import ABC, abstractmethod
+from matchms.typing import SpectrumType
+
+
+class BaseSpectrumFilter(ABC):
+    def process(self, spectrum_in: SpectrumType) -> SpectrumType:
+        if spectrum_in is None:
+            return None
+
+        spectrum = spectrum_in.clone()
+
+        spectrum = self.apply_filter(spectrum)
+
+        return spectrum
+
+    @abstractmethod
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        """This method should be implemented by child classes."""
+        raise NotImplementedError

--- a/matchms/filtering/filters/clean_adduct.py
+++ b/matchms/filtering/filters/clean_adduct.py
@@ -1,0 +1,66 @@
+import logging
+import re
+from matchms.filtering.filter_utils.load_known_adducts import \
+    load_known_adduct_conversions
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+logger = logging.getLogger("matchms")
+
+
+class CleanAdduct(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        adduct = spectrum.get("adduct")
+
+        cleaned_adduct = CleanAdduct._clean_adduct(adduct)
+        if adduct != cleaned_adduct:
+            spectrum.set("adduct", cleaned_adduct)
+            logger.info("The adduct %d was set to %s", adduct, cleaned_adduct)
+        return spectrum
+
+    def _clean_adduct(adduct: str) -> str:
+        """Clean adduct and make it consistent in style.
+        Will transform adduct strings of type 'M+H+' to '[M+H]+'.
+
+        Parameters
+        ----------
+        adduct
+            Input adduct string to be cleaned/edited.
+        """
+        def _get_adduct_charge(adduct):
+            regex_charges = r"[1-3]{0,1}[+-]{1,2}$"
+            match = re.search(regex_charges, adduct)
+            if match:
+                return match.group(0)
+            return match
+
+        def _adduct_conversion(adduct):
+            """Convert adduct if conversion rule is known"""
+            adduct_conversions = load_known_adduct_conversions()
+            if adduct in adduct_conversions:
+                return adduct_conversions[adduct]
+            return adduct
+
+        if not isinstance(adduct, str):
+            return adduct
+
+        adduct = adduct.strip().replace("\n", "").replace("*", "")
+        adduct = adduct.replace("++", "2+").replace("--", "2-")
+        if adduct.startswith("["):
+            return _adduct_conversion(adduct)
+
+        if adduct.endswith("]"):
+            return _adduct_conversion("[" + adduct)
+
+        adduct_core = "[" + adduct
+        # Remove parts that can confuse the charge extraction
+        for mol_part in ["CH2", "CH3", "NH3", "NH4", "O2"]:
+            if mol_part in adduct:
+                adduct = adduct.split(mol_part)[-1]
+        adduct_charge = _get_adduct_charge(adduct)
+
+        if adduct_charge is None:
+            return _adduct_conversion(adduct_core + "]")
+
+        adduct_cleaned = adduct_core[:-len(adduct_charge)] + "]" + adduct_charge
+        return _adduct_conversion(adduct_cleaned)

--- a/matchms/filtering/filters/clean_compound_name.py
+++ b/matchms/filtering/filters/clean_compound_name.py
@@ -1,0 +1,71 @@
+import logging
+import re
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class CleanCompoundName(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        if spectrum.get("compound_name", None) is not None:
+            name = spectrum.get("compound_name")
+        else:
+            assert spectrum.get("name", None) in [None, ""], ("Found 'name' but not 'compound_name' in metadata",
+                                                              "Apply 'add_compound_name' filter first.")
+            return spectrum
+
+        # Clean compound name
+        name_cleaned = self._remove_parts_by_regular_expression(name)
+        name_cleaned = self._remove_known_non_compound_parts(name_cleaned)
+        name_cleaned = self._remove_misplaced_mass(name_cleaned)
+        if name_cleaned != name:
+            spectrum.set("compound_name", name_cleaned)
+            logger.info("Added cleaned compound name: %s", name_cleaned)
+
+        return spectrum
+
+    def _remove_parts_by_regular_expression(self, name: str):
+        """Clean name string by removing known parts that don't belong there."""
+        name = name.strip()
+        # remove type NCGC00180417-03_C31H40O16_
+        name = re.split(r"[A-Z]{3,6}[0-9]{8,12}-[0-9]{2,5}_[A-Z,0-9]{4,15}_", name)[-1]
+        # remove type NCGC00160232-01! or MLS001142816-01!
+        name = re.split(r"[A-Z]{3,6}[0-9]{8,12}-[0-9]{2,3}\!", name)[-1]
+        # remove type Massbank:EA008813 option1|option2|option3
+        name = re.split(r"((Massbank:)|(MassbankEU:))[A-Z]{2}[0-9]{5,6}.*\|", name)[-1]
+        # remove type Massbank:EA008813 or MassbankEU:EA008813
+        name = re.split(r"((Massbank:)|(MassbankEU:))[A-Z]{2}[0-9]{5,6}", name)[-1]
+        # remove type HMDB:HMDB00943-1336
+        name = re.split(r"HMDB:HMDB[0-9]{4,7}-[0-9]{1,7}", name)[-1]
+        # remove type MoNA:662599
+        name = re.split(r"MoNA:[0-9]{5,10}", name)[-1]
+        # ReSpect:PS013405 option1|option2|option3...
+        name = re.split(r"ReSpect:[A-Z]{2,3}[0-9]{6}.*\|", name)[-1]
+        # ReSpect:PS013405 option1
+        name = re.split(r"[A-Z]{2,3}[0-9]{6}( )", name)[-1]
+        # remove type 0072_2-Mercaptobenzothiaz
+        name = re.split(r"^[0-9]{4}_", name)[-1]
+        # remove type nameofcompound_CID20_170920 or Spiraeoside_HCD30_170919
+        name = re.split(r"_((HCD)|(CID))[0-9]{2}_[0-9]{5,6}$", name)[0]
+        # Removes the collision energy from the compound name. Also allows for occurances of - 40.0 eV Unknown
+        name = re.split(r"(?: - )?[0-9]+(?:\.[0-9]+)? ?[eE][Vv](?: Unknown)?$", name)[0]
+        return name
+
+    def _remove_known_non_compound_parts(self, name: str):
+        """Remove known non compound-name strings from name."""
+        parts_remove = ["Spectral Match to",
+                        "from NIST14",
+                        "Massbank:"]
+        for part in parts_remove:
+            name = name.replace(part, "")
+        return name.strip("; ")
+
+    def _remove_misplaced_mass(self, name: str):
+        """Remove occasionally occurring parent mass addition to name."""
+        regex_mass = r"^[0-9]{2,4}\.[0-9]$"
+        end_part = name.split(" ")[-1]
+        if re.search(regex_mass, end_part) is not None:
+            return name.replace(end_part, "").strip()
+        return name

--- a/matchms/filtering/filters/correct_charge.py
+++ b/matchms/filtering/filters/correct_charge.py
@@ -1,0 +1,41 @@
+import logging
+import numpy as np
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class CorrectCharge(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        ionmode = spectrum.get("ionmode", None)
+        if ionmode:
+            assert ionmode == ionmode.lower(), ("Ionmode field not harmonized.",
+                                                "Apply 'make_ionmode_lowercase' filter first.")
+    
+        charge = spectrum.get("charge", None)
+        assert not isinstance(charge, str), ("Charge is given as string.",
+                                             "Apply 'make_charge_int' filter first.")
+    
+        if charge is None:
+            charge = 0
+    
+        if charge == 0 and ionmode == 'positive':
+            charge = 1
+            logger.info("Guessed charge to 1 based on positive ionmode")
+        elif charge == 0 and ionmode == 'negative':
+            charge = -1
+            logger.info("Guessed charge to -1 based on negative ionmode")
+    
+        # Correct charge when in conflict with ionmode (trust ionmode more!)
+        if np.sign(charge) == 1 and ionmode == 'negative':
+            charge *= -1
+            logger.warning("Changed sign of given charge to match negative ionmode")
+        elif np.sign(charge) == -1 and ionmode == 'positive':
+            charge *= -1
+            logger.warning("Changed sign of given charge to match positive ionmode")
+    
+        spectrum.set("charge", charge)
+    
+        return spectrum

--- a/matchms/filtering/filters/derive_adduct_from_name.py
+++ b/matchms/filtering/filters/derive_adduct_from_name.py
@@ -1,0 +1,51 @@
+import logging
+import re
+from matchms.typing import SpectrumType
+from ..filter_utils.load_known_adducts import load_known_adducts
+from ..filters.clean_adduct import CleanAdduct
+from matchms.filtering.filters.derive_from_name_template import DeriveFromNameTemplate
+
+
+logger = logging.getLogger("matchms")
+
+
+class DeriveAdductFromName(DeriveFromNameTemplate):
+    def __init__(self, remove_from_name: bool = True):
+        super().__init__(remove_from_name, "adduct")
+
+    def derive(self, name, spectrum):
+        adduct_from_name = None
+        name_split = name.split(" ")
+        for name_part in name_split[::-1][:2]:
+            if _looks_like_adduct(name_part):
+                adduct_from_name = name_part
+                break
+
+        if adduct_from_name and self.remove_from_name:
+            name_adduct_removed = " ".join([x for x in name_split if x != adduct_from_name])
+            name_adduct_removed = name_adduct_removed.strip("; ")
+            spectrum.set("compound_name", name_adduct_removed)
+            logger.info("Removed adduct %s from compound name.", adduct_from_name)
+
+        if adduct_from_name and not _looks_like_adduct(spectrum.get(self.metadata_key)):
+            adduct_cleaned = CleanAdduct._clean_adduct(adduct_from_name)
+            spectrum.set(self.metadata_key, adduct_cleaned)
+            logger.info("Added adduct %s from the compound name to metadata.", spectrum.get(self.metadata_key))
+
+        return spectrum
+
+
+def _looks_like_adduct(adduct):
+    """Return True if input string has expected format of an adduct."""
+    if not isinstance(adduct, str):
+        return False
+    # Clean adduct
+    adduct = CleanAdduct._clean_adduct(adduct)
+    # Load lists of default known adducts
+    known_adducts = load_known_adducts()
+    if adduct in list(known_adducts["adduct"]):
+        return True
+
+    # Expect format like: "[2M-H]" or "[2M+Na]+"
+    regexp1 = r"^\[(([0-4]M)|(M[0-9])|(M))((Br)|(Br81)|(Cl)|(Cl37)|(S)){0,}[+-][A-Z0-9\+\-\(\)aglire]{1,}[\]0-4+-]{1,4}"
+    return re.search(regexp1, adduct) is not None

--- a/matchms/filtering/filters/derive_formula_from_name.py
+++ b/matchms/filtering/filters/derive_formula_from_name.py
@@ -1,0 +1,37 @@
+import logging
+import re
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.derive_from_name_template import DeriveFromNameTemplate
+
+
+logger = logging.getLogger("matchms")
+
+
+class DeriveFormulaFromName(DeriveFromNameTemplate):
+    def __init__(self, remove_from_name: bool = True):
+        super().__init__(remove_from_name, "formula")
+
+    def derive(self, name, spectrum):
+        end_of_name = name.split(" ")[-1]
+        formula_from_name = end_of_name if _looks_like_formula(end_of_name) else None
+
+        if formula_from_name and self.remove_from_name:
+            name_formula_removed = " ".join(name.split(" ")[:-1])
+            spectrum.set("compound_name", name_formula_removed)
+            logger.info("Added formula %s to metadata.", formula_from_name)
+
+        if formula_from_name and spectrum.get(self.metadata_key) is None:
+            spectrum.set(self.metadata_key, formula_from_name)
+            logger.info("Added formula %s to metadata.", formula_from_name)
+
+        return spectrum
+
+
+def _looks_like_formula(formula):
+    """Return True if input string has expected format of a molecular formula.
+    Does only consider most frequent atoms found in many name strings.
+    """
+    regex_atoms = r"([CFHNOPS])"
+    atom_count = len(re.findall(regex_atoms, formula))
+    regexp = r"^([CFHNOPS]|[0-9]|\(|\)){3,}$"
+    return (atom_count > 2) and (re.search(regexp, formula) is not None)

--- a/matchms/filtering/filters/derive_from_inchi_smile_template.py
+++ b/matchms/filtering/filters/derive_from_inchi_smile_template.py
@@ -1,0 +1,32 @@
+import logging
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+
+class DeriveFromInchiSmileTemplate(BaseSpectrumFilter):
+    def __init__(self, derive_to, derive_from, convert_function, log_message):
+        self.derive_to = derive_to
+        self.derive_from = derive_from
+        self.convert_function = convert_function
+        self.log_message = log_message
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        derive_to = spectrum.get(self.derive_to)
+        derive_from = spectrum.get(self.derive_from)
+
+        if self.is_valid(derive_to, derive_from):
+            converted_value = self.convert_function(derive_from)
+            if converted_value:
+                converted_value = converted_value.rstrip()
+                spectrum.set(self.derive_to, converted_value)
+                logger.info(self.log_message % converted_value)
+            else:
+                logger.warning("Could not convert %s %s to %s.", self.derive_from, derive_from, self.derive_to)
+
+        return spectrum
+
+    def is_valid(self, input_value, output_value):
+        raise NotImplementedError("Subclasses must implement this method")
+

--- a/matchms/filtering/filters/derive_from_name_template.py
+++ b/matchms/filtering/filters/derive_from_name_template.py
@@ -1,0 +1,23 @@
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+class DeriveFromNameTemplate(BaseSpectrumFilter):
+    def __init__(self, remove_from_name: bool, metadata_key: str):
+        self.remove_from_name = remove_from_name
+        self.metadata_key = metadata_key
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        if spectrum.get("compound_name", None) is not None:
+            name = spectrum.get("compound_name")
+        else:
+            assert spectrum.get("name", None) in [None, ""], ("Found 'name' but not 'compound_name' in metadata",
+                                                              "Apply 'add_compound_name' filter first.")
+            return spectrum
+
+        spectrum = self.derive(name, spectrum)
+
+        return spectrum
+
+    def derive(self, name, spectrum):
+        raise NotImplementedError("Subclasses must implement the 'derive' method.")

--- a/matchms/filtering/filters/derive_inchi_from_smiles.py
+++ b/matchms/filtering/filters/derive_inchi_from_smiles.py
@@ -1,0 +1,15 @@
+from ...metadata_utils import convert_smiles_to_inchi, is_valid_inchi, is_valid_smiles
+from matchms.filtering.filters.derive_from_inchi_smile_template import DeriveFromInchiSmileTemplate
+
+
+class DeriveInchiFromSmiles(DeriveFromInchiSmileTemplate):
+    def __init__(self):
+        super().__init__(
+            derive_to="inchi",
+            derive_from="smiles",
+            convert_function=convert_smiles_to_inchi,
+            log_message="Added InChI (%s) to metadata (was converted from smiles).",
+        )
+
+    def is_valid(self, derive_to, derive_from):
+        return not is_valid_inchi(derive_to) and is_valid_smiles(derive_from)

--- a/matchms/filtering/filters/derive_inchikey_from_inchi.py
+++ b/matchms/filtering/filters/derive_inchikey_from_inchi.py
@@ -1,0 +1,15 @@
+from ...metadata_utils import convert_inchi_to_inchikey, is_valid_inchi, is_valid_inchikey
+from matchms.filtering.filters.derive_from_inchi_smile_template import DeriveFromInchiSmileTemplate
+
+
+class DeriveInchikeyFromInchi(DeriveFromInchiSmileTemplate):
+    def __init__(self):
+        super().__init__(
+            derive_to="inchikey",
+            derive_from="inchi",
+            convert_function=convert_inchi_to_inchikey,
+            log_message="Added InChIKey %s to metadata (was converted from inchi)",
+        )
+
+    def is_valid(self, derive_to, derive_from):
+        return is_valid_inchi(derive_from) and not is_valid_inchikey(derive_to)

--- a/matchms/filtering/filters/derive_ionmode.py
+++ b/matchms/filtering/filters/derive_ionmode.py
@@ -1,0 +1,36 @@
+import logging
+from matchms.typing import SpectrumType
+from ..filter_utils.load_known_adducts import load_known_adducts
+from ..filters.clean_adduct import CleanAdduct
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class DeriveIonmode(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        # Load lists of known adducts
+        known_adducts = load_known_adducts()
+
+        adduct = spectrum.get("adduct", None)
+        # Harmonize adduct string
+        if adduct:
+            adduct = CleanAdduct._clean_adduct(adduct)
+
+        ionmode = spectrum.get("ionmode")
+        if ionmode:
+            assert ionmode == ionmode.lower(), ("Ionmode field not harmonized.",
+                                                "Apply 'make_ionmode_lowercase' filter first.")
+        if ionmode in ["positive", "negative"]:
+            return spectrum
+        # Try completing missing or incorrect ionmodes
+        if adduct in list(known_adducts["adduct"]):
+            ionmode = known_adducts.loc[known_adducts["adduct"] == adduct, "ionmode"].values[0]
+        else:
+            ionmode = "n/a"
+
+        spectrum.set("ionmode", ionmode)
+        logger.info("Set ionmode to %s.", ionmode)
+
+        return spectrum

--- a/matchms/filtering/filters/derive_smiles_from_inchi.py
+++ b/matchms/filtering/filters/derive_smiles_from_inchi.py
@@ -1,0 +1,15 @@
+from ...metadata_utils import convert_inchi_to_smiles, is_valid_inchi, is_valid_smiles
+from matchms.filtering.filters.derive_from_inchi_smile_template import DeriveFromInchiSmileTemplate
+
+
+class DeriveSmilesFromInchi(DeriveFromInchiSmileTemplate):
+    def __init__(self):
+        super().__init__(
+            derive_to="smiles",
+            derive_from="inchi",
+            convert_function=convert_inchi_to_smiles,
+            log_message="Added smiles %s to metadata (was converted from InChI)",
+        )
+
+    def is_valid(self, derive_to, derive_from):
+        return not is_valid_smiles(derive_to) and is_valid_inchi(derive_from)

--- a/matchms/filtering/filters/harmonize_undefined_inchi.py
+++ b/matchms/filtering/filters/harmonize_undefined_inchi.py
@@ -1,0 +1,7 @@
+from matchms.filtering.filters.harmonize_undefined_template import HarmonizeUndefinedTemplate
+from matchms.typing import SpectrumType
+
+
+class HarmonizeUndefinedInchi(HarmonizeUndefinedTemplate):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        return super().apply_filter(spectrum, "inchi")

--- a/matchms/filtering/filters/harmonize_undefined_inchikey.py
+++ b/matchms/filtering/filters/harmonize_undefined_inchikey.py
@@ -1,0 +1,7 @@
+from matchms.filtering.filters.harmonize_undefined_template import HarmonizeUndefinedTemplate
+from matchms.typing import SpectrumType
+
+
+class HarmonizeUndefinedInchikey(HarmonizeUndefinedTemplate):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        return super().apply_filter(spectrum, "inchikey")

--- a/matchms/filtering/filters/harmonize_undefined_smiles.py
+++ b/matchms/filtering/filters/harmonize_undefined_smiles.py
@@ -1,0 +1,7 @@
+from matchms.filtering.filters.harmonize_undefined_template import HarmonizeUndefinedTemplate
+from matchms.typing import SpectrumType
+
+
+class HarmonizeUndefinedSmiles(HarmonizeUndefinedTemplate):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        return super().apply_filter(spectrum, "smiles")

--- a/matchms/filtering/filters/harmonize_undefined_template.py
+++ b/matchms/filtering/filters/harmonize_undefined_template.py
@@ -1,0 +1,22 @@
+from typing import List
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+class HarmonizeUndefinedTemplate(BaseSpectrumFilter):
+    def __init__(self, undefined: str = "", aliases: List[str] = None):
+        self.undefined = undefined
+        self.aliases = aliases or ["", "N/A", "NA", "n/a", "no data"]
+
+    def apply_filter(self, spectrum: SpectrumType, key: str) -> SpectrumType:
+        value = spectrum.get(key)
+        if value is None:
+            # spectrum does not have the specified key in its metadata
+            spectrum.set(key, self.undefined)
+            return spectrum
+
+        if value in self.aliases:
+            # harmonize aliases for undefined values
+            spectrum.set(key, self.undefined)
+
+        return spectrum

--- a/matchms/filtering/filters/interpret_pepmass.py
+++ b/matchms/filtering/filters/interpret_pepmass.py
@@ -1,0 +1,95 @@
+import logging
+import numpy as np
+from .make_charge_int import MakeChargeInt
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+_accepted_types = (float, str, int)
+_accepted_missing_entries = ["", "N/A", "NA", "n/a"]
+
+
+class InterpretPepmass(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        metadata_updated = InterpretPepmass._interpret_pepmass_metadata(spectrum.metadata)
+        spectrum.metadata = metadata_updated
+        return spectrum
+
+    def _interpret_pepmass_metadata(metadata):
+        pepmass = metadata.get("pepmass")
+        if pepmass is None:
+            return metadata
+
+        mz, intensity, charge = InterpretPepmass._get_mz_intensity_charge(pepmass)
+        mz = InterpretPepmass._convert_mz_or_intensity(mz)
+        intensity = InterpretPepmass._convert_mz_or_intensity(intensity)
+        charge = MakeChargeInt._convert_charge_to_int(charge)
+
+        if mz is not None:
+            if metadata.get("precursor_mz") is not None\
+                and InterpretPepmass._substantial_difference(metadata.get("precursor_mz"), mz, atol=0.001):
+                logger.warning("Overwriting existing precursor_mz %s with new one: %s",
+                               metadata.get("precursor_mz"), str(mz))
+            metadata["precursor_mz"] = mz
+            logger.info("Added precursor_mz entry based on field 'pepmass'.")
+
+        if intensity is not None:
+            if metadata.get("precursor_intensity") is not None:
+                logger.warning("Overwriting existing precursor_intensity %s with new one: %s",
+                               metadata.get("precursor_intensity"), str(intensity))
+            metadata["precursor_intensity"] = intensity
+            logger.info("Added precursor_intensity entry based on field 'pepmass'.")
+
+        if charge is not None:
+            if metadata.get("charge") is not None:
+                logger.warning("Overwriting existing charge %s with new one: %s",
+                               metadata.get("charge"), str(charge))
+            metadata["charge"] = charge
+            logger.info("Added charge entry based on field 'pepmass'.")
+
+        return metadata
+
+
+    def _get_mz_intensity_charge(pepmass):
+        try:
+            length = len(pepmass)
+            values = [None, None, None]
+            for i in range(length):
+                values[i] = pepmass[i]
+            return values[0], values[1], values[2]
+        except TypeError:
+            if pepmass is not None:
+                return pepmass, None, None
+            return None, None, None
+
+
+    def _convert_mz_or_intensity(entry):
+        """Convert mz or intensity to number if possible. Otherwise return None."""
+        if entry is None:
+            return None
+        if isinstance(entry, str) and entry in _accepted_missing_entries:
+            return None
+        if not isinstance(entry, _accepted_types):
+            logger.warning("Found undefined type.")
+            return None
+        if isinstance(entry, str):
+            try:
+                return float(entry.strip())
+            except ValueError:
+                logger.warning("%s can't be converted to float.", entry)
+                return None
+        return entry
+
+
+    def _substantial_difference(mz_now, mz_new, atol=0.001):
+        """Returns True if mz_now and mz_new differ by more than atol."""
+        if mz_now is None:
+            return True
+        try:
+            mz_now_float = float(mz_now)
+        except ValueError:
+            return True
+        if np.abs(mz_now_float - mz_new) > atol:
+            return True
+        return False

--- a/matchms/filtering/filters/make_charge_int.py
+++ b/matchms/filtering/filters/make_charge_int.py
@@ -1,0 +1,43 @@
+import logging
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class MakeChargeInt(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        charge = spectrum.get("charge", None)
+        charge_int = MakeChargeInt._convert_charge_to_int(charge)
+        if isinstance(charge_int, int):
+            spectrum.set("charge", charge_int)
+
+        return spectrum
+
+    def _convert_charge_to_int(charge):
+        """Convert charge to integer if possible, else return None."""
+        def _try_conversion(charge):
+            try:
+                return int(charge)
+            except ValueError:
+                logger.warning("Found charge (%s) cannot be converted to integer.",
+                               str(charge))
+                return None
+
+        if charge is None:
+            return None
+
+        if isinstance(charge, int):
+            return charge
+
+        # Avoid pyteomics ChargeList
+        if isinstance(charge, list):
+            return _try_conversion(charge[0])
+
+        # convert string charges to int
+        if isinstance(charge, str):
+            charge = charge.strip().replace("+", "")
+            if len(charge) > 1 and charge[-1] == "-":
+                charge = "-" + charge.replace("-", "")
+            return _try_conversion(charge)

--- a/matchms/filtering/filters/normalize_intensities.py
+++ b/matchms/filtering/filters/normalize_intensities.py
@@ -1,0 +1,33 @@
+import logging
+import numpy as np
+from matchms.typing import SpectrumType
+from ...Fragments import Fragments
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class NormalizeIntensities(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        if len(spectrum.peaks) == 0:
+            return spectrum
+    
+        max_intensity = np.max(spectrum.peaks.intensities)
+    
+        if max_intensity <= 0:
+            logger.warning("Spectrum with all peak intensities <= 0 was set to None.")
+            return None
+    
+        # Normalize peak intensities
+        mz, intensities = spectrum.peaks.mz, spectrum.peaks.intensities
+        normalized_intensities = intensities / max_intensity
+        spectrum.peaks = Fragments(mz=mz, intensities=normalized_intensities)
+    
+        # Normalize loss intensities
+        if spectrum.losses is not None and len(spectrum.losses) > 0:
+            mz, intensities = spectrum.losses.mz, spectrum.losses.intensities
+            normalized_intensities = intensities / max_intensity
+            spectrum.losses = Fragments(mz=mz, intensities=normalized_intensities)
+    
+        return spectrum

--- a/matchms/filtering/filters/reduce_to_number_of_peaks.py
+++ b/matchms/filtering/filters/reduce_to_number_of_peaks.py
@@ -1,0 +1,47 @@
+import logging
+from math import ceil
+from typing import Optional
+import numpy as np
+from matchms.Fragments import Fragments
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class ReduceToNumberOfPeaks(BaseSpectrumFilter):
+    def __init__(self, n_required: int = 1, n_max: int = np.inf, ratio_desired: Optional[float] = None):
+        self.n_required = n_required
+        self.n_max = n_max
+        self.ratio_desired = ratio_desired
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        def _set_maximum_number_of_peaks_to_keep():
+            parent_mass = spectrum.get("parent_mass", None)
+            if parent_mass and self.ratio_desired:
+                n_desired_by_mass = int(ceil(self.ratio_desired * parent_mass))
+                return min(max(self.n_required, n_desired_by_mass), self.n_max)
+            if not self.ratio_desired:
+                return self.n_max
+            raise ValueError("Cannot use ratio_desired for spectrum without parent_mass.")
+
+        def _remove_lowest_intensity_peaks():
+            mz, intensities = spectrum.peaks.mz, spectrum.peaks.intensities
+            idx = intensities.argsort()[-threshold:]
+            idx_sort_by_mz = mz[idx].argsort()
+            spectrum.peaks = Fragments(mz=mz[idx][idx_sort_by_mz],
+                                       intensities=intensities[idx][idx_sort_by_mz])
+
+        if spectrum.peaks.intensities.size < self.n_required:
+            logger.info("Spectrum with %s (<%s) peaks was set to None.",
+                        str(spectrum.peaks.intensities.size), str(self.n_required))
+            return None
+
+        threshold = _set_maximum_number_of_peaks_to_keep()
+        if spectrum.peaks.intensities.size < threshold:
+            return spectrum
+
+        _remove_lowest_intensity_peaks()
+
+        return spectrum

--- a/matchms/filtering/filters/remove_peaks_around_precursor_mz.py
+++ b/matchms/filtering/filters/remove_peaks_around_precursor_mz.py
@@ -1,0 +1,23 @@
+import numpy as np
+from matchms.Fragments import Fragments
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+class RemovePeaksAroundPrecursorMz(BaseSpectrumFilter):
+    def __init__(self, mz_tolerance: float = 17):
+        self.mz_tolerance = mz_tolerance
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        precursor_mz = spectrum.get("precursor_mz", None)
+        assert precursor_mz is not None, "Precursor mz absent."
+        assert isinstance(precursor_mz, (float, int)), ("Expected 'precursor_mz' to be a scalar number.",
+                                                        "Consider applying 'add_precursor_mz' filter first.")
+        assert self.mz_tolerance >= 0, "mz_tolerance must be a positive scalar."
+
+        mzs, intensities = spectrum.peaks.mz, spectrum.peaks.intensities
+        peaks_to_remove = ((np.abs(precursor_mz-mzs) <= self.mz_tolerance) & (mzs != precursor_mz))
+        new_mzs, new_intensities = mzs[~peaks_to_remove], intensities[~peaks_to_remove]
+        spectrum.peaks = Fragments(mz=new_mzs, intensities=new_intensities)
+
+        return spectrum

--- a/matchms/filtering/filters/remove_peaks_outside_top_k.py
+++ b/matchms/filtering/filters/remove_peaks_outside_top_k.py
@@ -1,0 +1,29 @@
+import numpy as np
+from matchms.Fragments import Fragments
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+class RemovePeaksOutsideTopK(BaseSpectrumFilter):
+    def __init__(self, k: int = 6, mz_window: float = 50):
+        self.k = k
+        self.mz_window = mz_window
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        assert self.k >= 1, "k must be a positive nonzero integer."
+        assert self.mz_window >= 0, "mz_window must be a positive scalar."
+        mzs, intensities = spectrum.peaks.mz, spectrum.peaks.intensities
+        top_k = intensities.argsort()[::-1][0:self.k]
+        k_ordered_mzs = mzs[top_k]
+        indices = [i for i in range(len(mzs)) if i not in top_k]
+        keep_idx = top_k.tolist()
+        for i in indices:
+            compare = abs(mzs[i]-k_ordered_mzs) <= self.mz_window
+            if np.any(compare):
+                keep_idx.append(i)
+
+        keep_idx.sort()
+        new_mzs, new_intensities = mzs[keep_idx], intensities[keep_idx]
+        spectrum.peaks = Fragments(mz=new_mzs, intensities=new_intensities)
+
+        return spectrum

--- a/matchms/filtering/filters/repair_adduct_based_on_smiles.py
+++ b/matchms/filtering/filters/repair_adduct_based_on_smiles.py
@@ -1,0 +1,54 @@
+import logging
+from matchms import Spectrum
+from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
+    get_monoisotopic_neutral_mass
+from ..filter_utils.load_known_adducts import load_known_adducts
+from ..metadata_processing.repair_parent_mass_is_mol_wt import repair_parent_mass_is_mol_wt
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class RepairAdductBasedOnSmiles(BaseSpectrumFilter):
+    def __init__(self, mass_tolerance, accept_parent_mass_is_mol_wt):
+        self.mass_tolerance = mass_tolerance
+        self.accept_parent_mass_is_mol_wt = accept_parent_mass_is_mol_wt
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        changed_spectrum = spectrum.clone()
+
+        precursor_mz = changed_spectrum.get("precursor_mz")
+        ion_mode = changed_spectrum.get("ionmode")
+        if ion_mode not in ("positive", "negative"):
+            logger.warning("Ionmode: %s not positive or negative, first run derive_ionmode",
+                            ion_mode)
+            return changed_spectrum
+        if precursor_mz is None:
+            logger.warning("Precursor_mz is None, first run add_precursor_mz")
+            return changed_spectrum
+    
+        adducts_df = load_known_adducts()
+        smiles_mass = get_monoisotopic_neutral_mass(changed_spectrum.get("smiles"))
+        parent_masses = (precursor_mz - adducts_df["correction_mass"]) / adducts_df["mass_multiplier"]
+        mass_differences = abs(parent_masses-smiles_mass)
+    
+        # Select the lowest value
+        smalles_mass_index = mass_differences.idxmin()
+        parent_mass = parent_masses[smalles_mass_index]
+        adduct = adducts_df.iloc[smalles_mass_index]["adduct"]
+        # Change spectrum. This spectrum will only be returned if the mass difference is smaller than mass tolerance
+        changed_spectrum.set("parent_mass", parent_mass)
+        changed_spectrum.set("adduct", adduct)
+        if mass_differences[smalles_mass_index] < self.mass_tolerance:
+            logger.info("Adduct was set from %s to %s",
+                        spectrum.get('adduct'), adduct)
+            return changed_spectrum
+        if self.accept_parent_mass_is_mol_wt:
+            changed_spectrum = repair_parent_mass_is_mol_wt(changed_spectrum, self.mass_tolerance)
+            if abs(changed_spectrum.get("parent_mass") - smiles_mass) < self.mass_tolerance:
+                logger.info("Adduct was set from %s to %s",
+                            spectrum.get('adduct'), adduct)
+                return changed_spectrum
+        return spectrum

--- a/matchms/filtering/filters/repair_inchi_inchikey_smiles.py
+++ b/matchms/filtering/filters/repair_inchi_inchikey_smiles.py
@@ -1,0 +1,25 @@
+from matchms.filtering.SpeciesString import SpeciesString
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+class RepairInchiInchikeySmiles(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        # interpret available data and clean each
+        inchi = spectrum.get("inchi", "")
+        inchiaux = spectrum.get("inchiaux", "")
+        inchikey = spectrum.get("inchikey", "")
+        smiles = spectrum.get("smiles", "")
+
+        cleaneds = [SpeciesString(s) for s in [inchi, inchiaux, inchikey, smiles]]
+
+        # for each type, list what we have and pick one
+        inchis = [c.cleaned for c in cleaneds if c.target == "inchi" and c.cleaned != ""]
+        inchikeys = [c.cleaned for c in cleaneds if c.target == "inchikey" and c.cleaned != ""]
+        smiles = [c.cleaned for c in cleaneds if c.target == "smiles" and c.cleaned != ""]
+
+        spectrum.set("inchi", inchis[0] if len(inchis) > 0 else "")
+        spectrum.set("inchikey", inchikeys[0] if len(inchikeys) > 0 else "")
+        spectrum.set("smiles", smiles[0] if len(smiles) > 0 else "")
+
+        return spectrum

--- a/matchms/filtering/filters/repair_parent_mass_is_mol_wt.py
+++ b/matchms/filtering/filters/repair_parent_mass_is_mol_wt.py
@@ -1,0 +1,39 @@
+import logging
+from matchms import Spectrum
+from matchms.filtering.filter_utils.derive_precursor_mz_and_parent_mass import \
+    derive_precursor_mz_from_parent_mass
+from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import (
+    get_molecular_weight_neutral_mass, get_monoisotopic_neutral_mass)
+from ..metadata_processing.require_parent_mass_match_smiles import require_parent_mass_match_smiles
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+
+
+class RepairParentMassIsMolWt(BaseSpectrumFilter):
+    def __init__(self, mass_tolerance: float):
+        self.mass_tolerance = mass_tolerance
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        # Check if parent mass already matches smiles
+        if require_parent_mass_match_smiles(spectrum, self.mass_tolerance) is not None:
+            return spectrum
+        # Check if the precursor_mz can be calculated from the parent mass. If not skip this function
+        if abs(spectrum.get("precursor_mz") - derive_precursor_mz_from_parent_mass(spectrum)) > self.mass_tolerance:
+            return spectrum
+        # Check if parent mass matches the smiles mass
+        parent_mass = spectrum.get("parent_mass")
+        smiles = spectrum.get("smiles")
+        smiles_mass = get_molecular_weight_neutral_mass(smiles)
+        mass_difference = parent_mass - smiles_mass
+        if abs(mass_difference) < self.mass_tolerance:
+            correct_mass = get_monoisotopic_neutral_mass(smiles)
+            spectrum.set("parent_mass", correct_mass)
+            logger.info("Parent mass was mol_wt corrected from %s to %s",
+                        parent_mass, correct_mass)
+            precursor_mz = derive_precursor_mz_from_parent_mass(spectrum)
+            logger.info("Precursor mz was derived from parent mass")
+            spectrum.set("precursor_mz", precursor_mz)
+        return spectrum

--- a/matchms/filtering/filters/repair_parent_mass_match_smiles_wrapper.py
+++ b/matchms/filtering/filters/repair_parent_mass_match_smiles_wrapper.py
@@ -1,0 +1,40 @@
+import logging
+from typing import Optional
+from matchms.filtering.metadata_processing.repair_adduct_based_on_smiles import \
+    repair_adduct_based_on_smiles
+from matchms.typing import SpectrumType
+from ..metadata_processing.repair_parent_mass_is_mol_wt import repair_parent_mass_is_mol_wt
+from ..metadata_processing.repair_precursor_is_parent_mass import repair_precursor_is_parent_mass
+from ..metadata_processing.repair_smiles_of_salts import repair_smiles_of_salts
+from ..metadata_processing.require_parent_mass_match_smiles import require_parent_mass_match_smiles
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+
+
+class RepairParentMassMatchSmilesWrapper(BaseSpectrumFilter):
+    def __init__(self, mass_tolerance: float = 0.2):
+        self.mass_tolerance = mass_tolerance
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        if require_parent_mass_match_smiles(spectrum, self.mass_tolerance) is not None:
+            return spectrum
+
+        spectrum = repair_smiles_of_salts(spectrum, self.mass_tolerance)
+        if require_parent_mass_match_smiles(spectrum, self.mass_tolerance) is not None:
+            return spectrum
+
+        spectrum = repair_precursor_is_parent_mass(spectrum, self.mass_tolerance)
+        if require_parent_mass_match_smiles(spectrum, self.mass_tolerance) is not None:
+            return spectrum
+
+        spectrum = repair_parent_mass_is_mol_wt(spectrum, self.mass_tolerance)
+        if require_parent_mass_match_smiles(spectrum, self.mass_tolerance) is not None:
+            return spectrum
+
+        spectrum = repair_adduct_based_on_smiles(spectrum, self.mass_tolerance, accept_parent_mass_is_mol_wt=True)
+        if require_parent_mass_match_smiles(spectrum, self.mass_tolerance) is not None:
+            return spectrum
+        return None

--- a/matchms/filtering/filters/repair_precursor_is_parent_mass.py
+++ b/matchms/filtering/filters/repair_precursor_is_parent_mass.py
@@ -1,0 +1,39 @@
+import logging
+from matchms import Spectrum
+from matchms.filtering.filter_utils.derive_precursor_mz_and_parent_mass import \
+    derive_precursor_mz_from_parent_mass
+from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
+    get_monoisotopic_neutral_mass
+from ..metadata_processing.require_parent_mass_match_smiles import require_parent_mass_match_smiles
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+
+
+class RepairPrecursorIsParentMass(BaseSpectrumFilter):
+    def __init__(self, mass_tolerance):
+        self.mass_tolerance = mass_tolerance
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        # Check if parent mass already matches smiles
+        if require_parent_mass_match_smiles(spectrum, self.mass_tolerance) is not None:
+            return spectrum
+
+        precursor_mz = spectrum.get("precursor_mz")
+        # Check if the precursor_mz can be calculated from the parent mass. If not skip this function
+        if abs(precursor_mz - derive_precursor_mz_from_parent_mass(spectrum)) > self.mass_tolerance:
+            return spectrum
+
+        smiles = spectrum.get("smiles")
+        smiles_mass = get_monoisotopic_neutral_mass(smiles)
+        mass_difference = precursor_mz - smiles_mass
+        if abs(mass_difference) < self.mass_tolerance:
+            logger.info("Parent mass was changed from %s to %s", spectrum.get("parent_mass"), smiles_mass)
+            spectrum.set("parent_mass", smiles_mass)
+            new_precursor_mz = derive_precursor_mz_from_parent_mass(spectrum)
+            if new_precursor_mz is not None:
+                logger.info("Parent mass was changed from %s to %s", spectrum.get("precursor_mz"), new_precursor_mz)
+                spectrum.set("precursor_mz", new_precursor_mz)
+        return spectrum

--- a/matchms/filtering/filters/repair_smiles_from_compound_name.py
+++ b/matchms/filtering/filters/repair_smiles_from_compound_name.py
@@ -1,0 +1,66 @@
+import logging
+import numpy as np
+import pandas as pd
+from matchms import Spectrum
+from matchms.metadata_utils import (is_valid_inchi, is_valid_inchikey,
+                                    is_valid_smiles)
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+
+
+class RepairSmilesFromCompoundName(BaseSpectrumFilter):
+    def __init__(self, annotated_compound_names_file, mass_tolerance=0.1):
+        self.annotated_compound_names_file = annotated_compound_names_file
+        self.mass_tolerance = mass_tolerance
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        annotated_compound_names = RepairSmilesFromCompoundName._load_compound_name_annotations(self.annotated_compound_names_file)
+
+        if RepairSmilesFromCompoundName._check_fully_annotated(spectrum):
+            return spectrum
+        compound_name = spectrum.get("compound_name")
+        parent_mass = spectrum.get('parent_mass')
+
+        if RepairSmilesFromCompoundName._is_plausible_name(compound_name) and parent_mass is not None:
+            matching_compound_name = annotated_compound_names[annotated_compound_names["compound_name"] == compound_name]
+            mass_differences = np.abs(matching_compound_name["monoisotopic_mass"]-parent_mass)
+            within_mass_tolerance = matching_compound_name[mass_differences < self.mass_tolerance]
+            if within_mass_tolerance.shape[0] > 0:
+                # Select the match with the most
+                best_match = within_mass_tolerance.loc[within_mass_tolerance["monoisotopic_mass"].idxmin()]
+                spectrum.set("smiles", best_match["smiles"])
+                spectrum.set("inchi", best_match["inchi"])
+                spectrum.set("inchikey", best_match["inchikey"])
+                logger.info("Added smiles %s based on the compound name %s", best_match["smiles"], compound_name)
+                return spectrum
+        return spectrum
+
+
+    def _load_compound_name_annotations(annotated_compound_names_file):
+        """Loads in the annotated compound names and checks format"""
+        annotated_compound_names = pd.read_csv(annotated_compound_names_file)
+        assert list(annotated_compound_names.columns) == ["compound_name", "smiles", "inchi",
+                                                          "inchikey", "monoisotopic_mass"], \
+            "Choose a different annotated compound names file with columns compound_name, smiles, inchi, inchikey, monoisotopic_mass"
+        return annotated_compound_names
+
+
+    def _check_fully_annotated(spectrum: Spectrum) -> bool:
+        """Combine multiple check functions.
+        Returns False if SMILES, InChIKey, or InChI are missing.
+        """
+        if not is_valid_smiles(spectrum.get("smiles")):
+            return False
+        if not is_valid_inchikey(spectrum.get("inchikey")):
+            return False
+        if not is_valid_inchi(spectrum.get("inchi")):
+            return False
+        return True
+
+
+    def _is_plausible_name(compound_name):
+        """Simple check if it can be a compound name."""
+        return isinstance(compound_name, str) and len(compound_name) > 4

--- a/matchms/filtering/filters/repair_smiles_of_salts.py
+++ b/matchms/filtering/filters/repair_smiles_of_salts.py
@@ -1,0 +1,54 @@
+import itertools
+import logging
+from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
+    get_monoisotopic_neutral_mass
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+
+
+class RepairSmilesOfSalts(BaseSpectrumFilter):
+    def __init__(self, mass_tolerance):
+        self.mass_tolerance = mass_tolerance
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        smiles = spectrum.get("smiles")
+        parent_mass = spectrum.get("parent_mass")
+        possible_ion_combinations = RepairSmilesOfSalts._create_possible_ions(smiles)
+        if not possible_ion_combinations:
+            # It is not a salt
+            return spectrum
+        for ion, not_used_ions in possible_ion_combinations:
+            ion_mass = get_monoisotopic_neutral_mass(ion)
+            mass_diff = abs(parent_mass - ion_mass)
+            # Check for Repair parent mass is mol wt did only return 1 spectrum. So not added as option for simplicity.
+            if mass_diff < self.mass_tolerance:
+                spectrum_with_ions = spectrum.clone()
+                spectrum_with_ions.set("smiles", ion)
+                spectrum_with_ions.set("salt_ions", not_used_ions)
+                logger.info("Removed salt ions: %s from %s to match parent mass",
+                            not_used_ions, smiles)
+                return spectrum_with_ions
+        logger.warning("None of the parts of the smile %s match the parent mass: %s",
+                       smiles, parent_mass)
+        return spectrum
+
+
+    def _create_possible_ions(smiles):
+        """Selects all possible ion combinations of a salt"""
+
+        results = []
+        if "." in smiles:
+            single_ions = smiles.split(".")
+            for r in range(1, len(single_ions) + 1):
+                combinations = itertools.combinations(single_ions, r)
+                for combination in combinations:
+                    combined_ion = ".".join(combination)
+                    removed_ions = single_ions.copy()
+                    for used_ion in combination:
+                        removed_ions.remove(used_ion)
+                    removed_ions = ".".join(removed_ions)
+                    results.append((combined_ion, removed_ions))
+        return results

--- a/matchms/filtering/filters/require_correct_ionmode.py
+++ b/matchms/filtering/filters/require_correct_ionmode.py
@@ -1,0 +1,27 @@
+import logging
+from typing import Optional
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+logger = logging.getLogger("matchms")
+
+
+class RequireCorrectIonmode(BaseSpectrumFilter):
+    def __init__(self, ion_mode_to_keep):
+        self.ion_mode_to_keep = ion_mode_to_keep
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        if self.ion_mode_to_keep not in {"positive", "negative", "both"}:
+            raise ValueError("ion_mode_to_keep should be 'positive', 'negative' or 'both'")
+        ion_mode = spectrum.get("ionmode")
+        if self.ion_mode_to_keep == "both":
+            if ion_mode in ("positive", "negative"):
+                return spectrum
+
+            logger.info("Spectrum was removed since ionmode was: %s which does not match positive or negative", ion_mode)
+            return None
+        if ion_mode == self.ion_mode_to_keep:
+            return spectrum
+        logger.info("Spectrum was removed since ionmode was: %s which does not match %s", ion_mode, self.ion_mode_to_keep)
+        return None

--- a/matchms/filtering/filters/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/filters/require_minimum_number_of_peaks.py
@@ -1,0 +1,29 @@
+import logging
+from math import ceil
+from typing import Optional
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class RequireMinimumNumberOfPeaks(BaseSpectrumFilter):
+    def __init__(self, n_required: int = 10, ratio_required: Optional[float] = None):
+        self.n_required = n_required
+        self.ratio_required = ratio_required
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        parent_mass = spectrum.get("parent_mass", None)
+        if parent_mass and self.ratio_required:
+            n_required_by_mass = int(ceil(self.ratio_required * parent_mass))
+            threshold = max(self.n_required, n_required_by_mass)
+        else:
+            threshold = self.n_required
+
+        if spectrum.peaks.intensities.size < threshold:
+            logger.info("Spectrum with %s (<%s) peaks was set to None.",
+                        str(spectrum.peaks.intensities.size), str(threshold))
+            return None
+
+        return spectrum

--- a/matchms/filtering/filters/require_minimum_of_high_peaks.py
+++ b/matchms/filtering/filters/require_minimum_of_high_peaks.py
@@ -1,0 +1,25 @@
+import logging
+from matchms.typing import SpectrumType
+#from .select_by_relative_intensity import select_by_relative_intensity
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.filtering.filters.select_by_relative_intensity import SelectByRelativeIntensity
+
+
+logger = logging.getLogger("matchms")
+
+
+class RequireMinimumOfHighPeaks(BaseSpectrumFilter):
+    def __init__(self, no_peaks: int = 5, intensity_percent: float = 2.0):
+        self.no_peaks = no_peaks
+        self.intensity_percent = intensity_percent
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        assert self.no_peaks >= 1, "no_peaks must be a positive nonzero integer."
+        assert 0 <= self.intensity_percent <= 100, "intensity_percent must be a scalar between 0-100."
+        intensities_above_p = SelectByRelativeIntensity(intensity_from=self.intensity_percent/100, intensity_to=1.0).process(spectrum)
+        if len(intensities_above_p.peaks) < self.no_peaks:
+            logger.info("Spectrum with %s (<%s) peaks was set to None.",
+                        str(len(intensities_above_p.peaks)), str(self.no_peaks))
+            return None
+
+        return spectrum

--- a/matchms/filtering/filters/require_parent_mass_match_smiles.py
+++ b/matchms/filtering/filters/require_parent_mass_match_smiles.py
@@ -1,0 +1,20 @@
+from typing import Optional
+from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
+    get_monoisotopic_neutral_mass
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+class RequireParentMassMatchSmiles(BaseSpectrumFilter):
+    def __init__(self, mass_tolerance):
+        self.mass_tolerance = mass_tolerance
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        # Check if parent mass matches the smiles mass
+        parent_mass = spectrum.get("parent_mass")
+        smiles = spectrum.get("smiles")
+        smiles_mass = get_monoisotopic_neutral_mass(smiles)
+        mass_difference = parent_mass - smiles_mass
+        if abs(mass_difference) < self.mass_tolerance:
+            return spectrum
+        return None

--- a/matchms/filtering/filters/require_precursor_below_mz.py
+++ b/matchms/filtering/filters/require_precursor_below_mz.py
@@ -1,0 +1,23 @@
+import logging
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+logger = logging.getLogger("matchms")
+
+
+class RequirePrecursorBelowMz(BaseSpectrumFilter):
+    def __init__(self, max_mz: float = 1000):
+        self.max_mz = max_mz
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        precursor_mz = spectrum.get("precursor_mz", None)
+        assert precursor_mz is not None, "Precursor mz absent."
+        assert isinstance(precursor_mz, (float, int)), ("Expected 'precursor_mz' to be a scalar number.",
+                                                        "Consider applying 'add_precursor_mz' filter first.")
+        assert self.max_mz >= 0, "max_mz must be a positive scalar."
+        if precursor_mz >= self.max_mz:
+            logger.info("Spectrum with precursor_mz %s (>%s) was set to None.",
+                        str(precursor_mz), str(self.max_mz))
+            return None
+
+        return spectrum

--- a/matchms/filtering/filters/require_precursor_mz.py
+++ b/matchms/filtering/filters/require_precursor_mz.py
@@ -1,0 +1,30 @@
+import logging
+from typing import Union
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+
+logger = logging.getLogger("matchms")
+
+
+class RequirePrecursorMz(BaseSpectrumFilter):
+    def __init__(self, minimum_accepted_mz: float = 10.0):
+        self.minimum_accepted_mz = minimum_accepted_mz
+
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        precursor_mz = spectrum.get("precursor_mz", None)
+        if precursor_mz is None:
+            pepmass = spectrum.get("pepmass", None)
+            assert pepmass is None or not isinstance(pepmass[0], (float, int)), \
+                "Found 'pepmass' but no 'precursor_mz'. " \
+                "Consider applying 'add_precursor_mz' filter first."
+            return None
+
+        assert isinstance(precursor_mz, (float, int)), \
+            ("Expected 'precursor_mz' to be a scalar number.",
+             "Consider applying 'add_precursor_mz' filter first.")
+        if precursor_mz <= self.minimum_accepted_mz:
+            logger.info("Spectrum without precursor_mz was set to None.")
+            return None
+
+        return spectrum

--- a/matchms/filtering/filters/require_valid_annotation.py
+++ b/matchms/filtering/filters/require_valid_annotation.py
@@ -1,0 +1,50 @@
+import logging
+from matchms import Spectrum
+from matchms.metadata_utils import (convert_inchi_to_inchikey,
+                                    convert_smiles_to_inchi, is_valid_inchi,
+                                    is_valid_inchikey, is_valid_smiles)
+from matchms.typing import SpectrumType
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+
+logger = logging.getLogger("matchms")
+
+
+class RequireValidAnnotation(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        smiles = spectrum.get("smiles")
+        inchi = spectrum.get("inchi")
+        inchikey = spectrum.get("inchikey")
+        if not is_valid_smiles(smiles):
+            logger.info("Removed spectrum since smiles is not valid. Incorrect smiles = %s", smiles)
+            return None
+        if not is_valid_inchikey(inchikey):
+            logger.info("Removed spectrum since inchikey is not valid. Incorrect inchikey = %s", inchikey)
+            return None
+        if not is_valid_inchi(inchi):
+            logger.info("Removed spectrum since inchi is not valid. Incorrect inchi = %s", inchi)
+            return None
+        if not RequireValidAnnotation._check_smiles_inchi_inchikey_match(spectrum):
+            return None
+        return spectrum
+
+
+    def _check_smiles_inchi_inchikey_match(spectrum) -> bool:
+        """Checks if a spectrum"""
+        if spectrum is None:
+            return False
+        smiles = spectrum.get("smiles")
+        inchi = spectrum.get("inchi")
+        inchikey = spectrum.get("inchikey")
+        # check if inchi matches the inchikey
+        if not inchikey[:14] == convert_inchi_to_inchikey(inchi)[:14]:
+            logger.warning("Removed spectrum since inchi and inchikey do not match. "
+                           "inchi = %s, inchikey = %s, expected_inchikey = %s",
+                           inchi, inchikey, convert_inchi_to_inchikey(inchi))
+            return False
+        # check if smiles matches the inchikey (first convert to inchi followed by converting to inchikey)
+        if not inchikey[:14] == convert_inchi_to_inchikey(convert_smiles_to_inchi(smiles))[:14]:
+            logger.warning("Removed spectrum since smiles does not match the inchikey. "
+                           "inchikey = %s, smiles = %s, expected_inchikey = %s",
+                           inchikey, smiles, convert_inchi_to_inchikey(convert_smiles_to_inchi(smiles)))
+            return False
+        return True

--- a/matchms/filtering/filters/select_by_intensity.py
+++ b/matchms/filtering/filters/select_by_intensity.py
@@ -1,0 +1,16 @@
+import numpy as np
+from matchms.filtering.filters.select_by_template import SelectByTemplate
+from matchms.typing import SpectrumType
+
+
+class SelectByIntensity(SelectByTemplate):
+    def __init__(self, intensity_from: float, intensity_to: float):
+        assert intensity_from <= intensity_to, "'intensity_from' should be smaller than or equal to 'intensity_to'."
+        self.intensity_from = intensity_from
+        self.intensity_to = intensity_to
+
+    def _create_condition(self, spectrum: SpectrumType):
+        return np.logical_and(
+            self.intensity_from <= spectrum.peaks.intensities,
+            spectrum.peaks.intensities <= self.intensity_to
+        )

--- a/matchms/filtering/filters/select_by_mz.py
+++ b/matchms/filtering/filters/select_by_mz.py
@@ -1,0 +1,16 @@
+import numpy as np
+from matchms.filtering.filters.select_by_template import SelectByTemplate
+from matchms.typing import SpectrumType
+
+
+class SelectByMz(SelectByTemplate):
+    def __init__(self, mz_from: float, mz_to: float):
+        assert mz_from <= mz_to, "'mz_from' should be smaller than or equal to 'mz_to'."
+        self.mz_from = mz_from
+        self.mz_to = mz_to
+
+    def _create_condition(self, spectrum: SpectrumType):
+        return np.logical_and(
+            self.mz_from <= spectrum.peaks.mz,
+            spectrum.peaks.mz <= self.mz_to
+        )

--- a/matchms/filtering/filters/select_by_relative_intensity.py
+++ b/matchms/filtering/filters/select_by_relative_intensity.py
@@ -1,0 +1,23 @@
+import numpy as np
+from matchms.filtering.filters.select_by_template import SelectByTemplate
+from matchms.typing import SpectrumType
+
+
+class SelectByRelativeIntensity(SelectByTemplate):
+    def __init__(self, intensity_from: float, intensity_to: float):
+        assert intensity_from >= 0.0, "'intensity_from' should be larger than or equal to 0."
+        assert intensity_to <= 1.0, "'intensity_to' should be smaller than or equal to 1.0."
+        assert intensity_from <= intensity_to, "'intensity_from' should be smaller than or equal to 'intensity_to'."
+        self.intensity_from = intensity_from
+        self.intensity_to = intensity_to
+
+    def _create_condition(self, spectrum: SpectrumType):
+        if len(spectrum.peaks) > 0:
+            scale_factor = np.max(spectrum.peaks.intensities)
+            normalized_intensities = spectrum.peaks.intensities / scale_factor
+            return np.logical_and(
+                self.intensity_from <= normalized_intensities,
+                normalized_intensities <= self.intensity_to
+            )
+        else:
+            return np.array([], dtype=bool)

--- a/matchms/filtering/filters/select_by_template.py
+++ b/matchms/filtering/filters/select_by_template.py
@@ -1,0 +1,17 @@
+from matchms.Fragments import Fragments
+from matchms.filtering.filters.base_spectrum_filter import BaseSpectrumFilter
+from matchms.typing import SpectrumType
+
+
+class SelectByTemplate(BaseSpectrumFilter):
+    def apply_filter(self, spectrum: SpectrumType) -> SpectrumType:
+        condition = self._create_condition(spectrum)
+        spectrum.peaks = Fragments(
+            mz=spectrum.peaks.mz[condition],
+            intensities=spectrum.peaks.intensities[condition]
+        )
+
+        return spectrum
+
+    def _create_condition(self, spectrum: SpectrumType):
+        raise NotImplementedError("Subclasses must implement _create_condition method.")

--- a/matchms/filtering/metadata_processing/add_compound_name.py
+++ b/matchms/filtering/metadata_processing/add_compound_name.py
@@ -1,5 +1,6 @@
 import logging
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.add_compound_name import AddCompoundName
 
 
 logger = logging.getLogger("matchms")
@@ -7,20 +8,6 @@ logger = logging.getLogger("matchms")
 
 def add_compound_name(spectrum_in: SpectrumType) -> SpectrumType:
     """Add compound_name to correct field: "compound_name" in metadata."""
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    if spectrum.get("compound_name", None) is None:
-        if isinstance(spectrum.get("name", None), str):
-            spectrum.set("compound_name", spectrum.get("name"))
-            return spectrum
-
-        if isinstance(spectrum.get("title", None), str):
-            spectrum.set("compound_name", spectrum.get("title"))
-            return spectrum
-
-        logger.info("No compound name found in metadata.")
-
+    spectrum = AddCompoundName().process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/add_fingerprint.py
+++ b/matchms/filtering/metadata_processing/add_fingerprint.py
@@ -1,8 +1,6 @@
 import logging
-import numpy as np
 from matchms.typing import SpectrumType
-from ...metadata_utils import (derive_fingerprint_from_inchi,
-                               derive_fingerprint_from_smiles)
+from matchms.filtering.filters.add_fingerprint import AddFingerprint
 
 
 logger = logging.getLogger("matchms")
@@ -25,26 +23,6 @@ def add_fingerprint(spectrum_in: SpectrumType, fingerprint_type: str = "daylight
     nbits:
         Dimension or number of bits of generated fingerprint. Default is 2048.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    # First try to get fingerprint from smiles
-    if spectrum.get("smiles", None):
-        fingerprint = derive_fingerprint_from_smiles(spectrum.get("smiles"),
-                                                     fingerprint_type, nbits)
-        if isinstance(fingerprint, np.ndarray) and fingerprint.sum() > 0:
-            spectrum.set("fingerprint", fingerprint)
-            return spectrum
-
-    # Second try to get fingerprint from inchi
-    if spectrum.get("inchi", None):
-        fingerprint = derive_fingerprint_from_inchi(spectrum.get("inchi"),
-                                                    fingerprint_type, nbits)
-        if isinstance(fingerprint, np.ndarray) and fingerprint.sum() > 0:
-            spectrum.set("fingerprint", fingerprint)
-            return spectrum
-
-    logger.info("No fingerprint was added (name: %s).", spectrum.get("compound_name"))
+    spectrum = AddFingerprint(fingerprint_type, nbits).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/add_parent_mass.py
+++ b/matchms/filtering/metadata_processing/add_parent_mass.py
@@ -1,17 +1,5 @@
-import logging
-from matchms.filtering.filter_utils.derive_precursor_mz_and_parent_mass import \
-    derive_parent_mass_from_precursor_mz
 from matchms.typing import SpectrumType
-from ...utils import get_first_common_element
-
-
-logger = logging.getLogger("matchms")
-
-
-_default_key = "parent_mass"
-_accepted_keys = ["parentmass", "exact_mass"]
-_accepted_types = (float, str, int)
-_accepted_missing_entries = ["", "N/A", "NA", "n/a"]
+from matchms.filtering.filters.add_parent_mass import AddParentMass
 
 
 def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True,
@@ -36,48 +24,6 @@ def add_parent_mass(spectrum_in: SpectrumType, estimate_from_adduct: bool = True
     overwrite_existing_entry
         Default is False. If set to True, a newly computed value will replace existing ones.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    parent_mass = _get_parent_mass(spectrum.metadata)
-    if parent_mass is not None and not overwrite_existing_entry:
-        spectrum.set("parent_mass", parent_mass)
-        return spectrum
-
-    parent_mass = derive_parent_mass_from_precursor_mz(spectrum, estimate_from_adduct)
-
-    if parent_mass is None:
-        logger.warning("Not sufficient spectrum metadata to derive parent mass.")
-    else:
-        spectrum.set("parent_mass", float(parent_mass))
+    spectrum = AddParentMass(estimate_from_adduct, overwrite_existing_entry).process(spectrum_in)
     return spectrum
-
-
-def _get_parent_mass(metadata):
-    parent_mass_key = get_first_common_element([_default_key] + _accepted_keys,
-                                               metadata.keys())
-    parent_mass = metadata.get(parent_mass_key)
-    parent_mass = _convert_entry_to_num(parent_mass)
-    if parent_mass not in _accepted_missing_entries:
-        return parent_mass
-    return None
-
-
-def _convert_entry_to_num(entry):
-    """Convert precursor_mz to number if possible. Otherwise return None."""
-    if entry is None:
-        return None
-    if isinstance(entry, str) and entry in _accepted_missing_entries:
-        return None
-    if not isinstance(entry, _accepted_types):
-        logger.warning("Found parent_mass of undefined type.")
-        return None
-    if isinstance(entry, str):
-        try:
-            return float(entry.strip())
-        except ValueError:
-            logger.warning("%s can't be converted to float.", entry)
-            return None
-    return entry

--- a/matchms/filtering/metadata_processing/add_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/add_precursor_mz.py
@@ -1,15 +1,4 @@
-import logging
-from matchms.utils import get_first_common_element
-
-
-logger = logging.getLogger("matchms")
-
-
-_default_key = "precursor_mz"
-_accepted_keys = ["precursormz", "precursor_mass"]
-_accepted_types = (float, str, int)
-_accepted_missing_entries = ["", "N/A", "NA", "n/a"]
-
+from matchms.filtering.filters.add_precursor_mz import AddPrecursorMz
 
 def add_precursor_mz(spectrum_in):
     """Add precursor_mz to correct field and make it a float.
@@ -17,52 +6,6 @@ def add_precursor_mz(spectrum_in):
     For missing precursor_mz field: check if there is "pepmass"" entry instead.
     For string parsed as precursor_mz: convert to float.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    metadata_updated = _add_precursor_mz_metadata(spectrum.metadata)
-    spectrum.metadata = metadata_updated
+    spectrum = AddPrecursorMz().process(spectrum_in)
     return spectrum
-
-
-def _convert_precursor_mz(precursor_mz):
-    """Convert precursor_mz to number if possible. Otherwise return None."""
-    if precursor_mz is None:
-        return None
-    if isinstance(precursor_mz, str) and precursor_mz in _accepted_missing_entries:
-        return None
-    if not isinstance(precursor_mz, _accepted_types):
-        logger.warning("Found precursor_mz of undefined type.")
-        return None
-    if isinstance(precursor_mz, str):
-        try:
-            return float(precursor_mz.strip())
-        except ValueError:
-            logger.warning("%s can't be converted to float.", precursor_mz)
-            return None
-    return precursor_mz
-
-
-def _add_precursor_mz_metadata(metadata):
-    precursor_mz_key = get_first_common_element([_default_key] + _accepted_keys,
-                                                metadata.keys())
-    precursor_mz = metadata.get(precursor_mz_key)
-    precursor_mz = _convert_precursor_mz(precursor_mz)
-    if isinstance(precursor_mz, (float, int)):
-        metadata["precursor_mz"] = float(precursor_mz)
-        for key in _accepted_keys:
-            metadata.pop(key, None)
-        return metadata
-
-    pepmass = metadata.get("pepmass", None)
-    if pepmass is not None and _convert_precursor_mz(pepmass[0]) is not None:
-        metadata["precursor_mz"] = pepmass[0]
-        logger.warning("Added precursor_mz entry based on field 'pepmass'."
-                       "Consider running 'interpret_pepmass() filter first.")
-        return metadata
-
-    logger.warning("No precursor_mz found in metadata.")
-    metadata.pop("precursor_mz", None)
-    return metadata

--- a/matchms/filtering/metadata_processing/clean_adduct.py
+++ b/matchms/filtering/metadata_processing/clean_adduct.py
@@ -1,10 +1,4 @@
-import logging
-import re
-from matchms.filtering.filter_utils.load_known_adducts import \
-    load_known_adduct_conversions
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.clean_adduct import CleanAdduct
 
 
 def clean_adduct(spectrum_in):
@@ -16,61 +10,6 @@ def clean_adduct(spectrum_in):
     spectrum_in
         Matchms Spectrum object.
     """
-    if spectrum_in is None:
-        return None
-    spectrum = spectrum_in.clone()
-    adduct = spectrum.get("adduct")
 
-    cleaned_adduct = _clean_adduct(adduct)
-    if adduct != cleaned_adduct:
-        spectrum.set("adduct", cleaned_adduct)
-        logger.info("The adduct %d was set to %s", adduct, cleaned_adduct)
+    spectrum = CleanAdduct().process(spectrum_in)
     return spectrum
-
-
-def _clean_adduct(adduct: str) -> str:
-    """Clean adduct and make it consistent in style.
-    Will transform adduct strings of type 'M+H+' to '[M+H]+'.
-
-    Parameters
-    ----------
-    adduct
-        Input adduct string to be cleaned/edited.
-    """
-    def _get_adduct_charge(adduct):
-        regex_charges = r"[1-3]{0,1}[+-]{1,2}$"
-        match = re.search(regex_charges, adduct)
-        if match:
-            return match.group(0)
-        return match
-
-    def _adduct_conversion(adduct):
-        """Convert adduct if conversion rule is known"""
-        adduct_conversions = load_known_adduct_conversions()
-        if adduct in adduct_conversions:
-            return adduct_conversions[adduct]
-        return adduct
-
-    if not isinstance(adduct, str):
-        return adduct
-
-    adduct = adduct.strip().replace("\n", "").replace("*", "")
-    adduct = adduct.replace("++", "2+").replace("--", "2-")
-    if adduct.startswith("["):
-        return _adduct_conversion(adduct)
-
-    if adduct.endswith("]"):
-        return _adduct_conversion("[" + adduct)
-
-    adduct_core = "[" + adduct
-    # Remove parts that can confuse the charge extraction
-    for mol_part in ["CH2", "CH3", "NH3", "NH4", "O2"]:
-        if mol_part in adduct:
-            adduct = adduct.split(mol_part)[-1]
-    adduct_charge = _get_adduct_charge(adduct)
-
-    if adduct_charge is None:
-        return _adduct_conversion(adduct_core + "]")
-
-    adduct_cleaned = adduct_core[:-len(adduct_charge)] + "]" + adduct_charge
-    return _adduct_conversion(adduct_cleaned)

--- a/matchms/filtering/metadata_processing/clean_compound_name.py
+++ b/matchms/filtering/metadata_processing/clean_compound_name.py
@@ -1,9 +1,5 @@
-import logging
-import re
 from matchms.typing import SpectrumType
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.clean_compound_name import CleanCompoundName
 
 
 def clean_compound_name(spectrum_in: SpectrumType) -> SpectrumType:
@@ -12,71 +8,6 @@ def clean_compound_name(spectrum_in: SpectrumType) -> SpectrumType:
     A list of frequently seen name additions that do not belong to the compound
     name will be removed.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    if spectrum.get("compound_name", None) is not None:
-        name = spectrum.get("compound_name")
-    else:
-        assert spectrum.get("name", None) in [None, ""], ("Found 'name' but not 'compound_name' in metadata",
-                                                          "Apply 'add_compound_name' filter first.")
-        return spectrum
-
-    # Clean compound name
-    name_cleaned = _remove_parts_by_regular_expression(name)
-    name_cleaned = _remove_known_non_compound_parts(name_cleaned)
-    name_cleaned = _remove_misplaced_mass(name_cleaned)
-    if name_cleaned != name:
-        spectrum.set("compound_name", name_cleaned)
-        logger.info("Added cleaned compound name: %s", name_cleaned)
-
+    spectrum = CleanCompoundName().process(spectrum_in)
     return spectrum
-
-
-def _remove_parts_by_regular_expression(name: str):
-    """Clean name string by removing known parts that don't belong there."""
-    name = name.strip()
-    # remove type NCGC00180417-03_C31H40O16_
-    name = re.split(r"[A-Z]{3,6}[0-9]{8,12}-[0-9]{2,5}_[A-Z,0-9]{4,15}_", name)[-1]
-    # remove type NCGC00160232-01! or MLS001142816-01!
-    name = re.split(r"[A-Z]{3,6}[0-9]{8,12}-[0-9]{2,3}\!", name)[-1]
-    # remove type Massbank:EA008813 option1|option2|option3
-    name = re.split(r"((Massbank:)|(MassbankEU:))[A-Z]{2}[0-9]{5,6}.*\|", name)[-1]
-    # remove type Massbank:EA008813 or MassbankEU:EA008813
-    name = re.split(r"((Massbank:)|(MassbankEU:))[A-Z]{2}[0-9]{5,6}", name)[-1]
-    # remove type HMDB:HMDB00943-1336
-    name = re.split(r"HMDB:HMDB[0-9]{4,7}-[0-9]{1,7}", name)[-1]
-    # remove type MoNA:662599
-    name = re.split(r"MoNA:[0-9]{5,10}", name)[-1]
-    # ReSpect:PS013405 option1|option2|option3...
-    name = re.split(r"ReSpect:[A-Z]{2,3}[0-9]{6}.*\|", name)[-1]
-    # ReSpect:PS013405 option1
-    name = re.split(r"[A-Z]{2,3}[0-9]{6}( )", name)[-1]
-    # remove type 0072_2-Mercaptobenzothiaz
-    name = re.split(r"^[0-9]{4}_", name)[-1]
-    # remove type nameofcompound_CID20_170920 or Spiraeoside_HCD30_170919
-    name = re.split(r"_((HCD)|(CID))[0-9]{2}_[0-9]{5,6}$", name)[0]
-    # Removes the collision energy from the compound name. Also allows for occurances of - 40.0 eV Unknown
-    name = re.split(r"(?: - )?[0-9]+(?:\.[0-9]+)? ?[eE][Vv](?: Unknown)?$", name)[0]
-    return name
-
-
-def _remove_known_non_compound_parts(name: str):
-    """Remove known non compound-name strings from name."""
-    parts_remove = ["Spectral Match to",
-                    "from NIST14",
-                    "Massbank:"]
-    for part in parts_remove:
-        name = name.replace(part, "")
-    return name.strip("; ")
-
-
-def _remove_misplaced_mass(name: str):
-    """Remove occasionally occurring parent mass addition to name."""
-    regex_mass = r"^[0-9]{2,4}\.[0-9]$"
-    end_part = name.split(" ")[-1]
-    if re.search(regex_mass, end_part) is not None:
-        return name.replace(end_part, "").strip()
-    return name

--- a/matchms/filtering/metadata_processing/correct_charge.py
+++ b/matchms/filtering/metadata_processing/correct_charge.py
@@ -1,9 +1,5 @@
-import logging
-import numpy as np
 from matchms.typing import SpectrumType
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.correct_charge import CorrectCharge
 
 
 def correct_charge(spectrum_in: SpectrumType) -> SpectrumType:
@@ -18,38 +14,5 @@ def correct_charge(spectrum_in: SpectrumType) -> SpectrumType:
         Input spectrum.
     """
 
-    if spectrum_in is None:
-        return None
-
-    spectrum = spectrum_in.clone()
-
-    ionmode = spectrum.get("ionmode", None)
-    if ionmode:
-        assert ionmode == ionmode.lower(), ("Ionmode field not harmonized.",
-                                            "Apply 'make_ionmode_lowercase' filter first.")
-
-    charge = spectrum.get("charge", None)
-    assert not isinstance(charge, str), ("Charge is given as string.",
-                                         "Apply 'make_charge_int' filter first.")
-
-    if charge is None:
-        charge = 0
-
-    if charge == 0 and ionmode == 'positive':
-        charge = 1
-        logger.info("Guessed charge to 1 based on positive ionmode")
-    elif charge == 0 and ionmode == 'negative':
-        charge = -1
-        logger.info("Guessed charge to -1 based on negative ionmode")
-
-    # Correct charge when in conflict with ionmode (trust ionmode more!)
-    if np.sign(charge) == 1 and ionmode == 'negative':
-        charge *= -1
-        logger.warning("Changed sign of given charge to match negative ionmode")
-    elif np.sign(charge) == -1 and ionmode == 'positive':
-        charge *= -1
-        logger.warning("Changed sign of given charge to match positive ionmode")
-
-    spectrum.set("charge", charge)
-
+    spectrum = CorrectCharge().process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -1,11 +1,5 @@
-import logging
-import re
 from matchms.typing import SpectrumType
-from ..filter_utils.load_known_adducts import load_known_adducts
-from .clean_adduct import _clean_adduct
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.derive_adduct_from_name import DeriveAdductFromName
 
 
 def derive_adduct_from_name(spectrum_in: SpectrumType,
@@ -21,52 +15,6 @@ def derive_adduct_from_name(spectrum_in: SpectrumType,
     remove_adduct_from_name:
         Remove found adducts from compound name if set to True. Default is True.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    if spectrum.get("compound_name", None) is not None:
-        name = spectrum.get("compound_name")
-    else:
-        assert spectrum.get("name", None) in [None, ""], ("Found 'name' but not 'compound_name' in metadata",
-                                                          "Apply 'add_compound_name' filter first.")
-        return spectrum
-
-    # Detect adduct in compound name
-    adduct_from_name = None
-    name_split = name.split(" ")
-    for name_part in name_split[::-1][:2]:
-        if _looks_like_adduct(name_part):
-            adduct_from_name = name_part
-            break
-
-    if adduct_from_name and remove_adduct_from_name:
-        name_adduct_removed = " ".join([x for x in name_split if x != adduct_from_name])
-        name_adduct_removed = name_adduct_removed.strip("; ")
-        spectrum.set("compound_name", name_adduct_removed)
-        logger.info("Removed adduct %s from compound name.", adduct_from_name)
-
-    # Add found adduct to metadata (if not present yet)
-    if adduct_from_name and not _looks_like_adduct(spectrum.get("adduct")):
-        adduct_cleaned = _clean_adduct(adduct_from_name)
-        spectrum.set("adduct", adduct_cleaned)
-        logger.info("Added adduct %s from the compound name to metadata.", spectrum.get('adduct'))
-
+    spectrum = DeriveAdductFromName(remove_adduct_from_name).process(spectrum_in)
     return spectrum
-
-
-def _looks_like_adduct(adduct):
-    """Return True if input string has expected format of an adduct."""
-    if not isinstance(adduct, str):
-        return False
-    # Clean adduct
-    adduct = _clean_adduct(adduct)
-    # Load lists of default known adducts
-    known_adducts = load_known_adducts()
-    if adduct in list(known_adducts["adduct"]):
-        return True
-
-    # Expect format like: "[2M-H]" or "[2M+Na]+"
-    regexp1 = r"^\[(([0-4]M)|(M[0-9])|(M))((Br)|(Br81)|(Cl)|(Cl37)|(S)){0,}[+-][A-Z0-9\+\-\(\)aglire]{1,}[\]0-4+-]{1,4}"
-    return re.search(regexp1, adduct) is not None

--- a/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
@@ -1,28 +1,9 @@
-import logging
 from matchms.typing import SpectrumType
-from ...metadata_utils import (convert_smiles_to_inchi, is_valid_inchi,
-                               is_valid_smiles)
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.derive_inchi_from_smiles import DeriveInchiFromSmiles
 
 
 def derive_inchi_from_smiles(spectrum_in: SpectrumType) -> SpectrumType:
     """Find missing Inchi and derive from smiles where possible."""
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-    inchi = spectrum.get("inchi")
-    smiles = spectrum.get("smiles")
-
-    if not is_valid_inchi(inchi) and is_valid_smiles(smiles):
-        inchi = convert_smiles_to_inchi(smiles)
-        if inchi:
-            inchi = inchi.rstrip()
-            spectrum.set("inchi", inchi)
-            logger.info("Added InChI (%s) to metadata (was converted from smiles).", inchi)
-        else:
-            logger.warning("Could not convert smiles %s to InChI.", smiles)
-
+    spectrum = DeriveInchiFromSmiles().process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
@@ -1,27 +1,9 @@
-import logging
 from matchms.typing import SpectrumType
-from ...metadata_utils import (convert_inchi_to_inchikey, is_valid_inchi,
-                               is_valid_inchikey)
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.derive_inchikey_from_inchi import DeriveInchikeyFromInchi
 
 
 def derive_inchikey_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
     """Find missing InchiKey and derive from Inchi where possible."""
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-    inchi = spectrum.get("inchi")
-    inchikey = spectrum.get("inchikey")
-
-    if is_valid_inchi(inchi) and not is_valid_inchikey(inchikey):
-        inchikey = convert_inchi_to_inchikey(inchi)
-        if inchikey:
-            spectrum.set("inchikey", inchikey)
-            logger.info("Added InChIKey %s to metadata (was converted from inchi)", inchikey)
-        else:
-            logger.warning("Could not convert InChI %s to inchikey.", inchi)
-
+    spectrum = DeriveInchikeyFromInchi().process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -1,10 +1,5 @@
-import logging
 from matchms.typing import SpectrumType
-from ..filter_utils.load_known_adducts import load_known_adducts
-from .clean_adduct import _clean_adduct
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.derive_ionmode import DeriveIonmode
 
 
 def derive_ionmode(spectrum_in: SpectrumType) -> SpectrumType:
@@ -24,32 +19,5 @@ def derive_ionmode(spectrum_in: SpectrumType) -> SpectrumType:
     Spectrum object with `ionmode` attribute set.
     """
 
-    if spectrum_in is None:
-        return None
-
-    spectrum = spectrum_in.clone()
-
-    # Load lists of known adducts
-    known_adducts = load_known_adducts()
-
-    adduct = spectrum.get("adduct", None)
-    # Harmonize adduct string
-    if adduct:
-        adduct = _clean_adduct(adduct)
-
-    ionmode = spectrum.get("ionmode")
-    if ionmode:
-        assert ionmode == ionmode.lower(), ("Ionmode field not harmonized.",
-                                            "Apply 'make_ionmode_lowercase' filter first.")
-    if ionmode in ["positive", "negative"]:
-        return spectrum
-    # Try completing missing or incorrect ionmodes
-    if adduct in list(known_adducts["adduct"]):
-        ionmode = known_adducts.loc[known_adducts["adduct"] == adduct, "ionmode"].values[0]
-    else:
-        ionmode = "n/a"
-
-    spectrum.set("ionmode", ionmode)
-    logger.info("Set ionmode to %s.", ionmode)
-
+    spectrum = DeriveIonmode().process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
@@ -1,28 +1,9 @@
-import logging
 from matchms.typing import SpectrumType
-from ...metadata_utils import (convert_inchi_to_smiles, is_valid_inchi,
-                               is_valid_smiles)
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.derive_smiles_from_inchi import DeriveSmilesFromInchi
 
 
 def derive_smiles_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
     """Find missing smiles and derive from Inchi where possible."""
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-    inchi = spectrum.get("inchi")
-    smiles = spectrum.get("smiles")
-
-    if not is_valid_smiles(smiles) and is_valid_inchi(inchi):
-        smiles = convert_inchi_to_smiles(inchi)
-        if smiles:
-            smiles = smiles.rstrip()
-            spectrum.set("smiles", smiles)
-            logger.info("Added smiles %s to metadata (was converted from InChI)", smiles)
-        else:
-            logger.warning("Could not convert InChI %s to smiles.", inchi)
-
+    spectrum = DeriveSmilesFromInchi().process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
@@ -1,5 +1,6 @@
 from typing import List
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.harmonize_undefined_inchi import HarmonizeUndefinedInchi
 
 
 def harmonize_undefined_inchi(spectrum_in: SpectrumType, undefined: str = "",
@@ -14,27 +15,6 @@ def harmonize_undefined_inchi(spectrum_in: SpectrumType, undefined: str = "",
         Enter list of strings that are expected to represent undefined entries.
         Default is ["", "N/A", "NA", "n/a"].
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    if aliases is None:
-        aliases = [
-            "",
-            "N/A",
-            "NA",
-            "n/a"
-        ]
-
-    inchi = spectrum.get("inchi")
-    if inchi is None:
-        # spectrum does not have an "inchi" key in its metadata
-        spectrum.set("inchi", undefined)
-        return spectrum
-
-    if inchi in aliases:
-        # harmonize aliases for undefined values
-        spectrum.set("inchi", undefined)
-
+    spectrum = HarmonizeUndefinedInchi(undefined, aliases).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
@@ -1,5 +1,6 @@
 from typing import List
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.harmonize_undefined_inchikey import HarmonizeUndefinedInchikey
 
 
 def harmonize_undefined_inchikey(spectrum_in: SpectrumType, undefined: str = "",
@@ -14,28 +15,6 @@ def harmonize_undefined_inchikey(spectrum_in: SpectrumType, undefined: str = "",
         Enter list of strings that are expected to represent undefined entries.
         Default is ["", "N/A", "NA", "n/a", "no data"].
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    if aliases is None:
-        aliases = [
-            "",
-            "N/A",
-            "NA",
-            "n/a",
-            "no data"
-        ]
-
-    inchikey = spectrum.get("inchikey")
-    if inchikey is None:
-        # spectrum does not have an "inchikey" key in its metadata
-        spectrum.set("inchikey", undefined)
-        return spectrum
-
-    if inchikey in aliases:
-        # harmonize aliases for undefined values
-        spectrum.set("inchikey", undefined)
-
+    spectrum = HarmonizeUndefinedInchikey(undefined, aliases).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
@@ -1,5 +1,6 @@
 from typing import List
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.harmonize_undefined_smiles import HarmonizeUndefinedSmiles
 
 
 def harmonize_undefined_smiles(spectrum_in: SpectrumType, undefined: str = "",
@@ -14,28 +15,6 @@ def harmonize_undefined_smiles(spectrum_in: SpectrumType, undefined: str = "",
         Enter list of strings that are expected to represent undefined entries.
         Default is ["", "N/A", "NA", "n/a", "no data"].
     """
-    if spectrum_in is None:
-        return None
-
-    spectrum = spectrum_in.clone()
-
-    if aliases is None:
-        aliases = [
-            "",
-            "N/A",
-            "NA",
-            "n/a",
-            "no data"
-        ]
-
-    smiles = spectrum.get("smiles")
-    if smiles is None:
-        # spectrum does not have a "smiles" key in its metadata
-        spectrum.set("smiles", undefined)
-        return spectrum
-
-    if smiles in aliases:
-        # harmonize aliases for undefined values
-        spectrum.set("smiles", undefined)
-
+    
+    spectrum = HarmonizeUndefinedSmiles(undefined, aliases).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -1,11 +1,4 @@
-import logging
-import numpy as np
-from .make_charge_int import _convert_charge_to_int
-
-
-logger = logging.getLogger("matchms")
-_accepted_types = (float, str, int)
-_accepted_missing_entries = ["", "N/A", "NA", "n/a"]
+from matchms.filtering.filters.interpret_pepmass import InterpretPepmass
 
 
 def interpret_pepmass(spectrum_in):
@@ -16,90 +9,6 @@ def interpret_pepmass(spectrum_in):
     will be splitted (if present) added to the fields "precursor_mz",
     "precursor_intensity", and "charge".
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    metadata_updated = _interpret_pepmass_metadata(spectrum.metadata)
-    spectrum.metadata = metadata_updated
+    spectrum = InterpretPepmass().process(spectrum_in)
     return spectrum
-
-
-def _interpret_pepmass_metadata(metadata):
-    pepmass = metadata.get("pepmass")
-    if pepmass is None:
-        return metadata
-
-    mz, intensity, charge = _get_mz_intensity_charge(pepmass)
-    mz = _convert_mz_or_intensity(mz)
-    intensity = _convert_mz_or_intensity(intensity)
-    charge = _convert_charge_to_int(charge)
-
-    if mz is not None:
-        if metadata.get("precursor_mz") is not None\
-            and _substantial_difference(metadata.get("precursor_mz"), mz, atol=0.001):
-            logger.warning("Overwriting existing precursor_mz %s with new one: %s",
-                           metadata.get("precursor_mz"), str(mz))
-        metadata["precursor_mz"] = mz
-        logger.info("Added precursor_mz entry based on field 'pepmass'.")
-
-    if intensity is not None:
-        if metadata.get("precursor_intensity") is not None:
-            logger.warning("Overwriting existing precursor_intensity %s with new one: %s",
-                           metadata.get("precursor_intensity"), str(intensity))
-        metadata["precursor_intensity"] = intensity
-        logger.info("Added precursor_intensity entry based on field 'pepmass'.")
-
-    if charge is not None:
-        if metadata.get("charge") is not None:
-            logger.warning("Overwriting existing charge %s with new one: %s",
-                           metadata.get("charge"), str(charge))
-        metadata["charge"] = charge
-        logger.info("Added charge entry based on field 'pepmass'.")
-
-    return metadata
-
-
-def _get_mz_intensity_charge(pepmass):
-    try:
-        length = len(pepmass)
-        values = [None, None, None]
-        for i in range(length):
-            values[i] = pepmass[i]
-        return values[0], values[1], values[2]
-    except TypeError:
-        if pepmass is not None:
-            return pepmass, None, None
-        return None, None, None
-
-
-def _convert_mz_or_intensity(entry):
-    """Convert mz or intensity to number if possible. Otherwise return None."""
-    if entry is None:
-        return None
-    if isinstance(entry, str) and entry in _accepted_missing_entries:
-        return None
-    if not isinstance(entry, _accepted_types):
-        logger.warning("Found undefined type.")
-        return None
-    if isinstance(entry, str):
-        try:
-            return float(entry.strip())
-        except ValueError:
-            logger.warning("%s can't be converted to float.", entry)
-            return None
-    return entry
-
-
-def _substantial_difference(mz_now, mz_new, atol=0.001):
-    """Returns True if mz_now and mz_new differ by more than atol."""
-    if mz_now is None:
-        return True
-    try:
-        mz_now_float = float(mz_now)
-    except ValueError:
-        return True
-    if np.abs(mz_now_float - mz_new) > atol:
-        return True
-    return False

--- a/matchms/filtering/metadata_processing/make_charge_int.py
+++ b/matchms/filtering/metadata_processing/make_charge_int.py
@@ -1,48 +1,9 @@
-import logging
 from matchms.typing import SpectrumType
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.make_charge_int import MakeChargeInt
 
 
 def make_charge_int(spectrum_in: SpectrumType) -> SpectrumType:
     """Convert charge field to integer (if possible)."""
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    charge = spectrum.get("charge", None)
-    charge_int = _convert_charge_to_int(charge)
-    if isinstance(charge_int, int):
-        spectrum.set("charge", charge_int)
-
+    spectrum = MakeChargeInt().process(spectrum_in)
     return spectrum
-
-
-def _convert_charge_to_int(charge):
-    """Convert charge to integer if possible, else return None."""
-    def _try_conversion(charge):
-        try:
-            return int(charge)
-        except ValueError:
-            logger.warning("Found charge (%s) cannot be converted to integer.",
-                           str(charge))
-            return None
-
-    if charge is None:
-        return None
-
-    if isinstance(charge, int):
-        return charge
-
-    # Avoid pyteomics ChargeList
-    if isinstance(charge, list):
-        return _try_conversion(charge[0])
-
-    # convert string charges to int
-    if isinstance(charge, str):
-        charge = charge.strip().replace("+", "")
-        if len(charge) > 1 and charge[-1] == "-":
-            charge = "-" + charge.replace("-", "")
-        return _try_conversion(charge)

--- a/matchms/filtering/metadata_processing/repair_adduct_based_on_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_based_on_smiles.py
@@ -1,12 +1,5 @@
-import logging
 from matchms import Spectrum
-from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
-    get_monoisotopic_neutral_mass
-from ..filter_utils.load_known_adducts import load_known_adducts
-from .repair_parent_mass_is_mol_wt import repair_parent_mass_is_mol_wt
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.repair_adduct_based_on_smiles import RepairAdductBasedOnSmiles
 
 
 def repair_adduct_based_on_smiles(spectrum_in: Spectrum,
@@ -14,40 +7,6 @@ def repair_adduct_based_on_smiles(spectrum_in: Spectrum,
                                   accept_parent_mass_is_mol_wt):
     """If the parent mass is wrong due to a wrong of is derived from the precursor mz
     To do this the charge and adduct are used"""
-    if spectrum_in is None:
-        return None
-    changed_spectrum = spectrum_in.clone()
 
-    precursor_mz = changed_spectrum.get("precursor_mz")
-    ion_mode = changed_spectrum.get("ionmode")
-    if ion_mode not in ("positive", "negative"):
-        logger.warning("Ionmode: %s not positive or negative, first run derive_ionmode",
-                        ion_mode)
-        return changed_spectrum
-    if precursor_mz is None:
-        logger.warning("Precursor_mz is None, first run add_precursor_mz")
-        return changed_spectrum
-
-    adducts_df = load_known_adducts()
-    smiles_mass = get_monoisotopic_neutral_mass(changed_spectrum.get("smiles"))
-    parent_masses = (precursor_mz - adducts_df["correction_mass"]) / adducts_df["mass_multiplier"]
-    mass_differences = abs(parent_masses-smiles_mass)
-
-    # Select the lowest value
-    smalles_mass_index = mass_differences.idxmin()
-    parent_mass = parent_masses[smalles_mass_index]
-    adduct = adducts_df.iloc[smalles_mass_index]["adduct"]
-    # Change spectrum. This spectrum will only be returned if the mass difference is smaller than mass tolerance
-    changed_spectrum.set("parent_mass", parent_mass)
-    changed_spectrum.set("adduct", adduct)
-    if mass_differences[smalles_mass_index] < mass_tolerance:
-        logger.info("Adduct was set from %s to %s",
-                    spectrum_in.get('adduct'), adduct)
-        return changed_spectrum
-    if accept_parent_mass_is_mol_wt:
-        changed_spectrum = repair_parent_mass_is_mol_wt(changed_spectrum, mass_tolerance)
-        if abs(changed_spectrum.get("parent_mass") - smiles_mass) < mass_tolerance:
-            logger.info("Adduct was set from %s to %s",
-                        spectrum_in.get('adduct'), adduct)
-            return changed_spectrum
-    return spectrum_in
+    spectrum = RepairAdductBasedOnSmiles(mass_tolerance, accept_parent_mass_is_mol_wt).process(spectrum_in)
+    return spectrum

--- a/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
@@ -1,5 +1,5 @@
-from matchms.filtering.SpeciesString import SpeciesString
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.repair_inchi_inchikey_smiles import RepairInchiInchikeySmiles
 
 
 def repair_inchi_inchikey_smiles(spectrum_in: SpectrumType) -> SpectrumType:
@@ -7,26 +7,6 @@ def repair_inchi_inchikey_smiles(spectrum_in: SpectrumType) -> SpectrumType:
     if any of those entries clearly belongs into one of the other two fields (e.g.
     inchikey found in inchi field).
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    # interpret available data and clean each
-    inchi = spectrum.get("inchi", "")
-    inchiaux = spectrum.get("inchiaux", "")
-    inchikey = spectrum.get("inchikey", "")
-    smiles = spectrum.get("smiles", "")
-
-    cleaneds = [SpeciesString(s) for s in [inchi, inchiaux, inchikey, smiles]]
-
-    # for each type, list what we have and pick one
-    inchis = [c.cleaned for c in cleaneds if c.target == "inchi" and c.cleaned != ""]
-    inchikeys = [c.cleaned for c in cleaneds if c.target == "inchikey" and c.cleaned != ""]
-    smiles = [c.cleaned for c in cleaneds if c.target == "smiles" and c.cleaned != ""]
-
-    spectrum.set("inchi", inchis[0] if len(inchis) > 0 else "")
-    spectrum.set("inchikey", inchikeys[0] if len(inchikeys) > 0 else "")
-    spectrum.set("smiles", smiles[0] if len(smiles) > 0 else "")
-
+    spectrum = RepairInchiInchikeySmiles().process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/repair_parent_mass_is_mol_wt.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_is_mol_wt.py
@@ -1,13 +1,5 @@
-import logging
 from matchms import Spectrum
-from matchms.filtering.filter_utils.derive_precursor_mz_and_parent_mass import \
-    derive_precursor_mz_from_parent_mass
-from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import (
-    get_molecular_weight_neutral_mass, get_monoisotopic_neutral_mass)
-from .require_parent_mass_match_smiles import require_parent_mass_match_smiles
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.repair_parent_mass_is_mol_wt import RepairParentMassIsMolWt
 
 
 def repair_parent_mass_is_mol_wt(spectrum_in: Spectrum, mass_tolerance: float):
@@ -15,26 +7,6 @@ def repair_parent_mass_is_mol_wt(spectrum_in: Spectrum, mass_tolerance: float):
 
     Manual entered precursor mz is sometimes wrongly added as Molar weight instead of monoisotopic mass
     """
-    if spectrum_in is None:
-        return None
-    spectrum = spectrum_in.clone()
-    # Check if parent mass already matches smiles
-    if require_parent_mass_match_smiles(spectrum, mass_tolerance) is not None:
-        return spectrum
-    # Check if the precursor_mz can be calculated from the parent mass. If not skip this function
-    if abs(spectrum.get("precursor_mz") - derive_precursor_mz_from_parent_mass(spectrum)) > mass_tolerance:
-        return spectrum
-    # Check if parent mass matches the smiles mass
-    parent_mass = spectrum.get("parent_mass")
-    smiles = spectrum.get("smiles")
-    smiles_mass = get_molecular_weight_neutral_mass(smiles)
-    mass_difference = parent_mass - smiles_mass
-    if abs(mass_difference) < mass_tolerance:
-        correct_mass = get_monoisotopic_neutral_mass(smiles)
-        spectrum.set("parent_mass", correct_mass)
-        logger.info("Parent mass was mol_wt corrected from %s to %s",
-                    parent_mass, correct_mass)
-        precursor_mz = derive_precursor_mz_from_parent_mass(spectrum)
-        logger.info("Precursor mz was derived from parent mass")
-        spectrum.set("precursor_mz", precursor_mz)
+
+    spectrum = RepairParentMassIsMolWt(mass_tolerance).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/repair_parent_mass_match_smiles_wrapper.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_match_smiles_wrapper.py
@@ -1,39 +1,10 @@
-import logging
 from typing import Optional
-from matchms.filtering.metadata_processing.repair_adduct_based_on_smiles import \
-    repair_adduct_based_on_smiles
 from matchms.typing import SpectrumType
-from .repair_parent_mass_is_mol_wt import repair_parent_mass_is_mol_wt
-from .repair_precursor_is_parent_mass import repair_precursor_is_parent_mass
-from .repair_smiles_of_salts import repair_smiles_of_salts
-from .require_parent_mass_match_smiles import require_parent_mass_match_smiles
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.repair_parent_mass_match_smiles_wrapper import RepairParentMassMatchSmilesWrapper
 
 
 def repair_parent_mass_match_smiles_wrapper(spectrum_in: SpectrumType, mass_tolerance: float = 0.2) -> Optional[SpectrumType]:
     """Wrapper function for repairing a mismatch between parent mass and smiles mass"""
-    if spectrum_in is None:
-        return None
-    spectrum = spectrum_in.clone()
 
-    if require_parent_mass_match_smiles(spectrum, mass_tolerance) is not None:
-        return spectrum
-
-    spectrum = repair_smiles_of_salts(spectrum, mass_tolerance)
-    if require_parent_mass_match_smiles(spectrum, mass_tolerance) is not None:
-        return spectrum
-
-    spectrum = repair_precursor_is_parent_mass(spectrum, mass_tolerance)
-    if require_parent_mass_match_smiles(spectrum, mass_tolerance) is not None:
-        return spectrum
-
-    spectrum = repair_parent_mass_is_mol_wt(spectrum, mass_tolerance)
-    if require_parent_mass_match_smiles(spectrum, mass_tolerance) is not None:
-        return spectrum
-
-    spectrum = repair_adduct_based_on_smiles(spectrum, mass_tolerance, accept_parent_mass_is_mol_wt=True)
-    if require_parent_mass_match_smiles(spectrum, mass_tolerance) is not None:
-        return spectrum
-    return None
+    spectrum = RepairParentMassMatchSmilesWrapper(mass_tolerance).process(spectrum_in)
+    return spectrum

--- a/matchms/filtering/metadata_processing/repair_precursor_is_parent_mass.py
+++ b/matchms/filtering/metadata_processing/repair_precursor_is_parent_mass.py
@@ -1,40 +1,10 @@
-import logging
 from matchms import Spectrum
-from matchms.filtering.filter_utils.derive_precursor_mz_and_parent_mass import \
-    derive_precursor_mz_from_parent_mass
-from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
-    get_monoisotopic_neutral_mass
-from .require_parent_mass_match_smiles import require_parent_mass_match_smiles
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.repair_precursor_is_parent_mass import RepairPrecursorIsParentMass
 
 
 def repair_precursor_is_parent_mass(spectrum_in: Spectrum,
                                     mass_tolerance):
     """Repairs parent mass and precursor mz if the parent mass is entered instead of the precursor_mz"""
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    # Check if parent mass already matches smiles
-    if require_parent_mass_match_smiles(spectrum, mass_tolerance) is not None:
-        return spectrum
-
-    precursor_mz = spectrum.get("precursor_mz")
-    # Check if the precursor_mz can be calculated from the parent mass. If not skip this function
-    if abs(precursor_mz - derive_precursor_mz_from_parent_mass(spectrum)) > mass_tolerance:
-        return spectrum
-
-    smiles = spectrum.get("smiles")
-    smiles_mass = get_monoisotopic_neutral_mass(smiles)
-    mass_difference = precursor_mz - smiles_mass
-    if abs(mass_difference) < mass_tolerance:
-        logger.info("Parent mass was changed from %s to %s", spectrum.get("parent_mass"), smiles_mass)
-        spectrum.set("parent_mass", smiles_mass)
-        new_precursor_mz = derive_precursor_mz_from_parent_mass(spectrum)
-        if new_precursor_mz is not None:
-            logger.info("Parent mass was changed from %s to %s", spectrum.get("precursor_mz"), new_precursor_mz)
-            spectrum.set("precursor_mz", new_precursor_mz)
+    spectrum = RepairPrecursorIsParentMass(mass_tolerance).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/repair_smiles_from_compound_name.py
+++ b/matchms/filtering/metadata_processing/repair_smiles_from_compound_name.py
@@ -1,12 +1,5 @@
-import logging
-import numpy as np
-import pandas as pd
 from matchms import Spectrum
-from matchms.metadata_utils import (is_valid_inchi, is_valid_inchikey,
-                                    is_valid_smiles)
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.repair_smiles_from_compound_name import RepairSmilesFromCompoundName
 
 
 def repair_smiles_from_compound_name(spectrum_in: Spectrum,
@@ -30,52 +23,6 @@ def repair_smiles_from_compound_name(spectrum_in: Spectrum,
     mass_tolerance.
         Acceptable mass difference between query compound and pubchem result.
     """
-    annotated_compound_names = _load_compound_name_annotations(annotated_compound_names_file)
-    if spectrum_in is None:
-        return None
-    spectrum = spectrum_in.clone()
-    if _check_fully_annotated(spectrum):
-        return spectrum
-    compound_name = spectrum.get("compound_name")
-    parent_mass = spectrum.get('parent_mass')
 
-    if _is_plausible_name(compound_name) and parent_mass is not None:
-        matching_compound_name = annotated_compound_names[annotated_compound_names["compound_name"] == compound_name]
-        mass_differences = np.abs(matching_compound_name["monoisotopic_mass"]-parent_mass)
-        within_mass_tolerance = matching_compound_name[mass_differences < mass_tolerance]
-        if within_mass_tolerance.shape[0] > 0:
-            # Select the match with the most
-            best_match = within_mass_tolerance.loc[within_mass_tolerance["monoisotopic_mass"].idxmin()]
-            spectrum.set("smiles", best_match["smiles"])
-            spectrum.set("inchi", best_match["inchi"])
-            spectrum.set("inchikey", best_match["inchikey"])
-            logger.info("Added smiles %s based on the compound name %s", best_match["smiles"], compound_name)
-            return spectrum
+    spectrum = RepairSmilesFromCompoundName(annotated_compound_names_file, mass_tolerance).process(spectrum_in)
     return spectrum
-
-
-def _load_compound_name_annotations(annotated_compound_names_file):
-    """Loads in the annotated compound names and checks format"""
-    annotated_compound_names = pd.read_csv(annotated_compound_names_file)
-    assert list(annotated_compound_names.columns) == ["compound_name", "smiles", "inchi",
-                                                      "inchikey", "monoisotopic_mass"], \
-        "Choose a different annotated compound names file with columns compound_name, smiles, inchi, inchikey, monoisotopic_mass"
-    return annotated_compound_names
-
-
-def _check_fully_annotated(spectrum: Spectrum) -> bool:
-    """Combine multiple check functions.
-    Returns False if SMILES, InChIKey, or InChI are missing.
-    """
-    if not is_valid_smiles(spectrum.get("smiles")):
-        return False
-    if not is_valid_inchikey(spectrum.get("inchikey")):
-        return False
-    if not is_valid_inchi(spectrum.get("inchi")):
-        return False
-    return True
-
-
-def _is_plausible_name(compound_name):
-    """Simple check if it can be a compound name."""
-    return isinstance(compound_name, str) and len(compound_name) > 4

--- a/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
+++ b/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
@@ -1,10 +1,4 @@
-import itertools
-import logging
-from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
-    get_monoisotopic_neutral_mass
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.repair_smiles_of_salts import RepairSmilesOfSalts
 
 
 def repair_smiles_of_salts(spectrum_in,
@@ -12,45 +6,6 @@ def repair_smiles_of_salts(spectrum_in,
     """Repairs the smiles of a salt to match the parent mass.
     E.g. C1=NC2=NC=NC(=C2N1)N.Cl is converted to 1=NC2=NC=NC(=C2N1)N if this matches the parent mass
     Checks if parent mass matches one of the ions"""
-    if spectrum_in is None:
-        return None
-    spectrum = spectrum_in.clone()
 
-    smiles = spectrum.get("smiles")
-    parent_mass = spectrum.get("parent_mass")
-    possible_ion_combinations = _create_possible_ions(smiles)
-    if not possible_ion_combinations:
-        # It is not a salt
-        return spectrum
-    for ion, not_used_ions in possible_ion_combinations:
-        ion_mass = get_monoisotopic_neutral_mass(ion)
-        mass_diff = abs(parent_mass - ion_mass)
-        # Check for Repair parent mass is mol wt did only return 1 spectrum. So not added as option for simplicity.
-        if mass_diff < mass_tolerance:
-            spectrum_with_ions = spectrum.clone()
-            spectrum_with_ions.set("smiles", ion)
-            spectrum_with_ions.set("salt_ions", not_used_ions)
-            logger.info("Removed salt ions: %s from %s to match parent mass",
-                        not_used_ions, smiles)
-            return spectrum_with_ions
-    logger.warning("None of the parts of the smile %s match the parent mass: %s",
-                   smiles, parent_mass)
+    spectrum = RepairSmilesOfSalts(mass_tolerance).process(spectrum_in)
     return spectrum
-
-
-def _create_possible_ions(smiles):
-    """Selects all possible ion combinations of a salt"""
-
-    results = []
-    if "." in smiles:
-        single_ions = smiles.split(".")
-        for r in range(1, len(single_ions) + 1):
-            combinations = itertools.combinations(single_ions, r)
-            for combination in combinations:
-                combined_ion = ".".join(combination)
-                removed_ions = single_ions.copy()
-                for used_ion in combination:
-                    removed_ions.remove(used_ion)
-                removed_ions = ".".join(removed_ions)
-                results.append((combined_ion, removed_ions))
-    return results

--- a/matchms/filtering/metadata_processing/require_correct_ionmode.py
+++ b/matchms/filtering/metadata_processing/require_correct_ionmode.py
@@ -1,9 +1,6 @@
-import logging
 from typing import Optional
 from matchms.typing import SpectrumType
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.require_correct_ionmode import RequireCorrectIonmode
 
 
 def require_correct_ionmode(spectrum_in: SpectrumType,
@@ -27,19 +24,6 @@ def require_correct_ionmode(spectrum_in: SpectrumType,
     Spectrum or None
         The validated spectrum if its ion mode matches the desired one, or `None` otherwise.
     """
-    if spectrum_in is None:
-        return None
-    spectrum = spectrum_in.clone()
-    if ion_mode_to_keep not in {"positive", "negative", "both"}:
-        raise ValueError("ion_mode_to_keep should be 'positive', 'negative' or 'both'")
-    ion_mode = spectrum.get("ionmode")
-    if ion_mode_to_keep == "both":
-        if ion_mode in ("positive", "negative"):
-            return spectrum
 
-        logger.info("Spectrum was removed since ionmode was: %s which does not match positive or negative", ion_mode)
-        return None
-    if ion_mode == ion_mode_to_keep:
-        return spectrum
-    logger.info("Spectrum was removed since ionmode was: %s which does not match %s", ion_mode, ion_mode_to_keep)
-    return None
+    spectrum = RequireCorrectIonmode(ion_mode_to_keep).process(spectrum_in)
+    return spectrum

--- a/matchms/filtering/metadata_processing/require_parent_mass_match_smiles.py
+++ b/matchms/filtering/metadata_processing/require_parent_mass_match_smiles.py
@@ -1,7 +1,6 @@
 from typing import Optional
-from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
-    get_monoisotopic_neutral_mass
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.require_parent_mass_match_smiles import RequireParentMassMatchSmiles
 
 
 def require_parent_mass_match_smiles(spectrum_in: SpectrumType,
@@ -25,15 +24,6 @@ def require_parent_mass_match_smiles(spectrum_in: SpectrumType,
         The validated spectrum if its parent mass matches the SMILES mass within the
         specified tolerance, or `None` otherwise.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-    # Check if parent mass matches the smiles mass
-    parent_mass = spectrum.get("parent_mass")
-    smiles = spectrum.get("smiles")
-    smiles_mass = get_monoisotopic_neutral_mass(smiles)
-    mass_difference = parent_mass - smiles_mass
-    if abs(mass_difference) < mass_tolerance:
-        return spectrum
-    return None
+    spectrum = RequireParentMassMatchSmiles(mass_tolerance).process(spectrum_in)
+    return spectrum

--- a/matchms/filtering/metadata_processing/require_precursor_below_mz.py
+++ b/matchms/filtering/metadata_processing/require_precursor_below_mz.py
@@ -1,8 +1,5 @@
-import logging
 from matchms.typing import SpectrumType
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.require_precursor_below_mz import RequirePrecursorBelowMz
 
 
 def require_precursor_below_mz(spectrum_in: SpectrumType, max_mz: float = 1000) -> SpectrumType:
@@ -19,19 +16,6 @@ def require_precursor_below_mz(spectrum_in: SpectrumType, max_mz: float = 1000) 
         All precursor mz values greater or equal to this
         will return none. Default is 1000.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    precursor_mz = spectrum.get("precursor_mz", None)
-    assert precursor_mz is not None, "Precursor mz absent."
-    assert isinstance(precursor_mz, (float, int)), ("Expected 'precursor_mz' to be a scalar number.",
-                                                    "Consider applying 'add_precursor_mz' filter first.")
-    assert max_mz >= 0, "max_mz must be a positive scalar."
-    if precursor_mz >= max_mz:
-        logger.info("Spectrum with precursor_mz %s (>%s) was set to None.",
-                    str(precursor_mz), str(max_mz))
-        return None
-
+    spectrum = RequirePrecursorBelowMz(max_mz).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/require_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/require_precursor_mz.py
@@ -1,9 +1,6 @@
-import logging
 from typing import Union
 from matchms.typing import SpectrumType
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.require_precursor_mz import RequirePrecursorMz
 
 
 def require_precursor_mz(spectrum_in: SpectrumType,
@@ -19,24 +16,6 @@ def require_precursor_mz(spectrum_in: SpectrumType,
     minimum_accepted_mz:
         Set to minimum acceptable value for precursor m/z. Default is set to 10.0.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    precursor_mz = spectrum.get("precursor_mz", None)
-    if precursor_mz is None:
-        pepmass = spectrum.get("pepmass", None)
-        assert pepmass is None or not isinstance(pepmass[0], (float, int)), \
-            "Found 'pepmass' but no 'precursor_mz'. " \
-            "Consider applying 'add_precursor_mz' filter first."
-        return None
-
-    assert isinstance(precursor_mz, (float, int)), \
-        ("Expected 'precursor_mz' to be a scalar number.",
-         "Consider applying 'add_precursor_mz' filter first.")
-    if precursor_mz <= minimum_accepted_mz:
-        logger.info("Spectrum without precursor_mz was set to None.")
-        return None
-
+    spectrum = RequirePrecursorMz(minimum_accepted_mz).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/metadata_processing/require_valid_annotation.py
+++ b/matchms/filtering/metadata_processing/require_valid_annotation.py
@@ -1,51 +1,9 @@
-import logging
 from matchms import Spectrum
-from matchms.metadata_utils import (convert_inchi_to_inchikey,
-                                    convert_smiles_to_inchi, is_valid_inchi,
-                                    is_valid_inchikey, is_valid_smiles)
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.require_valid_annotation import RequireValidAnnotation
 
 
 def require_valid_annotation(spectrum: Spectrum):
     """Removes spectra that are not fully annotated (correct and matching, smiles, inchi and inchikey)"""
-    if spectrum is None:
-        return None
-    smiles = spectrum.get("smiles")
-    inchi = spectrum.get("inchi")
-    inchikey = spectrum.get("inchikey")
-    if not is_valid_smiles(smiles):
-        logger.info("Removed spectrum since smiles is not valid. Incorrect smiles = %s", smiles)
-        return None
-    if not is_valid_inchikey(inchikey):
-        logger.info("Removed spectrum since inchikey is not valid. Incorrect inchikey = %s", inchikey)
-        return None
-    if not is_valid_inchi(inchi):
-        logger.info("Removed spectrum since inchi is not valid. Incorrect inchi = %s", inchi)
-        return None
-    if not _check_smiles_inchi_inchikey_match(spectrum):
-        return None
+
+    spectrum = RequireValidAnnotation().process(spectrum)
     return spectrum
-
-
-def _check_smiles_inchi_inchikey_match(spectrum) -> bool:
-    """Checks if a spectrum"""
-    if spectrum is None:
-        return False
-    smiles = spectrum.get("smiles")
-    inchi = spectrum.get("inchi")
-    inchikey = spectrum.get("inchikey")
-    # check if inchi matches the inchikey
-    if not inchikey[:14] == convert_inchi_to_inchikey(inchi)[:14]:
-        logger.warning("Removed spectrum since inchi and inchikey do not match. "
-                       "inchi = %s, inchikey = %s, expected_inchikey = %s",
-                       inchi, inchikey, convert_inchi_to_inchikey(inchi))
-        return False
-    # check if smiles matches the inchikey (first convert to inchi followed by converting to inchikey)
-    if not inchikey[:14] == convert_inchi_to_inchikey(convert_smiles_to_inchi(smiles))[:14]:
-        logger.warning("Removed spectrum since smiles does not match the inchikey. "
-                       "inchikey = %s, smiles = %s, expected_inchikey = %s",
-                       inchikey, smiles, convert_inchi_to_inchikey(convert_smiles_to_inchi(smiles)))
-        return False
-    return True

--- a/matchms/filtering/peak_processing/add_losses.py
+++ b/matchms/filtering/peak_processing/add_losses.py
@@ -1,10 +1,5 @@
-import logging
-import numpy as np
-from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.add_losses import AddLosses
 
 
 def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -> SpectrumType:
@@ -19,24 +14,6 @@ def add_losses(spectrum_in: SpectrumType, loss_mz_from=0.0, loss_mz_to=1000.0) -
     loss_mz_to:
         Maximum allowed m/z value for losses. Default is 1000.0.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    precursor_mz = spectrum.get("precursor_mz", None)
-    if precursor_mz:
-        assert isinstance(precursor_mz, (float, int)), ("Expected 'precursor_mz' to be a scalar number.",
-                                                        "Consider applying 'add_precursor_mz' filter first.")
-        peaks_mz, peaks_intensities = spectrum.peaks.mz, spectrum.peaks.intensities
-        losses_mz = (precursor_mz - peaks_mz)[::-1]
-        losses_intensities = peaks_intensities[::-1]
-        # Add losses which are within given boundaries
-        mask = np.where((losses_mz >= loss_mz_from)
-                           & (losses_mz <= loss_mz_to))
-        spectrum.losses = Fragments(mz=losses_mz[mask],
-                                    intensities=losses_intensities[mask])
-    else:
-        logger.warning("No precursor_mz found. Consider applying 'add_precursor_mz' filter first.")
-
+    spectrum = AddLosses(loss_mz_from, loss_mz_to).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/peak_processing/normalize_intensities.py
+++ b/matchms/filtering/peak_processing/normalize_intensities.py
@@ -1,38 +1,9 @@
-import logging
-import numpy as np
 from matchms.typing import SpectrumType
-from ...Fragments import Fragments
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.normalize_intensities import NormalizeIntensities
 
 
 def normalize_intensities(spectrum_in: SpectrumType) -> SpectrumType:
     """Normalize intensities of peaks (and losses) to unit height."""
 
-    if spectrum_in is None:
-        return None
-
-    spectrum = spectrum_in.clone()
-
-    if len(spectrum.peaks) == 0:
-        return spectrum
-
-    max_intensity = np.max(spectrum.peaks.intensities)
-
-    if max_intensity <= 0:
-        logger.warning("Spectrum with all peak intensities <= 0 was set to None.")
-        return None
-
-    # Normalize peak intensities
-    mz, intensities = spectrum.peaks.mz, spectrum.peaks.intensities
-    normalized_intensities = intensities / max_intensity
-    spectrum.peaks = Fragments(mz=mz, intensities=normalized_intensities)
-
-    # Normalize loss intensities
-    if spectrum.losses is not None and len(spectrum.losses) > 0:
-        mz, intensities = spectrum.losses.mz, spectrum.losses.intensities
-        normalized_intensities = intensities / max_intensity
-        spectrum.losses = Fragments(mz=mz, intensities=normalized_intensities)
-
+    spectrum = NormalizeIntensities().process(spectrum_in)
     return spectrum

--- a/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
@@ -1,12 +1,7 @@
-import logging
-from math import ceil
 from typing import Optional
 import numpy as np
-from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.reduce_to_number_of_peaks import ReduceToNumberOfPeaks
 
 
 def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 1, n_max: int = np.inf,
@@ -28,36 +23,6 @@ def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 1, n_
         error when ratio_desired is used.
         Default is None.
     """
-    def _set_maximum_number_of_peaks_to_keep():
-        parent_mass = spectrum.get("parent_mass", None)
-        if parent_mass and ratio_desired:
-            n_desired_by_mass = int(ceil(ratio_desired * parent_mass))
-            return min(max(n_required, n_desired_by_mass), n_max)
-        if not ratio_desired:
-            return n_max
-        raise ValueError("Cannot use ratio_desired for spectrum without parent_mass.")
 
-    def _remove_lowest_intensity_peaks():
-        mz, intensities = spectrum.peaks.mz, spectrum.peaks.intensities
-        idx = intensities.argsort()[-threshold:]
-        idx_sort_by_mz = mz[idx].argsort()
-        spectrum.peaks = Fragments(mz=mz[idx][idx_sort_by_mz],
-                                   intensities=intensities[idx][idx_sort_by_mz])
-
-    if spectrum_in is None:
-        return None
-
-    spectrum = spectrum_in.clone()
-
-    if spectrum.peaks.intensities.size < n_required:
-        logger.info("Spectrum with %s (<%s) peaks was set to None.",
-                    str(spectrum.peaks.intensities.size), str(n_required))
-        return None
-
-    threshold = _set_maximum_number_of_peaks_to_keep()
-    if spectrum.peaks.intensities.size < threshold:
-        return spectrum
-
-    _remove_lowest_intensity_peaks()
-
+    spectrum = ReduceToNumberOfPeaks(n_required, n_max, ratio_desired).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
+++ b/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
@@ -1,6 +1,5 @@
-import numpy as np
-from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.remove_peaks_around_precursor_mz import RemovePeaksAroundPrecursorMz
 
 
 def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: float = 17) -> SpectrumType:
@@ -16,20 +15,6 @@ def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: fl
         Tolerance of mz values that are not allowed to lie
         within the precursor mz. Default is 17 Da.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    precursor_mz = spectrum.get("precursor_mz", None)
-    assert precursor_mz is not None, "Precursor mz absent."
-    assert isinstance(precursor_mz, (float, int)), ("Expected 'precursor_mz' to be a scalar number.",
-                                                    "Consider applying 'add_precursor_mz' filter first.")
-    assert mz_tolerance >= 0, "mz_tolerance must be a positive scalar."
-
-    mzs, intensities = spectrum.peaks.mz, spectrum.peaks.intensities
-    peaks_to_remove = ((np.abs(precursor_mz-mzs) <= mz_tolerance) & (mzs != precursor_mz))
-    new_mzs, new_intensities = mzs[~peaks_to_remove], intensities[~peaks_to_remove]
-    spectrum.peaks = Fragments(mz=new_mzs, intensities=new_intensities)
-
+    spectrum = RemovePeaksAroundPrecursorMz(mz_tolerance).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
+++ b/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
@@ -1,6 +1,5 @@
-import numpy as np
-from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.remove_peaks_outside_top_k import RemovePeaksOutsideTopK
 
 
 def remove_peaks_outside_top_k(spectrum_in: SpectrumType, k: int = 6,
@@ -19,26 +18,6 @@ def remove_peaks_outside_top_k(spectrum_in: SpectrumType, k: int = 6,
         Window of mz values (in Da) that are allowed to lie within
         the top k peaks. Default is 50 Da.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    assert k >= 1, "k must be a positive nonzero integer."
-    assert mz_window >= 0, "mz_window must be a positive scalar."
-    mzs, intensities = spectrum.peaks.mz, spectrum.peaks.intensities
-    top_k = intensities.argsort()[::-1][0:k]
-    k_ordered_mzs = mzs[top_k]
-    indices = [i for i in range(len(mzs)) if i not in top_k]
-    keep_idx = top_k.tolist()
-    for i in indices:
-
-        compare = abs(mzs[i]-k_ordered_mzs) <= mz_window
-        if np.any(compare):
-            keep_idx.append(i)
-
-    keep_idx.sort()
-    new_mzs, new_intensities = mzs[keep_idx], intensities[keep_idx]
-    spectrum.peaks = Fragments(mz=new_mzs, intensities=new_intensities)
-
+    spectrum = RemovePeaksOutsideTopK(k, mz_window).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
@@ -1,10 +1,6 @@
-import logging
-from math import ceil
 from typing import Optional
 from matchms.typing import SpectrumType
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.require_minimum_number_of_peaks import RequireMinimumNumberOfPeaks
 
 
 def require_minimum_number_of_peaks(spectrum_in: SpectrumType,
@@ -24,21 +20,6 @@ def require_minimum_number_of_peaks(spectrum_in: SpectrumType,
         Default is None.
 
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    parent_mass = spectrum.get("parent_mass", None)
-    if parent_mass and ratio_required:
-        n_required_by_mass = int(ceil(ratio_required * parent_mass))
-        threshold = max(n_required, n_required_by_mass)
-    else:
-        threshold = n_required
-
-    if spectrum.peaks.intensities.size < threshold:
-        logger.info("Spectrum with %s (<%s) peaks was set to None.",
-                    str(spectrum.peaks.intensities.size), str(threshold))
-        return None
-
+    spectrum = RequireMinimumNumberOfPeaks(n_required, ratio_required).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/peak_processing/require_minimum_of_high_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_of_high_peaks.py
@@ -1,9 +1,5 @@
-import logging
 from matchms.typing import SpectrumType
-from .select_by_relative_intensity import select_by_relative_intensity
-
-
-logger = logging.getLogger("matchms")
+from matchms.filtering.filters.require_minimum_of_high_peaks import RequireMinimumOfHighPeaks
 
 
 def require_minimum_of_high_peaks(spectrum_in: SpectrumType, no_peaks: int = 5,
@@ -24,17 +20,6 @@ def require_minimum_of_high_peaks(spectrum_in: SpectrumType, no_peaks: int = 5,
         Minimum relative intensity (as a percentage between 0-100) for
         peaks that are searched. Default is 2
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    assert no_peaks >= 1, "no_peaks must be a positive nonzero integer."
-    assert 0 <= intensity_percent <= 100, "intensity_percent must be a scalar between 0-100."
-    intensities_above_p = select_by_relative_intensity(spectrum, intensity_from=intensity_percent/100, intensity_to=1.0)
-    if len(intensities_above_p.peaks) < no_peaks:
-        logger.info("Spectrum with %s (<%s) peaks was set to None.",
-                    str(len(intensities_above_p.peaks)), str(no_peaks))
-        return None
-
+    spectrum = RequireMinimumOfHighPeaks(no_peaks, intensity_percent).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/peak_processing/select_by_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_intensity.py
@@ -1,6 +1,5 @@
-import numpy as np
-from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.select_by_intensity import SelectByIntensity
 
 
 def select_by_intensity(spectrum_in: SpectrumType, intensity_from: float = 10.0,
@@ -16,17 +15,6 @@ def select_by_intensity(spectrum_in: SpectrumType, intensity_from: float = 10.0,
     intensity_to:
         Set upper threshold for peak intensity. Default is 200.0.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    assert intensity_from <= intensity_to, "'intensity_from' should be smaller than or equal to 'intensity_to'."
-
-    condition = np.logical_and(intensity_from <= spectrum.peaks.intensities,
-                                  spectrum.peaks.intensities <= intensity_to)
-
-    spectrum.peaks = Fragments(mz=spectrum.peaks.mz[condition],
-                               intensities=spectrum.peaks.intensities[condition])
-
+    spectrum = SelectByIntensity(intensity_from, intensity_to).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/peak_processing/select_by_mz.py
+++ b/matchms/filtering/peak_processing/select_by_mz.py
@@ -1,6 +1,5 @@
-import numpy as np
-from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.select_by_mz import SelectByMz
 
 
 def select_by_mz(spectrum_in: SpectrumType, mz_from: float = 0.0,
@@ -14,16 +13,6 @@ def select_by_mz(spectrum_in: SpectrumType, mz_from: float = 0.0,
     mz_to:
         Set upper threshold for m/z peak positions. Default is 1000.0.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    assert mz_from <= mz_to, "'mz_from' should be smaller than or equal to 'mz_to'."
-
-    condition = np.logical_and(mz_from <= spectrum.peaks.mz, spectrum.peaks.mz <= mz_to)
-
-    spectrum.peaks = Fragments(mz=spectrum.peaks.mz[condition],
-                               intensities=spectrum.peaks.intensities[condition])
-
+    spectrum = SelectByMz(mz_from, mz_to).process(spectrum_in)
     return spectrum

--- a/matchms/filtering/peak_processing/select_by_relative_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_relative_intensity.py
@@ -1,6 +1,5 @@
-import numpy as np
-from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType
+from matchms.filtering.filters.select_by_relative_intensity import SelectByRelativeIntensity
 
 
 def select_by_relative_intensity(spectrum_in: SpectrumType, intensity_from: float = 0.0,
@@ -15,20 +14,6 @@ def select_by_relative_intensity(spectrum_in: SpectrumType, intensity_from: floa
     intensity_to:
         Set upper threshold for relative peak intensity. Default is 1.0.
     """
-    if spectrum_in is None:
-        return None
 
-    spectrum = spectrum_in.clone()
-
-    assert intensity_from >= 0.0, "'intensity_from' should be larger than or equal to 0."
-    assert intensity_to <= 1.0, "'intensity_to' should be smaller than or equal to 1.0."
-    assert intensity_from <= intensity_to, "'intensity_from' should be smaller than or equal to 'intensity_to'."
-
-    if len(spectrum.peaks) > 0:
-        scale_factor = np.max(spectrum.peaks.intensities)
-        normalized_intensities = spectrum.peaks.intensities / scale_factor
-        condition = np.logical_and(intensity_from <= normalized_intensities, normalized_intensities <= intensity_to)
-        spectrum.peaks = Fragments(mz=spectrum.peaks.mz[condition],
-                                   intensities=spectrum.peaks.intensities[condition])
-
+    spectrum = SelectByRelativeIntensity(intensity_from, intensity_to).process(spectrum_in)
     return spectrum

--- a/matchms/similarity/ModifiedCosine.py
+++ b/matchms/similarity/ModifiedCosine.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Tuple
 import numpy as np
-from matchms.filtering.metadata_processing.add_precursor_mz import \
-    _convert_precursor_mz
+from matchms.filtering.filters.add_precursor_mz import \
+    AddPrecursorMz
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
 from .spectrum_similarity_functions import (collect_peak_pairs,
@@ -102,7 +102,7 @@ class ModifiedCosine(BaseSimilarity):
             precursor_mz = spectrum.get("precursor_mz", None)
             if not isinstance(precursor_mz, (int, float)):
                 logger.warning(message_precursor_no_number)
-            precursor_mz = _convert_precursor_mz(precursor_mz)
+            precursor_mz = AddPrecursorMz._convert_precursor_mz(precursor_mz)
             assert precursor_mz is not None, message_precursor_missing
             assert precursor_mz > 0, message_precursor_below_0
             return precursor_mz

--- a/matchms/similarity/NeutralLossesCosine.py
+++ b/matchms/similarity/NeutralLossesCosine.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Tuple
 import numpy as np
-from matchms.filtering.metadata_processing.add_precursor_mz import \
-    _convert_precursor_mz
+from matchms.filtering.filters.add_precursor_mz import \
+    AddPrecursorMz
 from matchms.typing import SpectrumType
 from .BaseSimilarity import BaseSimilarity
 from .spectrum_similarity_functions import (collect_peak_pairs,
@@ -78,7 +78,7 @@ class NeutralLossesCosine(BaseSimilarity):
             precursor_mz = spectrum.get("precursor_mz", None)
             if not isinstance(precursor_mz, (int, float)):
                 logger.warning(message_precursor_no_number)
-            precursor_mz = _convert_precursor_mz(precursor_mz)
+            precursor_mz = AddPrecursorMz._convert_precursor_mz(precursor_mz)
             assert precursor_mz is not None, message_precursor_missing
             assert precursor_mz > 0, message_precursor_below_0
             return precursor_mz

--- a/tests/filtering/test_derive_adduct_from_name.py
+++ b/tests/filtering/test_derive_adduct_from_name.py
@@ -1,7 +1,7 @@
 import pytest
 from testfixtures import LogCapture
 from matchms.filtering import derive_adduct_from_name
-from matchms.filtering.metadata_processing.derive_adduct_from_name import \
+from matchms.filtering.filters.derive_adduct_from_name import \
     _looks_like_adduct
 from matchms.logging_functions import (reset_matchms_logger,
                                        set_matchms_logger_level)


### PR DESCRIPTION
As per our discussion, Opening the draft PR for discussion. 

This implementation is based on the template design pattern, containing a base class that contains two functions process() and abstract method apply_filter(). Then it has further sub base class for filters that share quite a lot of similar code e.g. select_by filter and harmonize_undefined filters. There is not really a change in the current filter function usage to keep usage the same for now, but internally they now use class implementation.