### PR TITLE
Replace 'List' with 'list'

### DIFF
--- a/matchms/importing/load_from_msp.py
+++ b/matchms/importing/load_from_msp.py
@@ -32,7 +32,7 @@ def load_from_msp(filename: str,
 
         # Download msp file from MassBank of North America repository at https://mona.fiehnlab.ucdavis.edu/
         file_msp = "MoNA-export-GC-MS-first10.msp"
-        spectrums = List(load_from_msp(file_msp))
+        spectrums = list(load_from_msp(file_msp))
     """
 
     for spectrum in parse_msp_file(filename):


### PR DESCRIPTION
If not, the following error will occur.
```
NameError: name 'List' is not defined
```