### PR TITLE
fix name position

### DIFF
--- a/matchms/plotting/spectrum_plots.py
+++ b/matchms/plotting/spectrum_plots.py
@@ -193,7 +193,7 @@ def plot_spectra_mirror(spec_top,
     name1 = "Spectrum 1" if spec_top.get("compound_name") is None else spec_top.get("compound_name")
     name2 = "Spectrum 2" if spec_bottom.get("compound_name") is None else spec_bottom.get("compound_name")
 
-    x_text = 0.04 * (max_mz - min_mz)
+    x_text = 0.04 * (max_mz - min_mz) + min_mz
     ax.text(x_text, y_max, name1, ha="left", va="top", zorder=2, backgroundcolor="white")
     ax.text(x_text, y_min, name2, ha="left", va="bottom", zorder=2, backgroundcolor="white")
     ax.set_title("Spectrum comparison")


### PR DESCRIPTION
I had the problem with the plot_aigainst function that the labels were not at the correct place when setting min and max mz values , because it assumed the axis starts at 0.


![image](https://github.com/matchms/matchms/assets/43442120/b2343f3f-c7df-49e5-90c2-deafd97e83c1)


This very small fix makes it work by offsetting the labels to min_mz