### PR TITLE
IndexError in `.matrix` when all scores are 0

### DIFF
--- a/matchms/similarity/BaseSimilarity.py
+++ b/matchms/similarity/BaseSimilarity.py
@@ -85,8 +85,8 @@ class BaseSimilarity:
                         idx_col.append(i_query)
                         scores.append(score)
 
-        idx_row = np.array(idx_row)
-        idx_col = np.array(idx_col)
+        idx_row = np.array(idx_row, dtype=int)
+        idx_col = np.array(idx_col, dtype=int)
         scores_data = np.array(scores, dtype=self.score_datatype)
         # TODO: make StackedSpareseArray the default and add fixed function to output different formats (with code below)
         if array_type == "numpy":

--- a/matchms/similarity/BaseSimilarity.py
+++ b/matchms/similarity/BaseSimilarity.py
@@ -85,8 +85,8 @@ class BaseSimilarity:
                         idx_col.append(i_query)
                         scores.append(score)
 
-        idx_row = np.array(idx_row, dtype=int)
-        idx_col = np.array(idx_col, dtype=int)
+        idx_row = np.array(idx_row, dtype=np.int_)
+        idx_col = np.array(idx_col, dtype=np.int_)
         scores_data = np.array(scores, dtype=self.score_datatype)
         # TODO: make StackedSpareseArray the default and add fixed function to output different formats (with code below)
         if array_type == "numpy":

--- a/tests/similarity/test_cosine_greedy.py
+++ b/tests/similarity/test_cosine_greedy.py
@@ -88,3 +88,14 @@ def test_cosine_greedy_matrix_unsymmetric_error():
 
     with pytest.raises(ValueError, match="unequal number of spectra"):
         CosineGreedy().matrix([spectrum_1, spectrum_2], [spectrum_2], is_symmetric=True)
+
+def test_cosine_greedy_matrix_none_matching():
+    builder = SpectrumBuilder()
+    spectrum_1 = builder.with_mz(np.array([100, 200, 300], dtype="float")).with_intensities(
+        np.array([0.1, 0.2, 1.0], dtype="float")).build()
+
+    spectrum_2 = builder.with_mz(np.array([50, 60, 70], dtype="float")).with_intensities(
+        np.array([0.5, 0.2, 1.0], dtype="float")).build()
+    
+    scores = CosineGreedy().matrix([spectrum_1], [spectrum_2])
+    assert scores['score'][0][0] == 0.0, "Expected a single score of exactly 0.0."


### PR DESCRIPTION
Using .matrix of any similarity, when none of the scores are > 0, gets us an index error. Specifically:

```py

from matchms.similarity import CosineGreedy
from ..builder_Spectrum import SpectrumBuilder

builder = SpectrumBuilder()
spectrum_1 = builder.with_mz(np.array([100, 200, 300], dtype="float")).with_intensities(
    np.array([0.1, 0.2, 1.0], dtype="float")).build()

spectrum_2 = builder.with_mz(np.array([50, 60, 70], dtype="float")).with_intensities(
    np.array([0.5, 0.2, 1.0], dtype="float")).build()

scores = CosineGreedy().matrix([spectrum_1], [spectrum_2]) # IndexError
```

Will give an index error. This PR adds testcase, and a fix for this.