### PR TITLE
Fix repair not matching annotation

### DIFF
--- a/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
+++ b/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
@@ -109,9 +109,12 @@ def _repair_smiles_inchi(spectrum):
         logger.info("The InChI has been changed from %s to %s. "
                     "The new InChI matches the parent mass, while the old one did not", inchi, inchi_from_smiles)
         spectrum.set("inchi", inchi_from_smiles)
-    else:
+    elif inchi_correct and not smiles_correct:
         # Repair by using SMILES generated from the inchi
         logger.info("The SMILES has been changed from %s to %s to match the InChI. "
                     "The new SMILES matches the parent mass, while the old one did not", smiles, smiles_from_inchi)
         spectrum.set("smiles", smiles_from_inchi)
+    else:
+        logger.warning("Both the Smiles %s and the inchi %s do not match the parent mass %f", smiles, inchi,
+                       parent_mass)
     return spectrum

--- a/tests/filtering/test_repair_not_matching_annotation.py
+++ b/tests/filtering/test_repair_not_matching_annotation.py
@@ -32,6 +32,9 @@ def test_repair_not_matching_annotation_repair_inchikey(smile, inchi, inchikey, 
      "CCC", "InChI=1S/C3H8/c1-3-2/h3H2,1-2H3", "ATUOYWHBWRKTHZ-UHFFFAOYSA-N"),
     ("C(=O)=O", "InChI=1S/C3H8/c1-3-2/h3H2,1-2H3", "ATUOYWHBWRKTHZ-UHFFFAOYSA-N", 44,  # Both match the parent mass
      "C(=O)=O", "InChI=1S/C3H8/c1-3-2/h3H2,1-2H3", "ATUOYWHBWRKTHZ-UHFFFAOYSA-N"),  # So nothing should be changed
+    # Both don't match the parent mass, so nothing should be changed
+    ("C(=O)=O", "InChI=1S/C3H8/c1-3-2/h3H2,1-2H3", "ATUOYWHBWRKTHZ-UHFFFAOYSA-N", 50,
+     "C(=O)=O", "InChI=1S/C3H8/c1-3-2/h3H2,1-2H3", "ATUOYWHBWRKTHZ-UHFFFAOYSA-N"),
 ])
 def test_repair_not_matching_annotation_repair_smiles_inchi(smile, inchi, inchikey, parent_mass,
                                                      correct_smiles, correct_inchi, correct_inchikey):


### PR DESCRIPTION
Before this filter would still repair the smiles from the inchi, if both would actually be incorrect (not matching parent mass).