### PR TITLE
Enable setting key conversion with static method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Added
+- added option to set custom key replacements [#547](https://github.com/matchms/matchms/pull/547)
 ### Fixed
 - handle missing `precursor_mz` in representation and [#452](https://github.com/matchms/matchms/issues/452) introduced by [#514](https://github.com/matchms/matchms/pull/514/files)[#540](https://github.com/matchms/matchms/pull/540)
 

--- a/matchms/Metadata.py
+++ b/matchms/Metadata.py
@@ -11,11 +11,6 @@ from .filtering.metadata_processing.make_charge_int import \
 from .utils import load_export_key_conversions, load_known_key_conversions
 
 
-_key_regex_replacements = {r"\s": "_",
-                           r"[!?.,;:]": ""}
-_key_replacements = load_known_key_conversions()
-
-
 class Metadata:
     """Class to handle spectrum metadata in matchms.
 
@@ -46,6 +41,11 @@ class Metadata:
         print(metadata["compound_name"])  # => None (now you need to use "compound name")
 
     """
+
+    _key_regex_replacements = {r"\s": "_",
+                           r"[!?.,;:]": ""}
+    _key_replacements = load_known_key_conversions()
+
     def __init__(self, metadata: dict = None,
                  matchms_key_style: bool = True):
         """
@@ -90,8 +90,8 @@ class Metadata:
         replacements (such as precursor_mass --> precursor_mz).
 
         """
-        self._data.key_regex_replacements = _key_regex_replacements
-        self._data.key_replacements = _key_replacements
+        self._data.key_regex_replacements = Metadata._key_regex_replacements
+        self._data.key_replacements = Metadata._key_replacements
 
     def harmonize_values(self):
         """Runs default harmonization of metadata.
@@ -195,3 +195,14 @@ class Metadata:
                 self.harmonize_keys()
         else:
             raise TypeError("Expected input of type dict or PickyDict.")
+    
+    @staticmethod
+    def set_key_replacements(keys: dict):
+        """Set key replacements for metadata harmonization.
+
+        Parameters
+        ----------
+        keys:
+            Dictionary with key replacements.
+        """
+        Metadata._key_replacements = keys

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 from pickydict import PickyDict
 from matchms import Metadata
+from matchms.utils import load_known_key_conversions
 
 
 @pytest.mark.parametrize("input_dict, harmonize, expected", [
@@ -106,3 +107,20 @@ def test_remove_invalid_metadata(input_dict, expected):
     metadata.harmonize_values()
 
     assert metadata == expected, "Expected metadata to be equal."
+
+
+@pytest.mark.parametrize("mapping, metadata", [
+    [{"name": "compound_name"}, {"name": "test"}],
+    [{}, {"name": "test"}],
+])
+def test_metadata_key_mapping(mapping: dict, metadata: dict):
+    Metadata.set_key_replacements(mapping)
+
+    sut = Metadata(metadata)
+    if len(mapping) > 0:
+        assert sut[next(iter(mapping.values()))] == next(iter(metadata.values()))
+        assert sut[next(iter(mapping))] is None
+    else:
+        assert sut[next(iter(metadata))] == next(iter(metadata.values()))
+        
+    Metadata.set_key_replacements(load_known_key_conversions())


### PR DESCRIPTION
This allows setting a custom key conversion and changes the `_key_replacements` and `_key_regex` variables to be class variables from global.

This allows removing all key conversion if desired to allows reading and storing files in their original way if desired.

Fixes #546