### PR TITLE
Use poetry version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ In case you feel like you've made a valuable contribution, but you don't know ho
 To create release you need write permission on the repository.
 
 1. Check author list in `citation.cff` and `.zenodo.json` files
-1. Bump the version using `bump2version <major|minor|patch>`. For example, `bump2version major` will increase major version numbers everywhere its needed (code, meta, etc.) in the repo.
+1. Bump the version using `poetry version <major|minor|patch>`. For example, `poetry version major` will increase major version numbers everywhere its needed (code, meta, etc.) in the repo. Alternatively the verion can be manually changed in __version__.py and pyproject.toml
 1. Update the `CHANGELOG.md` to include changes made
 1. Goto [GitHub release page](https://github.com/matchms/matchms/releases)
 1. Press draft a new release button


### PR DESCRIPTION
I think bump2version is not installed anymore when installing the dependencies. Instead I now used poetry version minor. I think this was missed to update in contributing when updating to poetry. 