### PR TITLE
fix bug for empty peak array and add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## unreleased
 
 ### Fixed
+- Fix to handle spectra with empty peak arrays. [#598](https://github.com/matchms/matchms/issues/598)
 - Fix instability introduced in CosineGreedy by `np.argsort`. [#595](https://github.com/matchms/matchms/issues/595)
 
 ### Changed

--- a/matchms/Spectrum.py
+++ b/matchms/Spectrum.py
@@ -105,10 +105,12 @@ class Spectrum:
         return int.from_bytes(bytearray(combined_hash, 'utf-8'), 'big')
 
     def __repr__(self):
+        precursor_mz_str = f"{self.get('precursor_mz', 0.0):.2f}"
         num_peaks = len(self.peaks)
+        if num_peaks == 0:
+            return f"Spectrum(precursor m/z={precursor_mz_str}, no fragments)"
         min_mz = min(self.peaks.mz)
         max_mz = max(self.peaks.mz)
-        precursor_mz_str = f"{self.get('precursor_mz', 0.0):.2f}"
         return f"Spectrum(precursor m/z={precursor_mz_str}, {num_peaks} fragments between {min_mz:.1f} and {max_mz:.1f})"
 
     def __str__(self):

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -142,11 +142,14 @@ def test_spectrum_to_dict_matchms_style(spectrum: Spectrum):
 
 
 def test_spectrum_repr_and_str_method():
+    # Test the __repr__ and __str__ methods.
     spectrum = Spectrum(mz=np.array([1., 2., 3.]), intensities=np.array([0, 0.5, 1.]))
     assert repr(spectrum) == str(spectrum) == "Spectrum(precursor m/z=0.00, 3 fragments between 1.0 and 3.0)"
 
+    # Test if spectra with empty peak arrays are handled correctly:
     spectrum = Spectrum(mz=np.array([]), intensities=np.array([]))
     assert repr(spectrum) == str(spectrum) == "Spectrum(precursor m/z=0.00, no fragments)"
+
 
 def test_spectrum_hash(spectrum: Spectrum):
     assert hash(spectrum) == 382278160858921722, "Expected different hash."

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -141,12 +141,12 @@ def test_spectrum_to_dict_matchms_style(spectrum: Spectrum):
     assert spectrum_dict == expected_dict
 
 
-def test_spectrum_repr_method():
+def test_spectrum_repr_and_str_method():
     spectrum = Spectrum(mz=np.array([1., 2., 3.]), intensities=np.array([0, 0.5, 1.]))
-    assert spectrum.__repr__() == "Spectrum(precursor m/z=0.00, 3 fragments between 1.0 and 3.0)"
+    assert repr(spectrum) == str(spectrum) == "Spectrum(precursor m/z=0.00, 3 fragments between 1.0 and 3.0)"
 
     spectrum = Spectrum(mz=np.array([]), intensities=np.array([]))
-    assert spectrum.__repr__() == "Spectrum(precursor m/z=0.00, no fragments)"
+    assert repr(spectrum) == str(spectrum) == "Spectrum(precursor m/z=0.00, no fragments)"
 
 def test_spectrum_hash(spectrum: Spectrum):
     assert hash(spectrum) == 382278160858921722, "Expected different hash."

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -141,6 +141,13 @@ def test_spectrum_to_dict_matchms_style(spectrum: Spectrum):
     assert spectrum_dict == expected_dict
 
 
+def test_spectrum_repr_method():
+    spectrum = Spectrum(mz=np.array([1., 2., 3.]), intensities=np.array([0, 0.5, 1.]))
+    assert spectrum.__repr__() == "Spectrum(precursor m/z=0.00, 3 fragments between 1.0 and 3.0)"
+
+    spectrum = Spectrum(mz=np.array([]), intensities=np.array([]))
+    assert spectrum.__repr__() == "Spectrum(precursor m/z=0.00, no fragments)"
+
 def test_spectrum_hash(spectrum: Spectrum):
     assert hash(spectrum) == 382278160858921722, "Expected different hash."
     assert spectrum.metadata_hash() == "78c223faa157cc130390", \


### PR DESCRIPTION
Fix to handle spectra with empty peak arrays.

Closes #588 