### PR TITLE
add export_style parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
-- added option to set custom key replacements [#547](https://github.com/matchms/matchms/pull/547)
+- Option to set custom key replacements [#547](https://github.com/matchms/matchms/pull/547)
+- Option to set the export style in `save_as_mgf` and `save_as_json` to choose other than matchms styles such as `nist`, `riken`, `gnps` [#557](https://github.com/matchms/matchms/pull/557)
+
 ### Fixed
-- handle missing `precursor_mz` in representation and [#452](https://github.com/matchms/matchms/issues/452) introduced by [#514](https://github.com/matchms/matchms/pull/514/files)[#540](https://github.com/matchms/matchms/pull/540)
+- Handle missing `precursor_mz` in representation and [#452](https://github.com/matchms/matchms/issues/452) introduced by [#514](https://github.com/matchms/matchms/pull/514/files)[#540](https://github.com/matchms/matchms/pull/540)
 
 ## [0.23.1] - 2023-10-18
 ### Added

--- a/matchms/Scores.py
+++ b/matchms/Scores.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
+import copy
 import json
 import pickle
 import numpy as np
 from numpy.lib.recfunctions import unstructured_to_structured
 from scipy.sparse import coo_matrix
 from sparsestack import StackedSparseArray
-from matchms.exporting.save_as_json import ScoresJSONEncoder
 from matchms.importing.load_from_json import scores_json_decoder
 from matchms.similarity import get_similarity_function_by_name
 from matchms.similarity.BaseSimilarity import BaseSimilarity
@@ -475,3 +475,14 @@ class ScoresBuilder:
                              Make sure the file contains the following keys:\n\
                              ['__Scores__', 'is_symmetric', 'references', 'queries', 'scores_row',\
                              'scores_col', 'scores_data', 'scores_dtype']")
+
+
+class ScoresJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        """JSON Encoder for a matchms.Scores.Scores object"""
+        class_name = o.__class__.__name__
+        # do isinstance(o, Scores) without importing matchms.Scores
+        if class_name == "Scores":
+            scores = copy.deepcopy(o)
+            return scores.to_dict()
+        return json.JSONEncoder.default(self, o)

--- a/matchms/Spectrum.py
+++ b/matchms/Spectrum.py
@@ -187,17 +187,31 @@ class Spectrum:
         self._metadata.set(key, value)
         return self
 
-    def to_dict(self) -> dict:
-        """Return a dictionary representation of a spectrum."""
+    def to_dict(self, export_style: str = "matchms") -> dict:
+        """Return a dictionary representation of a spectrum.
+
+        Parameters
+        ----------
+        export_style:
+            Converts the keys to the required export style. One of ["matchms", "massbank", "nist", "riken", "gnps"].
+            Default is "matchms"
+        """
         peaks_list = np.vstack((self.peaks.mz, self.peaks.intensities)).T.tolist()
-        spectrum_dict = dict(self.metadata.items())
+        spectrum_dict = self.metadata_dict(export_style)  # dict(self.metadata.items())
         spectrum_dict["peaks_json"] = peaks_list
         if "fingerprint" in spectrum_dict:
             spectrum_dict["fingerprint"] = spectrum_dict["fingerprint"].tolist()
         return spectrum_dict
 
     def metadata_dict(self, export_style: str = "matchms") -> dict:
-        """Convert spectrum metadata to Python dictionary."""
+        """Convert spectrum metadata to Python dictionary.
+
+        Parameters
+        ----------
+        export_style:
+            Converts the keys to the required export style. One of ["matchms", "massbank", "nist", "riken", "gnps"].
+            Default is "matchms"
+        """
         return self._metadata.to_dict(export_style)
 
     @property

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -69,7 +69,7 @@ class ScoresJSONEncoder(json.JSONEncoder):
     def default(self, o):
         """JSON Encoder for a matchms.Scores.Scores object"""
         class_name = o.__class__.__name__
-        # do isinstance(obj, Scores) without importing matchms.Scores
+        # do isinstance(o, Scores) without importing matchms.Scores
         if class_name == "Scores":
             scores = copy.deepcopy(o)
             return scores.to_dict()

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -47,23 +47,22 @@ def save_as_json(spectrums: List[Spectrum], filename: str):
 
 
 class SpectrumJSONEncoder(json.JSONEncoder):
-    # See https://github.com/PyCQA/pylint/issues/414 for reference
-    def default(self, o):
-        """JSON Encoder which can encode a :py:class:`~matchms.Spectrum.Spectrum` object"""
-        if isinstance(o, Spectrum):
-            spec = o.clone().to_dict()
+    def default(self, obj):
+        """JSON Encoder for a matchms.Spectrum.Spectrum object"""
+        if isinstance(obj, Spectrum):
+            spec = obj.clone().to_dict()
             if "fingerprint" in spec.keys():
                 del spec["fingerprint"]
             return spec
-        return json.JSONEncoder.default(self, o)
+        return json.JSONEncoder.default(self, obj)
 
 
 class ScoresJSONEncoder(json.JSONEncoder):
-    def default(self, o):
-        """JSON Encoder which can encode a :py:class:`~matchms.Scores.Scores` object"""
-        class_name = o.__class__.__name__
-        # do isinstance(o, Scores) without importing matchms.Scores
+    def default(self, obj):
+        """JSON Encoder for a matchms.Scores.Scores object"""
+        class_name = obj.__class__.__name__
+        # do isinstance(obj, Scores) without importing matchms.Scores
         if class_name == "Scores":
-            scores = copy.deepcopy(o)
+            scores = copy.deepcopy(obj)
             return scores.to_dict()
-        return json.JSONEncoder.default(self, o)
+        return json.JSONEncoder.default(self, obj)

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -62,15 +62,3 @@ def create_spectrum_json_encoder(export_style):
                 return spec
             return super().default(o)
     return CustomSpectrumJSONEncoder
-
-
-class ScoresJSONEncoder(json.JSONEncoder):
-    export_style = "matchms"
-    def default(self, o):
-        """JSON Encoder for a matchms.Scores.Scores object"""
-        class_name = o.__class__.__name__
-        # do isinstance(o, Scores) without importing matchms.Scores
-        if class_name == "Scores":
-            scores = copy.deepcopy(o)
-            return scores.to_dict()
-        return json.JSONEncoder.default(self, o)

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -5,7 +5,9 @@ from ..Spectrum import Spectrum
 from ..utils import fingerprint_export_warning
 
 
-def save_as_json(spectrums: List[Spectrum], filename: str):
+def save_as_json(spectrums: List[Spectrum],
+                 filename: str,
+                 export_style: str = "matchms"):
     """Save spectrum(s) as json file.
 
     :py:attr:`~matchms.Spectrum.losses` of spectrum will not be saved.
@@ -34,6 +36,9 @@ def save_as_json(spectrums: List[Spectrum], filename: str):
         Expected input is a list of  :py:class:`~matchms.Spectrum.Spectrum` objects.
     filename:
         Provide filename to save spectrum(s).
+    export_style:
+        Converts the keys to the required export style. One of ["matchms", "massbank", "nist", "riken", "gnps"].
+        Default is "matchms"
     """
     if not isinstance(spectrums, list):
         # Assume that input was single Spectrum

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -1,4 +1,3 @@
-import copy
 import json
 from typing import List
 from ..Spectrum import Spectrum

--- a/matchms/exporting/save_as_mgf.py
+++ b/matchms/exporting/save_as_mgf.py
@@ -4,7 +4,9 @@ from ..Spectrum import Spectrum
 from ..utils import fingerprint_export_warning
 
 
-def save_as_mgf(spectrums: List[Spectrum], filename: str):
+def save_as_mgf(spectrums: List[Spectrum],
+                filename: str,
+                export_style: str = "matchms"):
     """Save spectrum(s) as mgf file.
 
     :py:attr:`~matchms.Spectrum.losses` of spectrum will not be saved.
@@ -33,6 +35,9 @@ def save_as_mgf(spectrums: List[Spectrum], filename: str):
         Expected input are match.Spectrum.Spectrum() objects.
     filename:
         Provide filename to save spectrum(s).
+    export_style:
+        Converts the keys to the required export style. One of ["matchms", "massbank", "nist", "riken", "gnps"].
+        Default is "matchms"
     """
     if not isinstance(spectrums, list):
         # Assume that input was single Spectrum
@@ -44,7 +49,7 @@ def save_as_mgf(spectrums: List[Spectrum], filename: str):
     for spectrum in spectrums:
         spectrum_dict = {"m/z array": spectrum.peaks.mz,
                          "intensity array": spectrum.peaks.intensities,
-                         "params": spectrum.metadata}
+                         "params": spectrum.metadata_dict(export_style)}
         if 'fingerprint' in spectrum_dict["params"]:
             del spectrum_dict["params"]["fingerprint"]
         # Append spectrum to file

--- a/tests/exporting/test_save_as_json_load_from_json.py
+++ b/tests/exporting/test_save_as_json_load_from_json.py
@@ -60,6 +60,17 @@ def test_save_and_load_json_spectrum_list(metadata_harmonization, tmp_path, buil
     assert spectrum_imports[1] == spectrum2, "Original and saved+loaded spectrum not identical"
 
 
+@pytest.mark.parametrize("style, expected",
+                         [("matchms", "precursor_mz"),
+                          ("nist", "PrecursorMZ")])
+def test_save_as_json_different_export_styles(tmp_path, builder, style, expected):
+    spectrum = builder.with_metadata({"precursor_mz": 123}).build()
+    filename = tmp_path / "test_matchms.json"
+    save_as_json([spectrum], str(filename), export_style=style)
+
+    with open(filename, "r", encoding="utf-8") as f:
+        data = json.load(f)
+        assert expected in data[0]
 
 
 def test_load_from_json_zero_peaks(tmp_path):

--- a/tests/exporting/test_save_as_mgf.py
+++ b/tests/exporting/test_save_as_mgf.py
@@ -68,6 +68,34 @@ def test_save_as_mgf_spectrum_list():
         assert mgf_content[8].split("=")[1] == "test2\n"
 
 
+@pytest.mark.parametrize("style, expected",
+                         [("matchms", ["PRECURSOR_MZ=100.1\n", "PRECURSOR_MZ=200.2\n"]),
+                          ("nist", ["PRECURSORMZ=100.1\n", "PRECURSORMZ=200.2\n"]),
+                          ("gnps", ["PEPMASS=100.1\n", "PEPMASS=200.2\n"]),
+                          ])
+def test_save_as_mgf_export_style(style, expected):
+    """Test saving spectrum list to .mgf file using differnt export styles.
+    """
+    mz = np.array([100, 200], dtype="float")
+    intensities = np.array([10, 500], dtype="float")
+    builder = SpectrumBuilder().with_mz(mz).with_intensities(intensities)
+    spectrum1 = builder.with_metadata({"precursor_mz": 100.1},
+                                      metadata_harmonization=False).build()
+    spectrum2 = builder.with_metadata({"precursor_mz": 200.2},
+                                      metadata_harmonization=False).build()
+
+    # Write to test file
+    with tempfile.TemporaryDirectory() as d:
+        filename = os.path.join(d, "test.mgf")
+        save_as_mgf([spectrum1, spectrum2], filename, export_style=style)
+
+        # Test if content of mgf file is correct
+        with open(filename, "r", encoding="utf-8") as f:
+            mgf_content = f.readlines()
+        assert mgf_content[1] == expected[0]
+        assert mgf_content[7] == expected[1]
+
+
 @pytest.mark.parametrize("charge, ionmode, parent_mass",
                          [(-1, "negative", 218.5),
                           (2, "positive", "n/a"),

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -167,6 +167,20 @@ def test_scores_next():
     assert actual == expected, "Expected different scores."
 
 
+def test_scores_to_dict():
+    """Test if export to Python dictionary works as intended"""
+    spectrum_1, spectrum_2, spectrum_3, _ = spectra()
+    spectrum_1.set("precursor_mz", 123.4)
+    references = [spectrum_1, spectrum_2]
+    queries = [spectrum_3]
+    scores = calculate_scores(references, queries, CosineGreedy())
+    scores_dict = scores.to_dict()
+    expected_dict = [{'id': 'spectrum1', 'precursor_mz': 123.4, 'peaks_json': [[100.0, 0.7], [150.0, 0.2], [200.0, 0.1]]},
+                     {'id': 'spectrum2', 'peaks_json': [[100.0, 0.4], [140.0, 0.2], [190.0, 0.1]]}]
+    assert len(scores_dict["references"]) == 2
+    assert scores_dict["references"] == expected_dict
+
+
 def test_scores_by_referencey():
     "Test scores_by_reference method."
     spectrum_1, spectrum_2, spectrum_3, spectrum_4 = spectra()


### PR DESCRIPTION
Work on #556.

- [x] `save_as_mgf` supports `export_style` parameter
- [x] tests for `save_as_mgf` using other than the default `export_style` parameter (e.g. `gnps`).
- [x] `save_as_json` supports `export_style` parameter
- [x] tests for `save_as_jsonf` using other than the default `export_style` parameter (e.g. `gnps`).

The exporting module could need some refactoring. The focus of this PR is mostly to have a functioning export style option in all export formats.