### PR TITLE
Fix pepmass issue

### DIFF
--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -76,7 +76,7 @@ def _get_mz_intensity_charge(pepmass):
                 try:
                     pepmass = float(pepmass)
                 except ValueError:
-                    return None, None, None
+                    return None, None, None 
         length = len(pepmass)
         values = [None, None, None]
         for i in range(length):

--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -69,8 +69,14 @@ def _get_mz_intensity_charge(pepmass):
         if isinstance(pepmass, str):
             matches = re.findall(r'\(([^)]+)\)', pepmass)
             if len(matches) > 1:
-                raise ValueError("Found more than one tuple in pepmass field.")            
-            pepmass = matches[0].split(",")
+                raise ValueError("Found more than one tuple in pepmass field.")
+            if len(matches) == 1:
+                pepmass = matches[0].split(",")
+            if len(matches) == 0:
+                try:
+                    pepmass = float(pepmass)
+                except ValueError:
+                    return None, None, None
         length = len(pepmass)
         values = [None, None, None]
         for i in range(length):

--- a/tests/filtering/test_interpret_pepmass.py
+++ b/tests/filtering/test_interpret_pepmass.py
@@ -87,8 +87,10 @@ def test_empty_spectrum():
 
 
 @pytest.mark.parametrize("input_pepmass, expected_results", [
- ["(981.54, None)", (981.54, None, None)],
- ["(981.54, 44, -2)", (981.54, 44, -2)],
+    ["(981.54, None)", (981.54, None, None)],
+    ["(981.54, 44, -2)", (981.54, 44, -2)],
+    ["100.2", (100.2, None, None)],
+    ["something_random", (None, None, None)]
 ])
 def test_interpret_pepmass_error_v0_22_0(input_pepmass, expected_results):
     spectrum = SpectrumBuilder().with_metadata({"PEPMASS": input_pepmass}, metadata_harmonization=True).build()
@@ -129,7 +131,7 @@ def test_load_pepmass_error_issue_452():
         "ExactMass": "504.169034944",
         "Comments": comment
     }
-    
+
     mz = np.array([387.3, 387.4, 505, 505.1, 505.2], dtype=np.float64)
     ints = np.array([50, 0, 0, 50, 100], dtype=np.float64)
 


### PR DESCRIPTION
Should fix #584
For cases like pepmass="112.3" the code will currently break, since no match is found with the regex. (there are no brackets). I drafted a quick fix here. @hechth could you check if this is a correct fix? 