### PR TITLE
Don't repeatedly open mgf file when exporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## unreleased
 
+### Changed
+- Speed up save_to_mgf by preventing repetitive file opening
 
 ## [0.24.0] -2023-11-21
 ### Added

--- a/matchms/exporting/save_as_mgf.py
+++ b/matchms/exporting/save_as_mgf.py
@@ -44,14 +44,13 @@ def save_as_mgf(spectrums: List[Spectrum],
         spectrums = [spectrums]
 
     fingerprint_export_warning(spectrums)
-
-    # Convert matchms.Spectrum() into dictionaries for pyteomics
-    for spectrum in spectrums:
-        spectrum_dict = {"m/z array": spectrum.peaks.mz,
-                         "intensity array": spectrum.peaks.intensities,
-                         "params": spectrum.metadata_dict(export_style)}
-        if 'fingerprint' in spectrum_dict["params"]:
-            del spectrum_dict["params"]["fingerprint"]
-        # Append spectrum to file
-        with open(filename, 'a', encoding="utf-8") as out:
-            py_mgf.write(spectrum_dict, out)
+    with open(filename, 'a', encoding="utf-8") as out:
+        # Convert matchms.Spectrum() into dictionaries for pyteomics
+        for spectrum in spectrums:
+            spectrum_dict = {"m/z array": spectrum.peaks.mz,
+                             "intensity array": spectrum.peaks.intensities,
+                             "params": spectrum.metadata_dict(export_style)}
+            if 'fingerprint' in spectrum_dict["params"]:
+                del spectrum_dict["params"]["fingerprint"]
+            # Append spectrum to file
+                py_mgf.write(spectrum_dict, out)

--- a/matchms/exporting/save_as_mgf.py
+++ b/matchms/exporting/save_as_mgf.py
@@ -53,4 +53,4 @@ def save_as_mgf(spectrums: List[Spectrum],
             if 'fingerprint' in spectrum_dict["params"]:
                 del spectrum_dict["params"]["fingerprint"]
             # Append spectrum to file
-                py_mgf.write(spectrum_dict, out)
+            py_mgf.write(spectrum_dict, out)


### PR DESCRIPTION
The exporting to mgf is very slow. >10 min for a library of 100.000 spectra.
It also gives the warning:
UserWarning: Passing a single spectrum to `write()` is discouraged. To write a set of spectra, pass them to `write()` all at once. For more info, see: https://github.com/levitsky/pyteomics/discussions/109.
  warnings.warn("Passing a single spectrum to `write()` is discouraged.
  
We can just use a generator to create the right format and this should speed up the process. (I did not yet try if this actually speeds things up on large test sets, but at least the warning will not be given anymore) 