### PR TITLE
Change scipy dependency to fix breakage in spec2vec / gensim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
 numpy = ">1.24"
-scipy = "^1.14.1"
+scipy = "<1.14.0"
 pandas = "^2.2.3"
 pillow = "!=9.4.0"
 lxml = "^4.9.3"


### PR DESCRIPTION
Installing matchms (`scipy^1.14.0`) with spec2vec leads to a dependency break because spec2vec depends on gensim, which requires scipy<1.14.0:

`gensim 4.3.3 requires scipy<1.14.0,>=1.7.0, but you have scipy 1.14.1 which is incompatible.`