### PR TITLE
Fix issue with parse metadata recognizing empty metadata as well.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added option to set custom key replacements [#547](https://github.com/matchms/matchms/pull/547)
 ### Fixed
 - handle missing `precursor_mz` in representation and [#452](https://github.com/matchms/matchms/issues/452) introduced by [#514](https://github.com/matchms/matchms/pull/514/files)[#540](https://github.com/matchms/matchms/pull/540)
-
+- Fixed bug when loading empty metadata in msp [#548](https://github.com/matchms/matchms/issues/548)
 ## [0.23.1] - 2023-10-18
 ### Added
 - Additional tests for filter pipeline order

--- a/matchms/importing/load_from_msp.py
+++ b/matchms/importing/load_from_msp.py
@@ -154,6 +154,9 @@ def parse_metadata(rline: str, params: dict):
         # The first checks for compound="caffeine", the second and third "compound=caffeine and the last for parent_mass=12.1
         # The second and third almost match the same pattern, but the second is there to ensure tha the pattern
         # "SMILES=CC(O)C(O)=O" is recognized as 'smiles': 'CC(O)C(O)=O' instead of 'smiles=cc(o)c(o)': 'O'
+        # Cases like "Smiles=" will not be stores (since len(match) = 1) The reason that we did not change the * to +
+        # in the regex, is that we want to still match to these cases, so that the if len(matches) == 0: below is not
+        # called in cases like comments: "smiles=".
         pattern = r'(\S+)="([^"]*)"|' \
                   r'"(\w+)=([^"]*)"|' \
                   r'"([^"]*)=([^"]*)"|' \

--- a/matchms/importing/load_from_msp.py
+++ b/matchms/importing/load_from_msp.py
@@ -172,7 +172,7 @@ def parse_metadata(rline: str, params: dict):
                     params[key.lower().strip()] = value.strip()
     # msp files can have the format comments: smiles="CC=O" but also the format smiles: CC=O.
     # The latter is captured by these lines.
-    if len(matches) == 0:
+    if len(matches) == 0 and splitted_line[0] != "comments":
         params[splitted_line[0].lower()] = splitted_line[1].strip()
 
 

--- a/matchms/importing/load_from_msp.py
+++ b/matchms/importing/load_from_msp.py
@@ -154,6 +154,7 @@ def parse_metadata(rline: str, params: dict):
         # The first checks for compound="caffeine", the second and third "compound=caffeine and the last for parent_mass=12.1
         # The second and third almost match the same pattern, but the second is there to ensure tha the pattern
         # "SMILES=CC(O)C(O)=O" is recognized as 'smiles': 'CC(O)C(O)=O' instead of 'smiles=cc(o)c(o)': 'O'
+        # The third pattern is needed since some keys like DB# should be stored, which is not recognized by the \w regex
         # Cases like "Smiles=" will not be stores (since len(match) = 1) The reason that we did not change the * to +
         # in the regex, is that we want to still match to these cases, so that the if len(matches) == 0: below is not
         # called in cases like comments: "smiles=".

--- a/matchms/importing/load_from_msp.py
+++ b/matchms/importing/load_from_msp.py
@@ -82,7 +82,7 @@ def parse_msp_file(filename: str) -> Generator[dict, None, None]:
 
             masses = np.append(masses, mz)
             intensities = np.append(intensities, ints)
-            
+
             if comment is not None:
                 peak_comments.update({masses[-1]: comment})
 
@@ -103,8 +103,6 @@ def parse_msp_file(filename: str) -> Generator[dict, None, None]:
                 masses = []
                 intensities = []
                 peak_comments = {}
-            
-
 
 
 def _parse_line_with_peaks(rline: str) -> Tuple[List[float], List[float], str]:
@@ -116,9 +114,9 @@ def _parse_line_with_peaks(rline: str) -> Tuple[List[float], List[float], str]:
     Returns:
         Tuple[List[float], List[float], str]: mz, intensity and peak comments obtained from the line.
     """
-    comment, rline = get_peak_comment(rline)   
+    comment, rline = get_peak_comment(rline)
     mz, intensities = get_peak_values(rline)
-    
+
     return mz, intensities, comment
 
 
@@ -127,7 +125,7 @@ def get_peak_values(peak: str) -> Tuple[List[float], List[float]]:
     tokens = re.findall(r'(\d+(?:\.\d+)?(?:e[-+]?\d+)?)', peak)
     if len(tokens) % 2 != 0:
         raise RuntimeError("Wrong peak format detected!")
-    
+
     tokens = list(map(float, tokens))
     mz = tokens[0::2]
     intensities = tokens[1::2]
@@ -149,16 +147,20 @@ def parse_metadata(rline: str, params: dict):
     matches = []
     splitted_line = rline.split(":", 1)
     if splitted_line[0].lower() == 'comments' and "=" in splitted_line[1]:
-        pattern = r'(\S+)="([^"]*)"|"(\w+)=([^"]*)"|"([^"]*)=([^"]*)"|(\S+)=(\d+(?:\.\d*)?)'
+        pattern = r'(\S+)="([^"]+)"|' \
+                  r'"(\w+)=([^"]+)"|' \
+                  r'"([^"]+)=([^"]+)"|' \
+                  r'(\S+)=(\d+(?:\.\d*)?)'
         matches = re.findall(pattern, splitted_line[1].replace("'", '"'))
         for match in matches:
             match = [i for i in match if i]
-            key = match[0]
-            value = match[1]
-            if key.lower().strip() in params.keys() and key.lower().strip() == 'smiles':
-                params[key.lower()+"_2"] = value.strip()
-            else:
-                params[key.lower().strip()] = value.strip()
+            if len(match) == 2:
+                key = match[0]
+                value = match[1]
+                if key.lower().strip() in params.keys() and key.lower().strip() == 'smiles':
+                    params[key.lower()+"_2"] = value.strip()
+                else:
+                    params[key.lower().strip()] = value.strip()
     if len(matches) == 0:
         params[splitted_line[0].lower()] = splitted_line[1].strip()
 

--- a/matchms/importing/load_from_msp.py
+++ b/matchms/importing/load_from_msp.py
@@ -154,9 +154,9 @@ def parse_metadata(rline: str, params: dict):
         # The first checks for compound="caffeine", the second and third "compound=caffeine and the last for parent_mass=12.1
         # The second and third almost match the same pattern, but the second is there to ensure tha the pattern
         # "SMILES=CC(O)C(O)=O" is recognized as 'smiles': 'CC(O)C(O)=O' instead of 'smiles=cc(o)c(o)': 'O'
-        pattern = r'(\S+)="([^"]+)"|' \
-                  r'"(\w+)=([^"]+)"|' \
-                  r'"([^"]+)=([^"]+)"|' \
+        pattern = r'(\S+)="([^"]*)"|' \
+                  r'"(\w+)=([^"]*)"|' \
+                  r'"([^"]*)=([^"]*)"|' \
                   r'(\S+)=(\d+(?:\.\d*)?)'
         matches = re.findall(pattern, splitted_line[1].replace("'", '"'))
         for match in matches:
@@ -172,7 +172,7 @@ def parse_metadata(rline: str, params: dict):
                     params[key.lower().strip()] = value.strip()
     # msp files can have the format comments: smiles="CC=O" but also the format smiles: CC=O.
     # The latter is captured by these lines.
-    if len(matches) == 0 and splitted_line[0] != "comments":
+    if len(matches) == 0:
         params[splitted_line[0].lower()] = splitted_line[1].strip()
 
 

--- a/tests/importing/test_load_from_msp.py
+++ b/tests/importing/test_load_from_msp.py
@@ -1,7 +1,8 @@
 import os
 import numpy as np
+import pytest
 from matchms import Spectrum
-from matchms.importing import load_from_msp
+from matchms.importing.load_from_msp import load_from_msp, parse_metadata
 from tests.builder_Spectrum import SpectrumBuilder
 
 
@@ -262,5 +263,18 @@ def test_load_msp_with_scientific_notation():
     module_root = os.path.join(os.path.dirname(__file__), "..")
     spectrums_file = os.path.join(module_root, "testdata", "test_spectra_collection.msp")
     actual = list(load_from_msp(spectrums_file))
-    
+
     assert len(actual) == 3
+
+
+@pytest.mark.parametrize("input, expected_output", [
+    ['comments: "SMILES=CC(O)C(O)=O"', {"smiles": "CC(O)C(O)=O"}],
+    ['comments: SMILES="CC(O)C(O)=O"', {"smiles": "CC(O)C(O)=O"}],
+    ['comments: mass=12.0', {"mass": '12.0'}],
+    ['name: 3,4-DICHLOROPHENOL', {'name': '3,4-DICHLOROPHENOL'}]
+])
+def test_parse_metadata(input, expected_output):
+    """tests if metadata is correctly parsed"""
+    params = {}
+    parse_metadata(input, params)
+    assert params == expected_output

--- a/tests/importing/test_load_from_msp.py
+++ b/tests/importing/test_load_from_msp.py
@@ -273,6 +273,7 @@ def test_load_msp_with_scientific_notation():
     ['comments: mass=12.0', {"mass": '12.0'}],
     ['name: 3,4-DICHLOROPHENOL', {'name': '3,4-DICHLOROPHENOL'}],
     ['comments: "SMILES=CC(O)C(O)=O"', {"smiles": "CC(O)C(O)=O"}],
+    ['comments: "DB#=JP000001"', {"db#":"JP000001"}],
 ])
 def test_parse_metadata(input_line, expected_output):
     """tests if metadata is correctly parsed"""

--- a/tests/importing/test_load_from_msp.py
+++ b/tests/importing/test_load_from_msp.py
@@ -267,14 +267,15 @@ def test_load_msp_with_scientific_notation():
     assert len(actual) == 3
 
 
-@pytest.mark.parametrize("input, expected_output", [
-    ['comments: "SMILES=CC(O)C(O)=O"', {"smiles": "CC(O)C(O)=O"}],
+@pytest.mark.parametrize("input_line, expected_output", [
+    ['comments: "SMILES="', {}],
     ['comments: SMILES="CC(O)C(O)=O"', {"smiles": "CC(O)C(O)=O"}],
     ['comments: mass=12.0', {"mass": '12.0'}],
-    ['name: 3,4-DICHLOROPHENOL', {'name': '3,4-DICHLOROPHENOL'}]
+    ['name: 3,4-DICHLOROPHENOL', {'name': '3,4-DICHLOROPHENOL'}],
+    ['comments: "SMILES=CC(O)C(O)=O"', {"smiles": "CC(O)C(O)=O"}],
 ])
-def test_parse_metadata(input, expected_output):
+def test_parse_metadata(input_line, expected_output):
     """tests if metadata is correctly parsed"""
     params = {}
-    parse_metadata(input, params)
+    parse_metadata(input_line, params)
     assert params == expected_output


### PR DESCRIPTION
Fixes #548 

This was a good lesson for me in the complexity of different metadata formats accepted in msp ...

What caused #548 is that cases like 'Comments: "compound class=" 'Comments: "compound class=" 'will be recognized by the regex, but will return '' for the seconds group, which makes match[1] not work. 
Simply adding if len(match) != 2 solves this issue.

The function was quite complex, so I wanted to simplify this at first. But I have now figured out why this was not possible, since it would not recognize all the possible formats anymore. I have added tests for these cases and added documentation to the function to clarify the reason for the steps.