### PR TITLE
allows users to save mgf files in write mode as well as well as append mode

### DIFF
--- a/matchms/exporting/save_as_mgf.py
+++ b/matchms/exporting/save_as_mgf.py
@@ -8,7 +8,9 @@ from ..utils import (filter_empty_spectra, fingerprint_export_warning,
 @rename_deprecated_params(param_mapping={"spectrums": "spectra"}, version="0.26.5")
 def save_as_mgf(spectra: Union[List[Spectrum], Spectrum],
                 filename: str,
-                export_style: str = "matchms"):
+                export_style: str = "matchms",
+                file_mode: str = "a",
+                ) -> None:
     """Save spectrum(s) as mgf file.
 
     Example:
@@ -38,6 +40,9 @@ def save_as_mgf(spectra: Union[List[Spectrum], Spectrum],
     export_style:
         Converts the keys to the required export style. One of ["matchms", "massbank", "nist", "riken", "gnps"].
         Default is "matchms"
+    file_mode: str
+        This is an optional parameter which defines the mode the file will be opened in.  
+        Default is "a" (append). The other option is "w" (write). If set worngly it will default to "a".
     """
     if not isinstance(spectra, list):
         # Assume that input was single Spectrum
@@ -55,5 +60,6 @@ def save_as_mgf(spectra: Union[List[Spectrum], Spectrum],
             if 'fingerprint' in spectrum_dict["params"]:
                 del spectrum_dict["params"]["fingerprint"]
             yield spectrum_dict
-
-    py_mgf.write(spectrum_dict_generator(spectra), filename, file_mode="a", encoding="utf-8")
+    if file_mode not in ["a", "w"]:
+        file_mode = "a"
+    py_mgf.write(spectrum_dict_generator(spectra), filename, file_mode=file_mode, encoding="utf-8")

--- a/tests/exporting/test_save_as_mgf.py
+++ b/tests/exporting/test_save_as_mgf.py
@@ -28,10 +28,13 @@ def test_save_as_mgf_single_spectrum():
     # Write to test file
     with tempfile.TemporaryDirectory() as d:
         filename = os.path.join(d, "test.mgf")
+        filename2 = os.path.join(d, "test2.mgf")
         save_as_mgf(spectrum, filename)
+        save_as_mgf(spectrum, filename2, file_mode="w")
 
         # test if file exists
         assert os.path.isfile(filename)
+        assert os.path.isfile(filename2)
 
         # Test if content of mgf file is correct
         with open(filename, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Describe your changes
Added functionality that allows users to add a file_mode when writing .mgf files.

## Issue ticket number and link
https://github.com/matchms/matchms/issues/726

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests to see if it is a core feature.
