### PR TITLE
Update numba and numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ pillow = "!=9.4.0"
 lxml = "^4.9.3"
 matplotlib = "^3.7.2"
 networkx = "^3.1"
-numba = ">=0.57.1,<0.60",
+numba = ">=0.57.1,<0.60"
 pickydict = "^0.4.0"
 pyteomics = "^4.6"
 requests = "^2.31.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,14 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-numpy = "<1.25"
+numpy = "<1.27"
 scipy = "<1.11"
 pandas = "^2.0.3"
 pillow = "!=9.4.0"
 lxml = "^4.9.3"
 matplotlib = "^3.7.2"
 networkx = "^3.1"
-numba = "^0.57.1"
+numba = ">=0.57.1,<0.60",
 pickydict = "^0.4.0"
 pyteomics = "^4.6"
 requests = "^2.31.0"


### PR DESCRIPTION
- Allow numba up to `<0.60` and numpy up to `<1.27`.
(Helps because Pandas 2.0 requires numpy > 1.25)