### PR TITLE
Fix array truth value error in Metadata tests

### DIFF
--- a/matchms/Metadata.py
+++ b/matchms/Metadata.py
@@ -121,9 +121,14 @@ class Metadata:
             metadata_filtered["charge"] = charge_int
 
         invalid_entries = ["", "NA", "N/A", "NaN"]
-        metadata_filtered = {k:v for k,v in metadata_filtered.items() if v not in invalid_entries}
-
-        self.data = metadata_filtered
+        
+        metadata_filtered_ = {}
+        # Necessary to check not isinstance(..., str), since some values are arrays, and `not in`
+        # operator results in iterable, that has an ambiguous truth value
+        for k,v in metadata_filtered.items():
+            if not isinstance(v, str) or v not in invalid_entries:
+                metadata_filtered_[k] = v
+        self.data = metadata_filtered_
 
     # ------------------------------
     # Getters and Setters

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -79,7 +79,7 @@ def find_matches(spec1_mz: np.ndarray, spec2_mz: np.ndarray,
             if mz2 > high_bound:
                 break
             if mz2 < low_bound:
-                lowest_idx = peak2_idx
+                lowest_idx = peak2_idx + 1
             else:
                 matches.append((peak1_idx, peak2_idx))
     return matches

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -79,7 +79,7 @@ def find_matches(spec1_mz: np.ndarray, spec2_mz: np.ndarray,
             if mz2 > high_bound:
                 break
             if mz2 < low_bound:
-                lowest_idx = peak2_idx + 1
+                lowest_idx = peak2_idx
             else:
                 matches.append((peak1_idx, peak2_idx))
     return matches


### PR DESCRIPTION
Tests always fail on `tests/networking/test_SimilarityNetwork.py`, due to `ambiguous array truth value`. This was caused by [this commit](https://github.com/matchms/matchms/commit/658861eb5da346c837cff60e7aa6f87ffa9a888a).  In particular, 

```python
        metadata_filtered = {k:v for k,v in metadata_filtered.items() if v not in invalid_entries}
```

Since `metadata_filtered` has attribute `footprint` which is an `np.ndarray`, `not in` operator causes it to become a boolean array, which can't be evaluated without an `any` or `all`. In this case I solved this by only checking that string entries **are not** in invalid values. 