### PR TITLE
adding colors for mirrror spectra and tests

### DIFF
--- a/matchms/plotting/spectrum_plots.py
+++ b/matchms/plotting/spectrum_plots.py
@@ -115,6 +115,8 @@ def plot_spectrum(spectrum,
 def plot_spectra_mirror(spec_top,
                         spec_bottom,
                         ax: Optional[plt.Axes] = None,
+                        color_top="darkblue",
+                        color_bottom="teal",
                         **spectrum_kws) -> plt.Axes:
     """Mirror plot two MS/MS spectra.
 
@@ -129,6 +131,10 @@ def plot_spectra_mirror(spec_top,
     ax:
         Axes instance on which to plot the spectrum. If None the current Axes
         instance is used.
+    color_top:
+        Set color of peaks in top spectrum.
+    color_bottom:
+        Set color of peaks in bottom spectrum.
     spectrum_kws:
         Keyword arguments for `plot_spectrum()`.
 
@@ -142,12 +148,17 @@ def plot_spectra_mirror(spec_top,
 
     if spectrum_kws is None:
         spectrum_kws = {}
+
+    if 'peak_color' in spectrum_kws:
+        raise ValueError("'peak_color' should not be set for `plot_spectra_mirror`. "
+                         "Use 'color_top' and 'color_bottom' instead.") 
+
     # Top spectrum.
-    plot_spectrum(spec_top, mirror_intensity=False, ax=ax, peak_color="darkblue", **spectrum_kws)
+    plot_spectrum(spec_top, mirror_intensity=False, ax=ax, peak_color=color_top, **spectrum_kws)
     y_max = ax.get_ylim()[1]
 
     # Mirrored bottom spectrum.
-    plot_spectrum(spec_bottom, mirror_intensity=True, ax=ax, peak_color="teal", **spectrum_kws)
+    plot_spectrum(spec_bottom, mirror_intensity=True, ax=ax, peak_color=color_bottom, **spectrum_kws)
     y_min = ax.get_ylim()[0]
     ax.set_ylim(y_min, y_max)
 

--- a/tests/plotting/test_spectrum_plots.py
+++ b/tests/plotting/test_spectrum_plots.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 from matplotlib import pyplot as plt
 from matchms import Spectrum
 from matchms.plotting import (plot_spectra_array, plot_spectra_mirror,

--- a/tests/plotting/test_spectrum_plots.py
+++ b/tests/plotting/test_spectrum_plots.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from matplotlib import pyplot as plt
 from matchms import Spectrum
@@ -34,6 +35,26 @@ def test_plot_mirror_plot():
     # Boundaries were not applied in the previous coce
     ax = plot_spectra_mirror(spec_a, spec_b, max_mz=max_mz, min_mz=min_mz)
     assert ax.get_xlim() == (min_mz, max_mz)
+
+def test_plot_mirror_colors():
+    # Create two random spectrums
+    spec_a = Spectrum(mz=np.array([100., 200.]),
+                      intensities=np.array([0.5, 0.3]))
+    spec_b = Spectrum(mz=np.array([10.2, 20.2, 30.2]),
+                      intensities=np.array([0.5, 0.3, 0.1]))
+
+    # Set specific colors to the top and bottom spectra
+    ax = plot_spectra_mirror(spec_a, spec_b, color_top="red", color_bottom="blue")
+    # Get the color of the lines 
+    all_colors = [line.get_color() for line in ax.get_lines()]
+    assert "red" in all_colors
+    assert "blue" in all_colors
+
+    # Test that it gives proper error if the wrong color argument is given
+    with pytest.raises(ValueError, 
+                       match="'peak_color' should not be set for `plot_spectra_mirror`. "):
+        plot_spectra_mirror(spec_a, spec_b, peak_color="green")
+
 
 
 def test_plot_spectrum_default():


### PR DESCRIPTION
Before it was not possible to change the colors of the spectra in the `plot_spectra_mirror` function.

This PR makes it possible, by adding two arguments `color_top` and `color_bottom` .
In case one tries the argument `peak_color` which can be used for `plot_spectrum`, a meaningful error is raised.

Also includes tests.