### PR TITLE
Remove adduct and mol wt wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## unreleased
 
+- Removed option accept_parent_mass_is_mol_wt in Repair_adduct_based_on_smiles
 ## [0.24.1] -2024-01-16
 ### Fixed
 - Fix to handle spectra with empty peak arrays. [#598](https://github.com/matchms/matchms/issues/598)

--- a/matchms/filtering/metadata_processing/repair_adduct_based_on_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_based_on_smiles.py
@@ -27,11 +27,6 @@ def repair_adduct_based_on_smiles(spectrum_in: Spectrum,
     mass_tolerance : float
         Maximum allowed mass difference between the calculated parent mass and the neutral
         monoisotopic mass derived from the SMILES.
-
-    accept_parent_mass_is_mol_wt : bool, optional (default=True)
-        Allows the function to attempt repairing the spectrum's parent mass by assuming it
-        represents the molecule's weight. If True, further checks and corrections are made
-        using `repair_parent_mass_is_mol_wt`.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_adduct_based_on_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_based_on_smiles.py
@@ -3,7 +3,6 @@ from matchms import Spectrum
 from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
     get_monoisotopic_neutral_mass
 from ..filter_utils.load_known_adducts import load_known_adducts
-from .repair_parent_mass_is_mol_wt import repair_parent_mass_is_mol_wt
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/repair_adduct_based_on_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_based_on_smiles.py
@@ -10,8 +10,7 @@ logger = logging.getLogger("matchms")
 
 
 def repair_adduct_based_on_smiles(spectrum_in: Spectrum,
-                                  mass_tolerance: float,
-                                  accept_parent_mass_is_mol_wt: bool = True):
+                                  mass_tolerance: float):
     """
     Corrects the adduct of a spectrum based on its SMILES representation and the precursor m/z.
 
@@ -62,17 +61,12 @@ def repair_adduct_based_on_smiles(spectrum_in: Spectrum,
     smallest_mass_index = mass_differences.idxmin()
     parent_mass = parent_masses[smallest_mass_index]
     adduct = adducts_df.loc[smallest_mass_index]["adduct"]
-    # Change spectrum. This spectrum will only be returned if the mass difference is smaller than mass tolerance
-    changed_spectrum.set("parent_mass", parent_mass)
-    changed_spectrum.set("adduct", adduct)
+
     if mass_differences[smallest_mass_index] < mass_tolerance:
+        # Change spectrum. This spectrum will only be returned if the mass difference is smaller than mass tolerance
+        changed_spectrum.set("parent_mass", parent_mass)
+        changed_spectrum.set("adduct", adduct)
         logger.info("Adduct was set from %s to %s",
                     spectrum_in.get('adduct'), adduct)
         return changed_spectrum
-    if accept_parent_mass_is_mol_wt:
-        changed_spectrum = repair_parent_mass_is_mol_wt(changed_spectrum, mass_tolerance)
-        if abs(changed_spectrum.get("parent_mass") - smiles_mass) < mass_tolerance:
-            logger.info("Adduct was set from %s to %s",
-                        spectrum_in.get('adduct'), adduct)
-            return changed_spectrum
     return spectrum_in

--- a/matchms/filtering/metadata_processing/repair_parent_mass_is_mol_wt.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_is_mol_wt.py
@@ -13,7 +13,8 @@ logger = logging.getLogger("matchms")
 def repair_parent_mass_is_mol_wt(spectrum_in: Spectrum, mass_tolerance: float):
     """Changes the parent mass from molecular mass into monoistopic mass
 
-    Manual entered precursor mz is sometimes wrongly added as Molar weight instead of monoisotopic mass
+    Manual entered parent mass is sometimes wrongly added as Molar weight instead of monoisotopic mass
+    We check if the given parent mass is equal to the Molar weight (based on the
     """
     if spectrum_in is None:
         return None

--- a/tests/filtering/test_repair_adduct/test_repair_adduct_based_on_smiles.py
+++ b/tests/filtering/test_repair_adduct/test_repair_adduct_based_on_smiles.py
@@ -19,7 +19,7 @@ def test_repair_adduct_based_on_smiles_not_mol_wt(precursor_mz, expected_adduct,
     spectrum_in = SpectrumBuilder().with_metadata({"smiles": "C",
                                                    "precursor_mz": precursor_mz,
                                                    "ionmode": ionmode}).build()
-    spectrum_out = repair_adduct_based_on_smiles(spectrum_in, mass_tolerance=0.1, accept_parent_mass_is_mol_wt=False)
+    spectrum_out = repair_adduct_based_on_smiles(spectrum_in, mass_tolerance=0.1)
     assert spectrum_out.get("adduct") == expected_adduct
     assert abs(spectrum_out.get("parent_mass") - 15.9589) < 0.1
 
@@ -31,20 +31,5 @@ def test_repair_adduct_based_on_smiles_not_repaired():
     spectrum_in = SpectrumBuilder().with_metadata({"smiles": "C",
                                                    "precursor_mz": 1000.0,
                                                    "ionmode": "negative"}).build()
-    spectrum_out = repair_adduct_based_on_smiles(spectrum_in, mass_tolerance=0.1, accept_parent_mass_is_mol_wt=False)
+    spectrum_out = repair_adduct_based_on_smiles(spectrum_in, mass_tolerance=0.1)
     assert spectrum_out.get("adduct") is None
-
-
-@pytest.mark.parametrize("precursor_mz, expected_adduct, ionmode",
-                         [(161.228422448, "[M-H]-", "negative"),
-                          (163.228422448, "[M+H]+", "positive"),
-                          ])
-def test_repair_adduct_based_on_smiles_with_mol_wt(precursor_mz, expected_adduct, ionmode):
-    pytest.importorskip("rdkit")
-
-    # CH4 is used as smiles, this has a mass of 16
-    spectrum_in = SpectrumBuilder().with_metadata({"smiles": "CN1CCCC1C2=CN=CC=C2",
-                                                   "precursor_mz": precursor_mz,
-                                                   "ionmode": ionmode}).build()
-    spectrum_out = repair_adduct_based_on_smiles(spectrum_in, mass_tolerance=0.1, accept_parent_mass_is_mol_wt=True)
-    assert spectrum_out.get("adduct") == expected_adduct


### PR DESCRIPTION
We had an option to repair the adduct and a mistakenly added mol_wt at the same time. But this does not make any sense, so I removed the option. 

It does not make sense, since repair_parent_mass_is_mol_wt, will repair wrongly added parent masses if the MolarWeight is used instead of the monoisotopic mass. But this will repair both the precursor_mz and the parent mass. The precursor mz will be updated based on the adduct, or the charge. So repairing an adduct after does not make any sense. 