### PR TITLE
Remove pepmass after running interpret_pepmass.py

### DIFF
--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -58,7 +58,7 @@ def _interpret_pepmass_metadata(metadata):
         metadata["charge"] = charge
         logger.info("Added charge entry based on field 'pepmass'.")
 
-    metadata["pepmass"] = None
+    del metadata["pepmass"]
     logger.info("Removed pepmass, since the information was added to other fields")
     return metadata
 

--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -58,6 +58,8 @@ def _interpret_pepmass_metadata(metadata):
         metadata["charge"] = charge
         logger.info("Added charge entry based on field 'pepmass'.")
 
+    metadata["pepmass"] = None
+    logger.info("Removed pepmass, since the information was added to other fields")
     return metadata
 
 


### PR DESCRIPTION
Solves #532 Let me know if you think this would be the correct solution. 

I am not very familiar with the pepmass field, do you think this makes sense? 

This solution will remove the pepmass field when interpret pepmass is run. Interpret pepmass retrieves mz, intensity and charge from the pepmass field. But currently it keeps the updated fields and the pepmass field. 

For me this became an issue, since if I save filtered spectra (that cleaned the precursor mz) and during the loading they are overwritten again by the pepmass field. The same goes for a cleaned charge. 

My solution now is to just remove the pepmass field after the information has been retrieved. In this way the second time a spectrum is loaded interpret pepmass will not accidentally overwrite previously cleaned fields. 
@florian-huber What do you think?