### PR TITLE
Do not consider lowest_idx again in find_matches

### DIFF
--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -79,7 +79,7 @@ def find_matches(spec1_mz: np.ndarray, spec2_mz: np.ndarray,
             if mz2 > high_bound:
                 break
             if mz2 < low_bound:
-                lowest_idx = peak2_idx
+                lowest_idx = peak2_idx + 1
             else:
                 matches.append((peak1_idx, peak2_idx))
     return matches


### PR DESCRIPTION
When writing an equivalent CUDA kernel for `CosineGreedy`, I've noticed that the algorithm is exactly the same when lowest_idx is not considered again in a loop. This should result in a tad bit less looping in `find_matches`. Relevant code:

```py
    for peak1_idx in range(spec1_mz.shape[0]):
        mz = spec1_mz[peak1_idx]
        low_bound = mz - tolerance
        high_bound = mz + tolerance
        for peak2_idx in range(lowest_idx, spec2_mz.shape[0]):
            mz2 = spec2_mz[peak2_idx] + shift
            if mz2 > high_bound:
                break
            if mz2 < low_bound:
                lowest_idx = peak2_idx + 1 # <--- this is equivalent to just lowest_idx = peak2_idx, but faster
            else:
                matches.append((peak1_idx, peak2_idx))
    return matches
```

The fact that some tests (outside of cosine tests) are failing are due to pr #605 - that is a separate issue.