### PR TITLE
Fix mz boundaries mirror plot

### DIFF
--- a/matchms/plotting/spectrum_plots.py
+++ b/matchms/plotting/spectrum_plots.py
@@ -122,9 +122,9 @@ def plot_spectra_mirror(spec_top,
 
     Parameters
     ----------
-    spec_top: matchms.Spectrum
+    spec_top: matchms.Spectrum.Spectrum
         The spectrum to be plotted on the top.
-    spec_bottom: matchms.Spectrum
+    spec_bottom: matchms.Spectrum.Spectrum
         The spectrum to be plotted on the bottom.
     ax:
         Axes instance on which to plot the spectrum. If None the current Axes
@@ -167,12 +167,10 @@ def plot_spectra_mirror(spec_top,
             np.ceil(spec_bottom.peaks.mz[-1] / 100 + 1) * 100,
         ]
     )
-    
-    # Enforce min_mz and max_mz if provided 
-    if 'max_mz' in spectrum_kws:
-        max_mz = spectrum_kws['max_mz']
-    if 'min_mz' in spectrum_kws:
-        min_mz = spectrum_kws['min_mz']
+
+    # # Enforce min_mz and max_mz if provided
+    max_mz = spectrum_kws.get("max_mz", max_mz)
+    min_mz = spectrum_kws.get("min_mz", min_mz)
 
     ax.set_xlim(min_mz, max_mz)
     ax.yaxis.set_major_locator(mticker.AutoLocator())

--- a/matchms/plotting/spectrum_plots.py
+++ b/matchms/plotting/spectrum_plots.py
@@ -167,6 +167,13 @@ def plot_spectra_mirror(spec_top,
             np.ceil(spec_bottom.peaks.mz[-1] / 100 + 1) * 100,
         ]
     )
+    
+    # Enforce min_mz and max_mz if provided 
+    if 'max_mz' in spectrum_kws:
+        max_mz = spectrum_kws['max_mz']
+    if 'min_mz' in spectrum_kws:
+        min_mz = spectrum_kws['min_mz']
+
     ax.set_xlim(min_mz, max_mz)
     ax.yaxis.set_major_locator(mticker.AutoLocator())
     ax.yaxis.set_minor_locator(mticker.AutoMinorLocator())

--- a/matchms/plotting/spectrum_plots.py
+++ b/matchms/plotting/spectrum_plots.py
@@ -122,9 +122,9 @@ def plot_spectra_mirror(spec_top,
 
     Parameters
     ----------
-    spec_top: matchms.Spectrum.Spectrum
+    spec_top: matchms.Spectrum.Spectrum.Spectrum
         The spectrum to be plotted on the top.
-    spec_bottom: matchms.Spectrum.Spectrum
+    spec_bottom: matchms.Spectrum.Spectrum.Spectrum
         The spectrum to be plotted on the bottom.
     ax:
         Axes instance on which to plot the spectrum. If None the current Axes

--- a/tests/plotting/test_spectrum_plots.py
+++ b/tests/plotting/test_spectrum_plots.py
@@ -1,7 +1,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 from matchms import Spectrum
-from matchms.plotting import plot_spectra_array, plot_spectrum
+from matchms.plotting import plot_spectra_array, plot_spectrum, plot_spectra_mirror
 
 
 def _assert_fig_ok(fig, n_plots, dpi, height):
@@ -20,6 +20,19 @@ def _assert_ax_ok(ax, n_lines, ylim, xlabel, ylabel):
     assert ax.get_ylim() == (0.0, ylim)
     assert ax.get_xlabel() == xlabel
     assert ax.get_ylabel() == ylabel
+
+
+def test_plot_mirror_plot():
+    # Create two random spectrums
+    spec_a = Spectrum(mz=np.array([100, 200, 300, 400.2]),
+                      intensities=np.array([0.5, 0.3, 0.1, 0.05]))
+    spec_b = Spectrum(mz=np.array([10.2, 20.2, 30.2, 40.2, 78.2]),
+                      intensities=np.array([0.5, 0.3, 0.1, 0.05, 3.1]))
+    max_mz = 250
+    min_mz = 60
+    # Boundaries were not applied in the previous coce
+    ax = plot_spectra_mirror(spec_a, spec_b, max_mz=max_mz, min_mz=min_mz)
+    assert ax.get_xlim() == (min_mz, max_mz)
 
 
 def test_plot_spectrum_default():

--- a/tests/plotting/test_spectrum_plots.py
+++ b/tests/plotting/test_spectrum_plots.py
@@ -1,7 +1,8 @@
 import numpy as np
 from matplotlib import pyplot as plt
 from matchms import Spectrum
-from matchms.plotting import plot_spectra_array, plot_spectrum, plot_spectra_mirror
+from matchms.plotting import (plot_spectra_array, plot_spectra_mirror,
+                              plot_spectrum)
 
 
 def _assert_fig_ok(fig, n_plots, dpi, height):


### PR DESCRIPTION
Noticed and fixed by @lionel42 in #607, added test and some linting changes here.

The function plot_spectra_mirror should behave the same as plot_spectrum for the keyword argument min_mz and max_mz.

this pull request provide a quick fix for that.