### PR TITLE
`normalize_intensities` no longer sets Spectrum to None

### DIFF
--- a/matchms/filtering/peak_processing/normalize_intensities.py
+++ b/matchms/filtering/peak_processing/normalize_intensities.py
@@ -21,9 +21,8 @@ def normalize_intensities(spectrum_in: SpectrumType) -> SpectrumType:
     max_intensity = np.max(spectrum.peaks.intensities)
 
     if max_intensity <= 0:
-        logger.warning("Peak intensities of spectrum with all peak intensities <= 0 were set to 0.")
-        zero_intensities = np.zeros(spectrum.peaks.intensities.shape)
-        spectrum.peaks = Fragments(mz=spectrum.peaks.mz, intensities=zero_intensities)
+        logger.warning("Peaks of spectrum with all peak intensities <= 0 were deleted.")
+        spectrum.peaks = Fragments(mz=np.array([]), intensities=np.array([]))
         return spectrum
 
     # Normalize peak intensities

--- a/matchms/filtering/peak_processing/normalize_intensities.py
+++ b/matchms/filtering/peak_processing/normalize_intensities.py
@@ -21,8 +21,10 @@ def normalize_intensities(spectrum_in: SpectrumType) -> SpectrumType:
     max_intensity = np.max(spectrum.peaks.intensities)
 
     if max_intensity <= 0:
-        logger.warning("Spectrum with all peak intensities <= 0 was set to None.")
-        return None
+        logger.warning("Peak intensities of spectrum with all peak intensities <= 0 were set to 0.")
+        zero_intensities = np.zeros(spectrum.peaks.intensities.shape)
+        spectrum.peaks = Fragments(mz=spectrum.peaks.mz, intensities=zero_intensities)
+        return spectrum
 
     # Normalize peak intensities
     mz, intensities = spectrum.peaks.mz, spectrum.peaks.intensities

--- a/tests/filtering/test_normalize_intensities.py
+++ b/tests/filtering/test_normalize_intensities.py
@@ -52,9 +52,9 @@ def test_normalize_intensities_all_zeros(caplog):
 
     spectrum = normalize_intensities(spectrum_in)
 
-    assert sum(spectrum.peaks.intensities) == 0.0, "Expected spectrum peak intensities to be set to 0."
-    assert max(spectrum.peaks.intensities) == 0.0, "Expected maximum spectrum peak intensity to be 0"
-    msg = "Peak intensities of spectrum with all peak intensities <= 0 were set to 0."
+    assert len(spectrum.peaks.intensities) == 0, "Expected no peak intensities."
+    assert len(spectrum.peaks.mz) == 0, "Expected no m/z values. "
+    msg = "Peaks of spectrum with all peak intensities <= 0 were deleted."
     assert msg in caplog.text, "Expected log message."
 
 

--- a/tests/filtering/test_normalize_intensities.py
+++ b/tests/filtering/test_normalize_intensities.py
@@ -52,8 +52,9 @@ def test_normalize_intensities_all_zeros(caplog):
 
     spectrum = normalize_intensities(spectrum_in)
 
-    assert spectrum is None, "Expected spectrum to be set to None."
-    msg = "Spectrum with all peak intensities <= 0 was set to None."
+    assert sum(spectrum.peaks.intensities) == 0.0, "Expected spectrum peak intensities to be set to 0."
+    assert max(spectrum.peaks.intensities) == 0.0, "Expected maximum spectrum peak intensity to be 0"
+    msg = "Peak intensities of spectrum with all peak intensities <= 0 were set to 0."
     assert msg in caplog.text, "Expected log message."
 
 


### PR DESCRIPTION
When a spectrum with only negative peak intensities is passed to `normalize_intensities` the peak intensities are all set to 0 and the spectrum is returned. Previously the function returned None in that case. 

Should fix #735