### PR TITLE
Fix/speedup filters

### DIFF
--- a/matchms/filtering/SpectrumProcessor.py
+++ b/matchms/filtering/SpectrumProcessor.py
@@ -232,6 +232,8 @@ class SpectrumProcessor:
                 raise FileExistsError("The specified save references file already exists")
             ftype = os.path.splitext(cleaned_spectra_file)[1].lower()[1:]
             incremental_save = ftype in ('mgf', 'msp')
+        else:
+            incremental_save = False
 
         if not self.filters:
             logger.warning("No filters have been specified, so spectra were not filtered")

--- a/matchms/filtering/SpectrumProcessor.py
+++ b/matchms/filtering/SpectrumProcessor.py
@@ -158,8 +158,11 @@ class SpectrumProcessor:
         for filter_func in self.filters:
             method_params = inspect.signature(filter_func).parameters
 
-            if clone and "clone" not in method_params:
-                logger.error("Processing report is set to True, but the filter function %s does not support cloning.", filter_func.__name__)
+            if not filter_func.__name__.startswith("require_"):
+                if clone and "clone" not in method_params:
+                    logger.error(
+                        "Processing report is set to True, but the filter function %s does not support cloning.",
+                        filter_func.__name__)
 
             # Ensures that filter function can be used, even if it does not support cloning
             spectrum_out = filter_func(spectrum, **({"clone": clone} if "clone" in method_params else {}))

--- a/matchms/filtering/SpectrumProcessor.py
+++ b/matchms/filtering/SpectrumProcessor.py
@@ -153,7 +153,7 @@ class SpectrumProcessor:
         if processing_report is not None:
             processing_report.counter_number_processed += 1
         for filter_func in self.filters:
-            spectrum_out = filter_func(spectrum)
+            spectrum_out = filter_func(spectrum, clone=False)
             if processing_report is not None:
                 processing_report.add_to_report(spectrum, spectrum_out, filter_func.__name__)
             if spectrum_out is None:
@@ -229,7 +229,8 @@ class SpectrumProcessor:
         for s in tqdm(spectra, disable=(not progress_bar), desc="Processing spectra"):
             if s is None:
                 continue  # empty spectra will be discarded
-            processed_spectrum = self.process_spectrum(s, processing_report)
+            spectrum = s.clone()
+            processed_spectrum = self.process_spectrum(spectrum, processing_report)
             if processed_spectrum is not None:
                 processed_spectra.append(processed_spectrum)
 

--- a/matchms/filtering/metadata_processing/add_compound_name.py
+++ b/matchms/filtering/metadata_processing/add_compound_name.py
@@ -7,7 +7,7 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def add_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def add_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Add compound_name to correct field: "compound_name" in metadata.
 
     Parameters

--- a/matchms/filtering/metadata_processing/add_compound_name.py
+++ b/matchms/filtering/metadata_processing/add_compound_name.py
@@ -16,6 +16,11 @@ def add_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True) -
         Input spectrum.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added compound name, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/add_compound_name.py
+++ b/matchms/filtering/metadata_processing/add_compound_name.py
@@ -8,7 +8,15 @@ logger = logging.getLogger("matchms")
 
 
 def add_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
-    """Add compound_name to correct field: "compound_name" in metadata."""
+    """Add compound_name to correct field: "compound_name" in metadata.
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
+    """
     if spectrum_in is None:
         return None
 

--- a/matchms/filtering/metadata_processing/add_compound_name.py
+++ b/matchms/filtering/metadata_processing/add_compound_name.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Optional
-
 from matchms.typing import SpectrumType
 
 

--- a/matchms/filtering/metadata_processing/add_compound_name.py
+++ b/matchms/filtering/metadata_processing/add_compound_name.py
@@ -1,16 +1,18 @@
 import logging
+from typing import Optional
+
 from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")
 
 
-def add_compound_name(spectrum_in: SpectrumType) -> SpectrumType:
+def add_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Add compound_name to correct field: "compound_name" in metadata."""
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if spectrum.get("compound_name", None) is None:
         if isinstance(spectrum.get("name", None), str):

--- a/matchms/filtering/metadata_processing/add_fingerprint.py
+++ b/matchms/filtering/metadata_processing/add_fingerprint.py
@@ -26,6 +26,8 @@ def add_fingerprint(spectrum_in: Optional[SpectrumType], fingerprint_type: str =
         are "daylight", "morgan1", "morgan2", "morgan3". Default is "daylight".
     nbits:
         Dimension or number of bits of generated fingerprint. Default is 2048.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/add_fingerprint.py
+++ b/matchms/filtering/metadata_processing/add_fingerprint.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("matchms")
 
 
 def add_fingerprint(spectrum_in: Optional[SpectrumType], fingerprint_type: str = "daylight",
-                    nbits: int = 2048) -> Optional[SpectrumType]:
+                    nbits: int = 2048, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Add molecular finterprint to spectrum.
 
     If smiles or inchi present in metadata, derive a molecular finterprint and
@@ -30,7 +30,7 @@ def add_fingerprint(spectrum_in: Optional[SpectrumType], fingerprint_type: str =
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     # First try to get fingerprint from smiles
     if spectrum.get("smiles", None):

--- a/matchms/filtering/metadata_processing/add_fingerprint.py
+++ b/matchms/filtering/metadata_processing/add_fingerprint.py
@@ -28,6 +28,11 @@ def add_fingerprint(spectrum_in: Optional[SpectrumType], fingerprint_type: str =
         Dimension or number of bits of generated fingerprint. Default is 2048.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added fingerprint derived from SMILES or INCHI, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/add_parent_mass.py
+++ b/matchms/filtering/metadata_processing/add_parent_mass.py
@@ -19,7 +19,7 @@ _accepted_missing_entries = ["", "N/A", "NA", "n/a"]
 
 def add_parent_mass(spectrum_in: Spectrum, estimate_from_adduct: bool = True,
                     overwrite_existing_entry: bool = False,
-                    estimate_from_charge: bool = True) -> Optional[Spectrum]:
+                    estimate_from_charge: bool = True, clone: Optional[bool] = True) -> Optional[Spectrum]:
     """Add estimated parent mass to metadata (if not present yet).
 
     Method to calculate the parent mass from given precursor m/z together
@@ -46,7 +46,7 @@ def add_parent_mass(spectrum_in: Spectrum, estimate_from_adduct: bool = True,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     parent_mass = _get_parent_mass(spectrum.metadata)
     if parent_mass is not None and not overwrite_existing_entry:

--- a/matchms/filtering/metadata_processing/add_parent_mass.py
+++ b/matchms/filtering/metadata_processing/add_parent_mass.py
@@ -31,17 +31,19 @@ def add_parent_mass(spectrum_in: Spectrum, estimate_from_adduct: bool = True,
 
     Parameters
     ----------
-    spectrum_in
+    spectrum_in:
         Input spectrum.
-    estimate_from_adduct
+    estimate_from_adduct:
         When set to True, use adduct to estimate actual molecular mass ("parent mass").
         Default is True. Switches back to charge-based estimate if adduct does not match
         a known adduct.
-    overwrite_existing_entry
+    overwrite_existing_entry:
         Default is False. If set to True, a newly computed value will replace existing ones.
-    estimate_from_charge
+    estimate_from_charge:
         Default is True. If set to True, the charge will be used to estimate the parent mass.
         Adduct of the form [M+H]+, [M+H]2+, [M-H]- etc are assumed.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/add_parent_mass.py
+++ b/matchms/filtering/metadata_processing/add_parent_mass.py
@@ -44,6 +44,11 @@ def add_parent_mass(spectrum_in: Spectrum, estimate_from_adduct: bool = True,
         Adduct of the form [M+H]+, [M+H]2+, [M-H]- etc are assumed.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added parent mass, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/add_parent_mass.py
+++ b/matchms/filtering/metadata_processing/add_parent_mass.py
@@ -3,6 +3,7 @@ from typing import Optional
 from matchms.filtering.filter_utils.derive_precursor_mz_and_parent_mass import \
     derive_parent_mass_from_precursor_mz
 from matchms.Spectrum import Spectrum
+from matchms.typing import SpectrumType
 from ...utils import get_first_common_element
 from ..filter_utils.get_neutral_mass_from_smiles import \
     get_monoisotopic_neutral_mass
@@ -19,7 +20,7 @@ _accepted_missing_entries = ["", "N/A", "NA", "n/a"]
 
 def add_parent_mass(spectrum_in: Spectrum, estimate_from_adduct: bool = True,
                     overwrite_existing_entry: bool = False,
-                    estimate_from_charge: bool = True, clone: Optional[bool] = True) -> Optional[Spectrum]:
+                    estimate_from_charge: bool = True, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Add estimated parent mass to metadata (if not present yet).
 
     Method to calculate the parent mass from given precursor m/z together

--- a/matchms/filtering/metadata_processing/add_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/add_precursor_mz.py
@@ -13,7 +13,7 @@ _accepted_types = (float, str, int)
 _accepted_missing_entries = ["", "N/A", "NA", "n/a"]
 
 
-def add_precursor_mz(spectrum_in, clone: Optional[bool] = True):
+def add_precursor_mz(spectrum_in, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Add precursor_mz to correct field and make it a float.
 
     For missing precursor_mz field: check if there is "pepmass"" entry instead.

--- a/matchms/filtering/metadata_processing/add_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/add_precursor_mz.py
@@ -25,6 +25,11 @@ def add_precursor_mz(spectrum_in, clone: Optional[bool] = True) -> Optional[Spec
         Input spectrum.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added precursor mz metadata, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/add_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/add_precursor_mz.py
@@ -18,6 +18,13 @@ def add_precursor_mz(spectrum_in, clone: Optional[bool] = True):
 
     For missing precursor_mz field: check if there is "pepmass"" entry instead.
     For string parsed as precursor_mz: convert to float.
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/add_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/add_precursor_mz.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms.utils import get_first_common_element
 
 
@@ -11,7 +13,7 @@ _accepted_types = (float, str, int)
 _accepted_missing_entries = ["", "N/A", "NA", "n/a"]
 
 
-def add_precursor_mz(spectrum_in):
+def add_precursor_mz(spectrum_in, clone: Optional[bool] = True):
     """Add precursor_mz to correct field and make it a float.
 
     For missing precursor_mz field: check if there is "pepmass"" entry instead.
@@ -20,7 +22,7 @@ def add_precursor_mz(spectrum_in):
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     metadata_updated = _add_precursor_mz_metadata(spectrum.metadata)
     spectrum.metadata = metadata_updated

--- a/matchms/filtering/metadata_processing/add_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/add_precursor_mz.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Optional
-
+from matchms.typing import SpectrumType
 from matchms.utils import get_first_common_element
 
 

--- a/matchms/filtering/metadata_processing/add_retention.py
+++ b/matchms/filtering/metadata_processing/add_retention.py
@@ -98,7 +98,7 @@ def _add_retention(metadata: dict, target_key: str, accepted_keys: List[str]) ->
     return metadata
 
 
-def add_retention_time(spectrum_in: SpectrumType) -> SpectrumType:
+def add_retention_time(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Add retention time information to the 'retention_time' key as float.
     Negative values and those not convertible to a float result in 'retention_time'
     being 'None'.
@@ -115,14 +115,14 @@ def add_retention_time(spectrum_in: SpectrumType) -> SpectrumType:
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     target_key = "retention_time"
     spectrum.metadata = _add_retention(spectrum.metadata, target_key, _retention_time_keys)
     return spectrum
 
 
-def add_retention_index(spectrum_in: SpectrumType) -> SpectrumType:
+def add_retention_index(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Add retention index into 'retention_index' key if present.
 
 
@@ -137,7 +137,7 @@ def add_retention_index(spectrum_in: SpectrumType) -> SpectrumType:
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     target_key = "retention_index"
     spectrum.metadata = _add_retention(spectrum.metadata, target_key, _retention_index_keys)

--- a/matchms/filtering/metadata_processing/add_retention.py
+++ b/matchms/filtering/metadata_processing/add_retention.py
@@ -105,8 +105,10 @@ def add_retention_time(spectrum_in: SpectrumType, clone: Optional[bool] = True) 
 
     Parameters
     ----------
-    spectrum
+    spectrum_in:
         Spectrum with retention time information.
+    clone:
+        Optionally clone the Spectrum.
 
     Returns
     -------
@@ -128,8 +130,10 @@ def add_retention_index(spectrum_in: SpectrumType, clone: Optional[bool] = True)
 
     Parameters
     ----------
-    spectrum
+    spectrum_in:
         Spectrum with RI information.
+    clone:
+        Optionally clone the Spectrum.
     Returns
     -------
     Spectrum with RI info stored under 'retention_index'.

--- a/matchms/filtering/metadata_processing/add_retention.py
+++ b/matchms/filtering/metadata_processing/add_retention.py
@@ -98,7 +98,7 @@ def _add_retention(metadata: dict, target_key: str, accepted_keys: List[str]) ->
     return metadata
 
 
-def add_retention_time(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def add_retention_time(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Add retention time information to the 'retention_time' key as float.
     Negative values and those not convertible to a float result in 'retention_time'
     being 'None'.
@@ -124,7 +124,7 @@ def add_retention_time(spectrum_in: SpectrumType, clone: Optional[bool] = True) 
     return spectrum
 
 
-def add_retention_index(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def add_retention_index(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Add retention index into 'retention_index' key if present.
 
 

--- a/matchms/filtering/metadata_processing/clean_adduct.py
+++ b/matchms/filtering/metadata_processing/clean_adduct.py
@@ -21,6 +21,11 @@ def clean_adduct(spectrum_in, clone: Optional[bool] = True) -> Optional[Spectrum
         Matchms Spectrum object.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with cleaned adduct, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/clean_adduct.py
+++ b/matchms/filtering/metadata_processing/clean_adduct.py
@@ -17,8 +17,10 @@ def clean_adduct(spectrum_in, clone: Optional[bool] = True):
 
     Parameters
     ----------
-    spectrum_in
+    spectrum_in:
         Matchms Spectrum object.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/clean_adduct.py
+++ b/matchms/filtering/metadata_processing/clean_adduct.py
@@ -11,7 +11,7 @@ from matchms.filtering.filter_utils.load_known_adducts import \
 logger = logging.getLogger("matchms")
 
 
-def clean_adduct(spectrum_in, clone: Optional[bool] = True):
+def clean_adduct(spectrum_in, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Clean adduct and make it consistent in style.
     Will transform adduct strings of type 'M+H+' to '[M+H]+'.
 

--- a/matchms/filtering/metadata_processing/clean_adduct.py
+++ b/matchms/filtering/metadata_processing/clean_adduct.py
@@ -1,5 +1,7 @@
 import logging
 import re
+from typing import Optional
+
 from matchms.filtering.filter_utils.interpret_unknown_adduct import \
     get_charge_of_adduct
 from matchms.filtering.filter_utils.load_known_adducts import \
@@ -9,7 +11,7 @@ from matchms.filtering.filter_utils.load_known_adducts import \
 logger = logging.getLogger("matchms")
 
 
-def clean_adduct(spectrum_in):
+def clean_adduct(spectrum_in, clone: Optional[bool] = True):
     """Clean adduct and make it consistent in style.
     Will transform adduct strings of type 'M+H+' to '[M+H]+'.
 
@@ -23,7 +25,8 @@ def clean_adduct(spectrum_in):
     adduct = spectrum_in.get("adduct")
     if adduct is None:
         return spectrum_in
-    spectrum = spectrum_in.clone()
+
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     cleaned_adduct = _clean_adduct(adduct, spectrum.get('charge'))
 

--- a/matchms/filtering/metadata_processing/clean_adduct.py
+++ b/matchms/filtering/metadata_processing/clean_adduct.py
@@ -1,11 +1,11 @@
 import logging
 import re
 from typing import Optional
-
 from matchms.filtering.filter_utils.interpret_unknown_adduct import \
     get_charge_of_adduct
 from matchms.filtering.filter_utils.load_known_adducts import \
     load_known_adduct_conversions
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/clean_compound_name.py
+++ b/matchms/filtering/metadata_processing/clean_compound_name.py
@@ -20,6 +20,11 @@ def clean_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True)
         Matchms Spectrum object.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with cleaned compound name, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/clean_compound_name.py
+++ b/matchms/filtering/metadata_processing/clean_compound_name.py
@@ -1,7 +1,6 @@
 import logging
 import re
 from typing import Optional
-
 from matchms.typing import SpectrumType
 
 

--- a/matchms/filtering/metadata_processing/clean_compound_name.py
+++ b/matchms/filtering/metadata_processing/clean_compound_name.py
@@ -1,12 +1,14 @@
 import logging
 import re
+from typing import Optional
+
 from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")
 
 
-def clean_compound_name(spectrum_in: SpectrumType) -> SpectrumType:
+def clean_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Clean compound name.
 
     A list of frequently seen name additions that do not belong to the compound
@@ -15,7 +17,7 @@ def clean_compound_name(spectrum_in: SpectrumType) -> SpectrumType:
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if spectrum.get("compound_name", None) is not None:
         name = spectrum.get("compound_name")

--- a/matchms/filtering/metadata_processing/clean_compound_name.py
+++ b/matchms/filtering/metadata_processing/clean_compound_name.py
@@ -8,7 +8,7 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def clean_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def clean_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Clean compound name.
 
     A list of frequently seen name additions that do not belong to the compound

--- a/matchms/filtering/metadata_processing/clean_compound_name.py
+++ b/matchms/filtering/metadata_processing/clean_compound_name.py
@@ -13,6 +13,13 @@ def clean_compound_name(spectrum_in: SpectrumType, clone: Optional[bool] = True)
 
     A list of frequently seen name additions that do not belong to the compound
     name will be removed.
+
+    Parameters
+    ----------
+    spectrum_in:
+        Matchms Spectrum object.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/correct_charge.py
+++ b/matchms/filtering/metadata_processing/correct_charge.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Optional
-
 import numpy as np
 from matchms.typing import SpectrumType
 

--- a/matchms/filtering/metadata_processing/correct_charge.py
+++ b/matchms/filtering/metadata_processing/correct_charge.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 import numpy as np
 from matchms.typing import SpectrumType
 
@@ -6,7 +8,7 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def correct_charge(spectrum_in: SpectrumType) -> SpectrumType:
+def correct_charge(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Correct charge values based on given ionmode.
 
     For some spectra, the charge value is either undefined or inconsistent with its
@@ -21,7 +23,7 @@ def correct_charge(spectrum_in: SpectrumType) -> SpectrumType:
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     ionmode = spectrum.get("ionmode", None)
     if ionmode:

--- a/matchms/filtering/metadata_processing/correct_charge.py
+++ b/matchms/filtering/metadata_processing/correct_charge.py
@@ -20,6 +20,11 @@ def correct_charge(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> O
         Input spectrum.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with corrected charge derived from ionmode, or `None` if not present.
     """
 
     if spectrum_in is None:

--- a/matchms/filtering/metadata_processing/correct_charge.py
+++ b/matchms/filtering/metadata_processing/correct_charge.py
@@ -8,7 +8,7 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def correct_charge(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def correct_charge(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Correct charge values based on given ionmode.
 
     For some spectra, the charge value is either undefined or inconsistent with its

--- a/matchms/filtering/metadata_processing/correct_charge.py
+++ b/matchms/filtering/metadata_processing/correct_charge.py
@@ -16,8 +16,10 @@ def correct_charge(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> S
 
     Parameters
     ----------
-    spectrum_in
+    spectrum_in:
         Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
     """
 
     if spectrum_in is None:

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -23,6 +23,8 @@ def derive_adduct_from_name(spectrum_in: Spectrum,
         Input spectrum.
     remove_adduct_from_name:
         Remove found adducts from compound name if set to True. Default is True.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from matchms.filtering.filter_utils.interpret_unknown_adduct import \
     get_multiplier_and_mass_from_adduct
 from matchms.Spectrum import Spectrum
+from matchms.typing import SpectrumType
 from ..filter_utils.load_known_adducts import load_known_adducts
 from .clean_adduct import _clean_adduct
 
@@ -12,7 +13,7 @@ logger = logging.getLogger("matchms")
 
 
 def derive_adduct_from_name(spectrum_in: Spectrum,
-                            remove_adduct_from_name: bool = True, clone: Optional[bool] = True) -> Optional[Spectrum]:
+                            remove_adduct_from_name: bool = True, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Find adduct in compound name and add to metadata (if not present yet).
 
     Method to interpret the given compound name to find the adduct.

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("matchms")
 
 
 def derive_adduct_from_name(spectrum_in: Spectrum,
-                            remove_adduct_from_name: bool = True) -> Optional[Spectrum]:
+                            remove_adduct_from_name: bool = True, clone: Optional[bool] = True) -> Optional[Spectrum]:
     """Find adduct in compound name and add to metadata (if not present yet).
 
     Method to interpret the given compound name to find the adduct.
@@ -27,7 +27,7 @@ def derive_adduct_from_name(spectrum_in: Spectrum,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     compound_name = spectrum.get("compound_name", None)
     if compound_name is None:

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -25,6 +25,11 @@ def derive_adduct_from_name(spectrum_in: Spectrum,
         Remove found adducts from compound name if set to True. Default is True.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added adduct, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
+++ b/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("matchms")
 
 def derive_annotation_from_compound_name(spectrum_in: Spectrum,
                                          annotated_compound_names_file: Optional[str] = None,
-                                         mass_tolerance: float = 0.1, clone: Optional[bool] = True):
+                                         mass_tolerance: float = 0.1, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Adds smiles, inchi, inchikey based on compound name by searching pubchem
 
     This filter is only run, if there is not yet a valid smiles or inchi in the metadata.

--- a/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
+++ b/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
@@ -37,6 +37,8 @@ def derive_annotation_from_compound_name(spectrum_in: Spectrum,
         The csv file should contain the columns ["compound_name", "smiles", "inchi", "inchikey", "monoisotopic_mass"]
     mass_tolerance:
         Acceptable mass difference between query compound and pubchem result.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
+++ b/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("matchms")
 
 def derive_annotation_from_compound_name(spectrum_in: Spectrum,
                                          annotated_compound_names_file: Optional[str] = None,
-                                         mass_tolerance: float = 0.1):
+                                         mass_tolerance: float = 0.1, clone: Optional[bool] = True):
     """Adds smiles, inchi, inchikey based on compound name by searching pubchem
 
     This filter is only run, if there is not yet a valid smiles or inchi in the metadata.
@@ -40,7 +40,9 @@ def derive_annotation_from_compound_name(spectrum_in: Spectrum,
     """
     if spectrum_in is None:
         return None
-    spectrum = spectrum_in.clone()
+
+    spectrum = spectrum_in.clone() if clone else spectrum_in
+
     # Only run this function if it does not yet have a useful annotation
     if is_valid_inchi(spectrum.get("inchi")) or is_valid_smiles(spectrum.get("smiles")):
         return spectrum

--- a/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
+++ b/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
@@ -12,6 +12,7 @@ import pubchempy
 from matchms import Spectrum
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     is_valid_inchi, is_valid_inchikey, is_valid_smiles)
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
+++ b/matchms/filtering/metadata_processing/derive_annotation_from_compound_name.py
@@ -39,6 +39,11 @@ def derive_annotation_from_compound_name(spectrum_in: Spectrum,
         Acceptable mass difference between query compound and pubchem result.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added annotation, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/derive_formula_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_name.py
@@ -24,6 +24,11 @@ def derive_formula_from_name(spectrum_in: SpectrumType,
         Remove found formula from compound name if set to True. Default is True.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with cleaned formula, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/derive_formula_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_name.py
@@ -1,5 +1,7 @@
 import logging
 import re
+from typing import Optional
+
 from matchms.typing import SpectrumType
 
 
@@ -7,7 +9,7 @@ logger = logging.getLogger("matchms")
 
 
 def derive_formula_from_name(spectrum_in: SpectrumType,
-                             remove_formula_from_name: bool = True) -> SpectrumType:
+                             remove_formula_from_name: bool = True, clone: Optional[bool] = True) -> SpectrumType:
     """Detect and remove misplaced formula in compound name and add to metadata.
 
     Method to find misplaced formulas in compound name based on regular expression.
@@ -24,7 +26,7 @@ def derive_formula_from_name(spectrum_in: SpectrumType,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if spectrum.get("compound_name", None) is not None:
         name = spectrum.get("compound_name")

--- a/matchms/filtering/metadata_processing/derive_formula_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_name.py
@@ -1,7 +1,6 @@
 import logging
 import re
 from typing import Optional
-
 from matchms.typing import SpectrumType
 
 

--- a/matchms/filtering/metadata_processing/derive_formula_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_name.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("matchms")
 
 
 def derive_formula_from_name(spectrum_in: SpectrumType,
-                             remove_formula_from_name: bool = True, clone: Optional[bool] = True) -> SpectrumType:
+                             remove_formula_from_name: bool = True, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Detect and remove misplaced formula in compound name and add to metadata.
 
     Method to find misplaced formulas in compound name based on regular expression.

--- a/matchms/filtering/metadata_processing/derive_formula_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_name.py
@@ -22,6 +22,8 @@ def derive_formula_from_name(spectrum_in: SpectrumType,
         Input spectrum.
     remove_formula_from_name:
         Remove found formula from compound name if set to True. Default is True.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Optional
-
 from rdkit import Chem
 from rdkit.Chem.rdMolDescriptors import CalcMolFormula
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
@@ -8,7 +8,7 @@ from rdkit.Chem.rdMolDescriptors import CalcMolFormula
 logger = logging.getLogger("matchms")
 
 
-def derive_formula_from_smiles(spectrum_in, overwrite=True, clone: Optional[bool] = True):
+def derive_formula_from_smiles(spectrum_in, overwrite=True, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Adds the molecule’s formula from SMILES.
 
     Parameters

--- a/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
@@ -19,6 +19,11 @@ def derive_formula_from_smiles(spectrum_in, overwrite=True, clone: Optional[bool
         If True, will overwrite the formula. Default is True.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added molecular formular, or `None` if not present.
     """
 
     if spectrum_in is None:

--- a/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from rdkit import Chem
 from rdkit.Chem.rdMolDescriptors import CalcMolFormula
 
@@ -6,10 +8,10 @@ from rdkit.Chem.rdMolDescriptors import CalcMolFormula
 logger = logging.getLogger("matchms")
 
 
-def derive_formula_from_smiles(spectrum_in, overwrite=True):
+def derive_formula_from_smiles(spectrum_in, overwrite=True, clone: Optional[bool] = True):
     if spectrum_in is None:
         return None
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
     if spectrum.get("formula") is not None:
         if overwrite is False:
             return spectrum

--- a/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_smiles.py
@@ -9,6 +9,18 @@ logger = logging.getLogger("matchms")
 
 
 def derive_formula_from_smiles(spectrum_in, overwrite=True, clone: Optional[bool] = True):
+    """Adds the molecule’s formula from SMILES.
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    overwrite:
+        If True, will overwrite the formula. Default is True.
+    clone:
+        Optionally clone the Spectrum.
+    """
+
     if spectrum_in is None:
         return None
     spectrum = spectrum_in.clone() if clone else spectrum_in

--- a/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
@@ -18,6 +18,11 @@ def derive_inchi_from_smiles(spectrum_in: SpectrumType, clone: Optional[bool] = 
         Input spectrum.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added INCHI, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Optional
-
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     convert_smiles_to_inchi, is_valid_inchi, is_valid_smiles)
 from matchms.typing import SpectrumType

--- a/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     convert_smiles_to_inchi, is_valid_inchi, is_valid_smiles)
 from matchms.typing import SpectrumType
@@ -7,12 +9,12 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def derive_inchi_from_smiles(spectrum_in: SpectrumType) -> SpectrumType:
+def derive_inchi_from_smiles(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Find missing Inchi and derive from smiles where possible."""
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
     inchi = spectrum.get("inchi")
     smiles = spectrum.get("smiles")
 

--- a/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
@@ -9,7 +9,7 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def derive_inchi_from_smiles(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def derive_inchi_from_smiles(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Find missing Inchi and derive from smiles where possible.
 
     Parameters

--- a/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
+++ b/matchms/filtering/metadata_processing/derive_inchi_from_smiles.py
@@ -10,7 +10,15 @@ logger = logging.getLogger("matchms")
 
 
 def derive_inchi_from_smiles(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
-    """Find missing Inchi and derive from smiles where possible."""
+    """Find missing Inchi and derive from smiles where possible.
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
+    """
     if spectrum_in is None:
         return None
 

--- a/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
@@ -10,7 +10,15 @@ logger = logging.getLogger("matchms")
 
 
 def derive_inchikey_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
-    """Find missing InchiKey and derive from Inchi where possible."""
+    """Find missing InchiKey and derive from Inchi where possible.
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
+    """
     if spectrum_in is None:
         return None
 

--- a/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Optional
-
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     convert_inchi_to_inchikey, is_valid_inchi, is_valid_inchikey)
 from matchms.typing import SpectrumType

--- a/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
@@ -18,6 +18,11 @@ def derive_inchikey_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] 
         Input spectrum.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added INCHIKEY, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     convert_inchi_to_inchikey, is_valid_inchi, is_valid_inchikey)
 from matchms.typing import SpectrumType
@@ -7,12 +9,12 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def derive_inchikey_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
+def derive_inchikey_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Find missing InchiKey and derive from Inchi where possible."""
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
     inchi = spectrum.get("inchi")
     inchikey = spectrum.get("inchikey")
 

--- a/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_inchikey_from_inchi.py
@@ -9,7 +9,7 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def derive_inchikey_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def derive_inchikey_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Find missing InchiKey and derive from Inchi where possible.
 
     Parameters

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms.Spectrum import Spectrum
 from ..filter_utils.load_known_adducts import load_known_adducts
 from .clean_adduct import _clean_adduct
@@ -7,7 +9,7 @@ from .clean_adduct import _clean_adduct
 logger = logging.getLogger("matchms")
 
 
-def derive_ionmode(spectrum_in: Spectrum) -> Spectrum:
+def derive_ionmode(spectrum_in: Spectrum, clone: Optional[bool] = True) -> Spectrum:
     """Derive missing ionmode based on adduct.
 
     Some input formates (e.g. MGF files) do not always provide a correct ionmode.
@@ -27,7 +29,7 @@ def derive_ionmode(spectrum_in: Spectrum) -> Spectrum:
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     ionmode = spectrum.get("ionmode")
     if ionmode in ["positive", "negative"]:

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
-
 from matchms.Spectrum import Spectrum
+from matchms.typing import SpectrumType
 from ..filter_utils.load_known_adducts import load_known_adducts
 from .clean_adduct import _clean_adduct
 

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -18,8 +18,10 @@ def derive_ionmode(spectrum_in: Spectrum, clone: Optional[bool] = True) -> Spect
 
     Parameters
     ----------
-    spectrum
+    spectrum_in:
         Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
 
     Returns
     -------

--- a/matchms/filtering/metadata_processing/derive_ionmode.py
+++ b/matchms/filtering/metadata_processing/derive_ionmode.py
@@ -9,7 +9,7 @@ from .clean_adduct import _clean_adduct
 logger = logging.getLogger("matchms")
 
 
-def derive_ionmode(spectrum_in: Spectrum, clone: Optional[bool] = True) -> Spectrum:
+def derive_ionmode(spectrum_in: Spectrum, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Derive missing ionmode based on adduct.
 
     Some input formates (e.g. MGF files) do not always provide a correct ionmode.

--- a/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
@@ -17,7 +17,12 @@ def derive_smiles_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] = 
     spectrum_in:
         Input spectrum.
     clone:
-        Optionally clone the Spectrum.
+        Optionally clone the Spectrum.#
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added SMILES, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Optional
-
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     convert_inchi_to_smiles, is_valid_inchi, is_valid_smiles)
 from matchms.typing import SpectrumType

--- a/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     convert_inchi_to_smiles, is_valid_inchi, is_valid_smiles)
 from matchms.typing import SpectrumType
@@ -7,12 +9,12 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def derive_smiles_from_inchi(spectrum_in: SpectrumType) -> SpectrumType:
+def derive_smiles_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Find missing smiles and derive from Inchi where possible."""
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
     inchi = spectrum.get("inchi")
     smiles = spectrum.get("smiles")
 

--- a/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
@@ -10,7 +10,15 @@ logger = logging.getLogger("matchms")
 
 
 def derive_smiles_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
-    """Find missing smiles and derive from Inchi where possible."""
+    """Find missing smiles and derive from Inchi where possible.
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
+    """
     if spectrum_in is None:
         return None
 

--- a/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
+++ b/matchms/filtering/metadata_processing/derive_smiles_from_inchi.py
@@ -9,7 +9,7 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def derive_smiles_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def derive_smiles_from_inchi(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Find missing smiles and derive from Inchi where possible.
 
     Parameters

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
@@ -3,7 +3,7 @@ from matchms.typing import SpectrumType
 
 
 def harmonize_undefined_inchi(spectrum_in: SpectrumType, undefined: str = "",
-                              aliases: List[str] = None, clone: Optional[bool] = True) -> SpectrumType:
+                              aliases: List[str] = None, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Replace all aliases for empty/undefined inchi entries by value of ``undefined`` argument.
 
     Parameters

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
@@ -8,11 +8,15 @@ def harmonize_undefined_inchi(spectrum_in: SpectrumType, undefined: str = "",
 
     Parameters
     ----------
+    spectrum_in:
+        Input spectrum.
     undefined:
         Give desired entry for undefined inchi fields. Default is "".
     aliases:
         Enter list of strings that are expected to represent undefined entries.
         Default is ["", "N/A", "NA", "n/a"].
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
@@ -17,6 +17,11 @@ def harmonize_undefined_inchi(spectrum_in: SpectrumType, undefined: str = "",
         Default is ["", "N/A", "NA", "n/a"].
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with undefined INCHI if not present or N/A, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchi.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import List, Optional
 from matchms.typing import SpectrumType
 
 
 def harmonize_undefined_inchi(spectrum_in: SpectrumType, undefined: str = "",
-                              aliases: List[str] = None) -> SpectrumType:
+                              aliases: List[str] = None, clone: Optional[bool] = True) -> SpectrumType:
     """Replace all aliases for empty/undefined inchi entries by value of ``undefined`` argument.
 
     Parameters
@@ -17,7 +17,7 @@ def harmonize_undefined_inchi(spectrum_in: SpectrumType, undefined: str = "",
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if aliases is None:
         aliases = [

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import List, Optional
 from matchms.typing import SpectrumType
 
 
 def harmonize_undefined_inchikey(spectrum_in: SpectrumType, undefined: str = "",
-                                 aliases: List[str] = None) -> SpectrumType:
+                                 aliases: List[str] = None, clone: Optional[bool] = True) -> SpectrumType:
     """Replace all aliases for empty/undefined inchikey entries by ``undefined``.
 
     Parameters
@@ -17,7 +17,7 @@ def harmonize_undefined_inchikey(spectrum_in: SpectrumType, undefined: str = "",
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if aliases is None:
         aliases = [

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
@@ -17,6 +17,11 @@ def harmonize_undefined_inchikey(spectrum_in: SpectrumType, undefined: str = "",
         Default is ["", "N/A", "NA", "n/a", "no data"].
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with undefined INCHIKEY if not present or N/A, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
@@ -3,7 +3,7 @@ from matchms.typing import SpectrumType
 
 
 def harmonize_undefined_inchikey(spectrum_in: SpectrumType, undefined: str = "",
-                                 aliases: List[str] = None, clone: Optional[bool] = True) -> SpectrumType:
+                                 aliases: List[str] = None, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Replace all aliases for empty/undefined inchikey entries by ``undefined``.
 
     Parameters

--- a/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_inchikey.py
@@ -8,11 +8,15 @@ def harmonize_undefined_inchikey(spectrum_in: SpectrumType, undefined: str = "",
 
     Parameters
     ----------
+    spectrum_in:
+        Input spectrum.
     undefined:
         Give desired entry for undefined inchikey fields. Default is "".
     aliases:
         Enter list of strings that are expected to represent undefined entries.
         Default is ["", "N/A", "NA", "n/a", "no data"].
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
@@ -3,7 +3,7 @@ from matchms.typing import SpectrumType
 
 
 def harmonize_undefined_smiles(spectrum_in: SpectrumType, undefined: str = "",
-                               aliases: List[str] = None, clone: Optional[bool] = True) -> SpectrumType:
+                               aliases: List[str] = None, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Replace all aliases for empty/undefined smiles entries by ``undefined``.
 
     Parameters

--- a/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
@@ -17,6 +17,11 @@ def harmonize_undefined_smiles(spectrum_in: SpectrumType, undefined: str = "",
         Default is ["", "N/A", "NA", "n/a", "no data"].
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with undefined SMILES if not present or N/A, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import List, Optional
 from matchms.typing import SpectrumType
 
 
 def harmonize_undefined_smiles(spectrum_in: SpectrumType, undefined: str = "",
-                               aliases: List[str] = None) -> SpectrumType:
+                               aliases: List[str] = None, clone: Optional[bool] = True) -> SpectrumType:
     """Replace all aliases for empty/undefined smiles entries by ``undefined``.
 
     Parameters
@@ -17,7 +17,7 @@ def harmonize_undefined_smiles(spectrum_in: SpectrumType, undefined: str = "",
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if aliases is None:
         aliases = [

--- a/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
+++ b/matchms/filtering/metadata_processing/harmonize_undefined_smiles.py
@@ -8,11 +8,15 @@ def harmonize_undefined_smiles(spectrum_in: SpectrumType, undefined: str = "",
 
     Parameters
     ----------
+    spectrum_in:
+        Input spectrum.
     undefined:
         Give desired entry for undefined smiles fields. Default is "".
     aliases:
         Enter list of strings that are expected to represent undefined entries.
         Default is ["", "N/A", "NA", "n/a", "no data"].
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -11,7 +11,7 @@ _accepted_types = (float, str, int)
 _accepted_missing_entries = ["", "N/A", "NA", "n/a"]
 
 
-def interpret_pepmass(spectrum_in, clone: Optional[bool] = True):
+def interpret_pepmass(spectrum_in, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Reads pepmass field (if present) and adds values to correct field(s).
 
     The field "pepmass" or "PEPMASS" is often used to describe the precursor ion.

--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -1,8 +1,8 @@
 import logging
 import re
 from typing import Optional
-
 import numpy as np
+from matchms.typing import SpectrumType
 from .make_charge_int import _convert_charge_to_int
 
 

--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -25,6 +25,11 @@ def interpret_pepmass(spectrum_in, clone: Optional[bool] = True) -> Optional[Spe
         Input spectrum.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with added pepmass, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -1,5 +1,7 @@
 import logging
 import re
+from typing import Optional
+
 import numpy as np
 from .make_charge_int import _convert_charge_to_int
 
@@ -9,7 +11,7 @@ _accepted_types = (float, str, int)
 _accepted_missing_entries = ["", "N/A", "NA", "n/a"]
 
 
-def interpret_pepmass(spectrum_in):
+def interpret_pepmass(spectrum_in, clone: Optional[bool] = True):
     """Reads pepmass field (if present) and adds values to correct field(s).
 
     The field "pepmass" or "PEPMASS" is often used to describe the precursor ion.
@@ -20,7 +22,7 @@ def interpret_pepmass(spectrum_in):
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     metadata_updated = _interpret_pepmass_metadata(spectrum.metadata)
     spectrum.metadata = metadata_updated
@@ -76,7 +78,7 @@ def _get_mz_intensity_charge(pepmass):
                 try:
                     pepmass = float(pepmass)
                 except ValueError:
-                    return None, None, None 
+                    return None, None, None
         length = len(pepmass)
         values = [None, None, None]
         for i in range(length):

--- a/matchms/filtering/metadata_processing/interpret_pepmass.py
+++ b/matchms/filtering/metadata_processing/interpret_pepmass.py
@@ -18,6 +18,13 @@ def interpret_pepmass(spectrum_in, clone: Optional[bool] = True):
     This function will interpret the values as (mz, intensity, charge) tuple. Those
     will be splitted (if present) added to the fields "precursor_mz",
     "precursor_intensity", and "charge".
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/make_charge_int.py
+++ b/matchms/filtering/metadata_processing/make_charge_int.py
@@ -16,6 +16,11 @@ def make_charge_int(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> 
         Input spectrum.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with converted charge, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/make_charge_int.py
+++ b/matchms/filtering/metadata_processing/make_charge_int.py
@@ -8,7 +8,15 @@ logger = logging.getLogger("matchms")
 
 
 def make_charge_int(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
-    """Convert charge field to integer (if possible)."""
+    """Convert charge field to integer (if possible).
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
+    """
     if spectrum_in is None:
         return None
 

--- a/matchms/filtering/metadata_processing/make_charge_int.py
+++ b/matchms/filtering/metadata_processing/make_charge_int.py
@@ -7,7 +7,7 @@ from matchms.typing import SpectrumType
 logger = logging.getLogger("matchms")
 
 
-def make_charge_int(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def make_charge_int(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Convert charge field to integer (if possible).
 
     Parameters

--- a/matchms/filtering/metadata_processing/make_charge_int.py
+++ b/matchms/filtering/metadata_processing/make_charge_int.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Optional
-
 from matchms.typing import SpectrumType
 
 

--- a/matchms/filtering/metadata_processing/make_charge_int.py
+++ b/matchms/filtering/metadata_processing/make_charge_int.py
@@ -1,16 +1,18 @@
 import logging
+from typing import Optional
+
 from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")
 
 
-def make_charge_int(spectrum_in: SpectrumType) -> SpectrumType:
+def make_charge_int(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Convert charge field to integer (if possible)."""
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     charge = spectrum.get("charge", None)
     charge_int = _convert_charge_to_int(charge)

--- a/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms import Spectrum
 from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
     get_monoisotopic_neutral_mass
@@ -11,7 +13,7 @@ logger = logging.getLogger("matchms")
 
 
 def repair_adduct_and_parent_mass_based_on_smiles(spectrum_in: Spectrum,
-                                                  mass_tolerance: float):
+                                                  mass_tolerance: float, clone: Optional[bool] = True):
     """
     Corrects the adduct and parent mass of a spectrum based on its SMILES representation and the precursor m/z.
 
@@ -31,7 +33,7 @@ def repair_adduct_and_parent_mass_based_on_smiles(spectrum_in: Spectrum,
     """
     if spectrum_in is None:
         return None
-    changed_spectrum = spectrum_in.clone()
+    changed_spectrum = spectrum_in.clone() if clone else spectrum_in
     smiles_mass = get_monoisotopic_neutral_mass(changed_spectrum.get("smiles"))
     if smiles_mass is None:
         return spectrum_in

--- a/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
@@ -33,6 +33,11 @@ def repair_adduct_and_parent_mass_based_on_smiles(spectrum_in: Spectrum,
 
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with repaired parent mass, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Optional
-
 from matchms import Spectrum
 from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
     get_monoisotopic_neutral_mass
+from matchms.typing import SpectrumType
 from ..filter_utils.derive_precursor_mz_and_parent_mass import \
     derive_parent_mass_from_precursor_mz
 from .repair_adduct_based_on_parent_mass import _get_matching_adduct

--- a/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("matchms")
 
 
 def repair_adduct_and_parent_mass_based_on_smiles(spectrum_in: Spectrum,
-                                                  mass_tolerance: float, clone: Optional[bool] = True):
+                                                  mass_tolerance: float, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """
     Corrects the adduct and parent mass of a spectrum based on its SMILES representation and the precursor m/z.
 

--- a/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_and_parent_mass_based_on_smiles.py
@@ -30,6 +30,9 @@ def repair_adduct_and_parent_mass_based_on_smiles(spectrum_in: Spectrum,
     mass_tolerance : float
         Maximum allowed mass difference between the calculated parent mass and the neutral
         monoisotopic mass derived from the SMILES.
+
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("matchms")
 
 
 def repair_adduct_based_on_parent_mass(spectrum_in: Spectrum,
-                                       mass_tolerance: float, clone: Optional[bool] = True):
+                                       mass_tolerance: float, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """
     Corrects the adduct of a spectrum based on its parent_mass representation and the precursor m/z.
 

--- a/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
@@ -23,6 +23,11 @@ def repair_adduct_based_on_parent_mass(spectrum_in: Spectrum,
 
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with repaired parent adduct, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
-
 from matchms import Spectrum
+from matchms.typing import SpectrumType
 from ..filter_utils.load_known_adducts import load_known_adducts
 
 
@@ -31,7 +31,7 @@ def repair_adduct_based_on_parent_mass(spectrum_in: Spectrum,
     """
     if spectrum_in is None:
         return None
-    changed_spectrum = spectrum_in.clone()
+    changed_spectrum = spectrum_in.clone() if clone else spectrum_in
 
     new_adduct = _get_matching_adduct(precursor_mz=spectrum_in.get("precursor_mz"),
                                       parent_mass=spectrum_in.get("parent_mass"),

--- a/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
@@ -20,6 +20,9 @@ def repair_adduct_based_on_parent_mass(spectrum_in: Spectrum,
 
     mass_tolerance : float
         Maximum allowed mass difference between the parent mass and the parent mass based on the adduct.
+
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
+++ b/matchms/filtering/metadata_processing/repair_adduct_based_on_parent_mass.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms import Spectrum
 from ..filter_utils.load_known_adducts import load_known_adducts
 
@@ -7,7 +9,7 @@ logger = logging.getLogger("matchms")
 
 
 def repair_adduct_based_on_parent_mass(spectrum_in: Spectrum,
-                                       mass_tolerance: float):
+                                       mass_tolerance: float, clone: Optional[bool] = True):
     """
     Corrects the adduct of a spectrum based on its parent_mass representation and the precursor m/z.
 

--- a/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
@@ -1,8 +1,10 @@
+from typing import Optional
+
 from matchms.filtering.SpeciesString import SpeciesString
 from matchms.typing import SpectrumType
 
 
-def repair_inchi_inchikey_smiles(spectrum_in: SpectrumType) -> SpectrumType:
+def repair_inchi_inchikey_smiles(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Check if inchi, inchikey, and smiles entries seem correct. Detect and correct
     if any of those entries clearly belongs into one of the other two fields (e.g.
     inchikey found in inchi field).
@@ -10,7 +12,7 @@ def repair_inchi_inchikey_smiles(spectrum_in: SpectrumType) -> SpectrumType:
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     # interpret available data and clean each
     inchi = spectrum.get("inchi", "")

--- a/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
@@ -1,5 +1,4 @@
 from typing import Optional
-
 from matchms.filtering.SpeciesString import SpeciesString
 from matchms.typing import SpectrumType
 

--- a/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
@@ -15,6 +15,11 @@ def repair_inchi_inchikey_smiles(spectrum_in: SpectrumType, clone: Optional[bool
         Input spectrum.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with repaired INCHI, INCHIKEY and SMILES, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
@@ -4,7 +4,7 @@ from matchms.filtering.SpeciesString import SpeciesString
 from matchms.typing import SpectrumType
 
 
-def repair_inchi_inchikey_smiles(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def repair_inchi_inchikey_smiles(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Check if inchi, inchikey, and smiles entries seem correct. Detect and correct
     if any of those entries clearly belongs into one of the other two fields (e.g.
     inchikey found in inchi field).

--- a/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
@@ -8,6 +8,13 @@ def repair_inchi_inchikey_smiles(spectrum_in: SpectrumType, clone: Optional[bool
     """Check if inchi, inchikey, and smiles entries seem correct. Detect and correct
     if any of those entries clearly belongs into one of the other two fields (e.g.
     inchikey found in inchi field).
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
+++ b/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Optional
-
 from matchms import Spectrum
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     convert_inchi_to_inchikey, convert_inchi_to_smiles,
@@ -8,6 +7,7 @@ from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     is_valid_smiles)
 from matchms.filtering.metadata_processing.require_parent_mass_match_smiles import \
     _check_smiles_and_parent_mass_match
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
+++ b/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
@@ -13,7 +13,7 @@ from matchms.filtering.metadata_processing.require_parent_mass_match_smiles impo
 logger = logging.getLogger("matchms")
 
 
-def repair_not_matching_annotation(spectrum_in: Spectrum, clone: Optional[bool] = True):
+def repair_not_matching_annotation(spectrum_in: Spectrum, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """
     Repairs mismatches in a spectrum's annotations related to SMILES, InChI, and InChIKey.
 

--- a/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
+++ b/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
@@ -34,6 +34,8 @@ def repair_not_matching_annotation(spectrum_in: Spectrum, clone: Optional[bool] 
     ----------
     spectrum_in : Spectrum
         The input spectrum containing annotations to be checked and repaired.
+    clone:
+        Optionally clone the Spectrum.
 
     Returns:
     -------

--- a/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
+++ b/matchms/filtering/metadata_processing/repair_not_matching_annotation.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms import Spectrum
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     convert_inchi_to_inchikey, convert_inchi_to_smiles,
@@ -11,7 +13,7 @@ from matchms.filtering.metadata_processing.require_parent_mass_match_smiles impo
 logger = logging.getLogger("matchms")
 
 
-def repair_not_matching_annotation(spectrum_in: Spectrum):
+def repair_not_matching_annotation(spectrum_in: Spectrum, clone: Optional[bool] = True):
     """
     Repairs mismatches in a spectrum's annotations related to SMILES, InChI, and InChIKey.
 
@@ -42,7 +44,7 @@ def repair_not_matching_annotation(spectrum_in: Spectrum):
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if not _check_repairing_is_possible(spectrum.get("smiles"), spectrum.get("inchi"), spectrum.get("inchikey")):
         # Repairing is not possible, since not all annotations are valid entries.

--- a/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("matchms")
 
 
 def repair_parent_mass_from_smiles(spectrum_in: Spectrum,
-                                        mass_tolerance: float = 0.1, clone: Optional[bool] = True):
+                                        mass_tolerance: float = 0.1, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Sets the parent mass to match the smiles mass, if not already close to smiles mass
 
     Parameters:

--- a/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
@@ -19,6 +19,11 @@ def repair_parent_mass_from_smiles(spectrum_in: Spectrum,
         The input spectrum containing annotations to be checked and repaired.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with repaired parent mass, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms import Spectrum
 from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
     get_monoisotopic_neutral_mass
@@ -8,11 +10,11 @@ logger = logging.getLogger("matchms")
 
 
 def repair_parent_mass_from_smiles(spectrum_in: Spectrum,
-                                        mass_tolerance: float = 0.1):
+                                        mass_tolerance: float = 0.1, clone: Optional[bool] = True):
     """Sets the parent mass to match the smiles mass, if not already close to smiles mass"""
     if spectrum_in is None:
         return None
-    changed_spectrum = spectrum_in.clone()
+    changed_spectrum = spectrum_in.clone() if clone else spectrum_in
     smiles_mass = get_monoisotopic_neutral_mass(changed_spectrum.get("smiles"))
     if smiles_mass is None:
         return spectrum_in

--- a/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
@@ -11,7 +11,15 @@ logger = logging.getLogger("matchms")
 
 def repair_parent_mass_from_smiles(spectrum_in: Spectrum,
                                         mass_tolerance: float = 0.1, clone: Optional[bool] = True):
-    """Sets the parent mass to match the smiles mass, if not already close to smiles mass"""
+    """Sets the parent mass to match the smiles mass, if not already close to smiles mass
+
+    Parameters:
+    ----------
+    spectrum_in : Spectrum
+        The input spectrum containing annotations to be checked and repaired.
+    clone:
+        Optionally clone the Spectrum.
+    """
     if spectrum_in is None:
         return None
     changed_spectrum = spectrum_in.clone() if clone else spectrum_in

--- a/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_from_smiles.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Optional
-
 from matchms import Spectrum
 from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
     get_monoisotopic_neutral_mass
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Optional
-
 from matchms import Spectrum
 from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import (
     get_molecular_weight_neutral_mass, get_monoisotopic_neutral_mass)
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms import Spectrum
 from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import (
     get_molecular_weight_neutral_mass, get_monoisotopic_neutral_mass)
@@ -7,7 +9,7 @@ from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import (
 logger = logging.getLogger("matchms")
 
 
-def repair_parent_mass_is_molar_mass(spectrum_in: Spectrum, mass_tolerance: float):
+def repair_parent_mass_is_molar_mass(spectrum_in: Spectrum, mass_tolerance: float, clone: Optional[bool] = True):
     """Changes the parent mass from molar mass into monoistopic mass
 
     Manual entered parent mass is sometimes wrongly added as Molar mass instead of monoisotopic mass
@@ -19,7 +21,7 @@ def repair_parent_mass_is_molar_mass(spectrum_in: Spectrum, mass_tolerance: floa
     """
     if spectrum_in is None:
         return None
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     parent_mass = spectrum.get("parent_mass")
     smiles = spectrum.get("smiles")

--- a/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
@@ -18,6 +18,16 @@ def repair_parent_mass_is_molar_mass(spectrum_in: Spectrum, mass_tolerance: floa
 
     The molar mass is an average mass based on the average of all common isotopes and will therefore differ from what
     is measured in mass spectrometry.
+
+    Parameters:
+    ----------
+    spectrum_in : Spectrum
+        The input spectrum containing annotations to be checked and repaired.
+    mass_tolerance:
+        Maximum allowed mass difference between the calculated parent mass and the neutral
+        monoisotopic mass derived from the SMILES.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
@@ -28,6 +28,11 @@ def repair_parent_mass_is_molar_mass(spectrum_in: Spectrum, mass_tolerance: floa
         monoisotopic mass derived from the SMILES.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with repaired parent mass, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_is_molar_mass.py
@@ -9,7 +9,7 @@ from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import (
 logger = logging.getLogger("matchms")
 
 
-def repair_parent_mass_is_molar_mass(spectrum_in: Spectrum, mass_tolerance: float, clone: Optional[bool] = True):
+def repair_parent_mass_is_molar_mass(spectrum_in: Spectrum, mass_tolerance: float, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Changes the parent mass from molar mass into monoistopic mass
 
     Manual entered parent mass is sometimes wrongly added as Molar mass instead of monoisotopic mass

--- a/matchms/filtering/metadata_processing/repair_parent_mass_match_smiles_wrapper.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_match_smiles_wrapper.py
@@ -13,11 +13,11 @@ logger = logging.getLogger("matchms")
 
 
 def repair_parent_mass_match_smiles_wrapper(spectrum_in: SpectrumType,
-                                            mass_tolerance: float = 0.2) -> Optional[SpectrumType]:
+                                            mass_tolerance: float = 0.2, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Wrapper function for repairing a mismatch between parent mass and smiles mass"""
     if spectrum_in is None:
         return None
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     filters_to_apply = [repair_smiles_of_salts,
                         repair_parent_mass_is_molar_mass,

--- a/matchms/filtering/metadata_processing/repair_parent_mass_match_smiles_wrapper.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_match_smiles_wrapper.py
@@ -25,6 +25,11 @@ def repair_parent_mass_match_smiles_wrapper(spectrum_in: SpectrumType,
         monoisotopic mass derived from the SMILES. Defaults to 0.2.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with repaired parent mass, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_parent_mass_match_smiles_wrapper.py
+++ b/matchms/filtering/metadata_processing/repair_parent_mass_match_smiles_wrapper.py
@@ -14,7 +14,18 @@ logger = logging.getLogger("matchms")
 
 def repair_parent_mass_match_smiles_wrapper(spectrum_in: SpectrumType,
                                             mass_tolerance: float = 0.2, clone: Optional[bool] = True) -> Optional[SpectrumType]:
-    """Wrapper function for repairing a mismatch between parent mass and smiles mass"""
+    """Wrapper function for repairing a mismatch between parent mass and smiles mass
+
+    Parameters:
+    ----------
+    spectrum_in : Spectrum
+        The input spectrum containing annotations to be checked and repaired.
+    mass_tolerance:
+        Maximum allowed mass difference between the calculated parent mass and the neutral
+        monoisotopic mass derived from the SMILES. Defaults to 0.2.
+    clone:
+        Optionally clone the Spectrum.
+    """
     if spectrum_in is None:
         return None
     spectrum = spectrum_in.clone() if clone else spectrum_in

--- a/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
+++ b/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("matchms")
 
 
 def repair_smiles_of_salts(spectrum_in,
-                           mass_tolerance: float, clone: Optional[bool] = True):
+                           mass_tolerance: float, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Repairs the smiles of a salt to match the parent mass.
     E.g. C1=NC2=NC=NC(=C2N1)N.Cl is converted to 1=NC2=NC=NC(=C2N1)N if this matches the parent mass
     Checks if parent mass matches one of the ions

--- a/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
+++ b/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
@@ -26,6 +26,11 @@ def repair_smiles_of_salts(spectrum_in,
         monoisotopic mass derived from the SMILES.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with repaired SMILES, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
+++ b/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
@@ -1,11 +1,11 @@
 import itertools
 import logging
 from typing import Optional
-
 from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
     get_monoisotopic_neutral_mass
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import \
     is_valid_smiles
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
+++ b/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
@@ -1,5 +1,7 @@
 import itertools
 import logging
+from typing import Optional
+
 from matchms.filtering.filter_utils.get_neutral_mass_from_smiles import \
     get_monoisotopic_neutral_mass
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import \
@@ -10,13 +12,13 @@ logger = logging.getLogger("matchms")
 
 
 def repair_smiles_of_salts(spectrum_in,
-                           mass_tolerance):
+                           mass_tolerance, clone: Optional[bool] = True):
     """Repairs the smiles of a salt to match the parent mass.
     E.g. C1=NC2=NC=NC(=C2N1)N.Cl is converted to 1=NC2=NC=NC(=C2N1)N if this matches the parent mass
     Checks if parent mass matches one of the ions"""
     if spectrum_in is None:
         return None
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     smiles = spectrum.get("smiles")
     if smiles is None:

--- a/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
+++ b/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
@@ -12,10 +12,21 @@ logger = logging.getLogger("matchms")
 
 
 def repair_smiles_of_salts(spectrum_in,
-                           mass_tolerance, clone: Optional[bool] = True):
+                           mass_tolerance: float, clone: Optional[bool] = True):
     """Repairs the smiles of a salt to match the parent mass.
     E.g. C1=NC2=NC=NC(=C2N1)N.Cl is converted to 1=NC2=NC=NC(=C2N1)N if this matches the parent mass
-    Checks if parent mass matches one of the ions"""
+    Checks if parent mass matches one of the ions
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    mass_tolerance:
+        Maximum allowed mass difference between the calculated parent mass and the neutral
+        monoisotopic mass derived from the SMILES.
+    clone:
+        Optionally clone the Spectrum.
+    """
     if spectrum_in is None:
         return None
     spectrum = spectrum_in.clone() if clone else spectrum_in

--- a/matchms/filtering/metadata_processing/require_correct_ionmode.py
+++ b/matchms/filtering/metadata_processing/require_correct_ionmode.py
@@ -7,7 +7,7 @@ logger = logging.getLogger("matchms")
 
 
 def require_correct_ionmode(spectrum_in: SpectrumType,
-                            ion_mode_to_keep, clone: Optional[bool] = True) -> Optional[SpectrumType]:
+                            ion_mode_to_keep) -> Optional[SpectrumType]:
     """
     Validates the ion mode of a given spectrum. If the spectrum's ion mode
     doesn't match the `ion_mode_to_keep`, it will be removed and a log message
@@ -22,9 +22,6 @@ def require_correct_ionmode(spectrum_in: SpectrumType,
         Desired ion mode ('positive', 'negative', or 'both'). If not one of these,
         a `ValueError` is raised.
 
-    clone:
-        Optionally clone the Spectrum.
-
     Returns
     -------
     Spectrum or None
@@ -32,7 +29,9 @@ def require_correct_ionmode(spectrum_in: SpectrumType,
     """
     if spectrum_in is None:
         return None
-    spectrum = spectrum_in.clone() if clone else spectrum_in
+
+    spectrum = spectrum_in
+
     if ion_mode_to_keep not in {"positive", "negative", "both"}:
         raise ValueError("ion_mode_to_keep should be 'positive', 'negative' or 'both'")
     ion_mode = spectrum.get("ionmode")

--- a/matchms/filtering/metadata_processing/require_correct_ionmode.py
+++ b/matchms/filtering/metadata_processing/require_correct_ionmode.py
@@ -22,6 +22,9 @@ def require_correct_ionmode(spectrum_in: SpectrumType,
         Desired ion mode ('positive', 'negative', or 'both'). If not one of these,
         a `ValueError` is raised.
 
+    clone:
+        Optionally clone the Spectrum.
+
     Returns
     -------
     Spectrum or None

--- a/matchms/filtering/metadata_processing/require_correct_ionmode.py
+++ b/matchms/filtering/metadata_processing/require_correct_ionmode.py
@@ -7,10 +7,10 @@ logger = logging.getLogger("matchms")
 
 
 def require_correct_ionmode(spectrum_in: SpectrumType,
-                            ion_mode_to_keep) -> Optional[SpectrumType]:
+                            ion_mode_to_keep, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """
-    Validates the ion mode of a given spectrum. If the spectrum's ion mode 
-    doesn't match the `ion_mode_to_keep`, it will be removed and a log message 
+    Validates the ion mode of a given spectrum. If the spectrum's ion mode
+    doesn't match the `ion_mode_to_keep`, it will be removed and a log message
     will be generated.
 
     Parameters
@@ -19,7 +19,7 @@ def require_correct_ionmode(spectrum_in: SpectrumType,
         The input spectrum to be validated. If `None`, the function will return `None`.
 
     ion_mode_to_keep: str
-        Desired ion mode ('positive', 'negative', or 'both'). If not one of these, 
+        Desired ion mode ('positive', 'negative', or 'both'). If not one of these,
         a `ValueError` is raised.
 
     Returns
@@ -29,7 +29,7 @@ def require_correct_ionmode(spectrum_in: SpectrumType,
     """
     if spectrum_in is None:
         return None
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
     if ion_mode_to_keep not in {"positive", "negative", "both"}:
         raise ValueError("ion_mode_to_keep should be 'positive', 'negative' or 'both'")
     ion_mode = spectrum.get("ionmode")

--- a/matchms/filtering/metadata_processing/require_matching_adduct_and_ionmode.py
+++ b/matchms/filtering/metadata_processing/require_matching_adduct_and_ionmode.py
@@ -6,7 +6,7 @@ from matchms.filtering.filter_utils.interpret_unknown_adduct import \
 logger = logging.getLogger("matchms")
 
 
-def require_matching_adduct_and_ionmode(spectrum):
+def require_matching_adduct_and_ionmode(spectrum) -> Optional[SpectrumType]:
     if spectrum is None:
         return None
     ionmode = spectrum.get("ionmode")

--- a/matchms/filtering/metadata_processing/require_matching_adduct_and_ionmode.py
+++ b/matchms/filtering/metadata_processing/require_matching_adduct_and_ionmode.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Optional
 from matchms.filtering.filter_utils.interpret_unknown_adduct import \
     get_charge_of_adduct
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/require_matching_adduct_precursor_mz_parent_mass.py
+++ b/matchms/filtering/metadata_processing/require_matching_adduct_precursor_mz_parent_mass.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("matchms")
 
 
 def require_matching_adduct_precursor_mz_parent_mass(spectrum,
-                                                     tolerance=0.1):
+                                                     tolerance=0.1) -> Optional[SpectrumType]:
     """Checks if the adduct precursor mz and parent mass match within the tolerance"""
     if spectrum is None:
         return None

--- a/matchms/filtering/metadata_processing/require_matching_adduct_precursor_mz_parent_mass.py
+++ b/matchms/filtering/metadata_processing/require_matching_adduct_precursor_mz_parent_mass.py
@@ -1,7 +1,9 @@
 import logging
 import math
+from typing import Optional
 from matchms.filtering.filter_utils.interpret_unknown_adduct import \
     get_multiplier_and_mass_from_adduct
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/require_parent_mass_match_smiles.py
+++ b/matchms/filtering/metadata_processing/require_parent_mass_match_smiles.py
@@ -5,7 +5,7 @@ from matchms.typing import SpectrumType
 
 
 def require_parent_mass_match_smiles(spectrum_in: SpectrumType,
-                                     mass_tolerance) -> Optional[SpectrumType]:
+                                     mass_tolerance, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """
     Validates if the parent mass of the given spectrum matches the mass calculated
     from its associated SMILES string within a specified tolerance.
@@ -28,7 +28,7 @@ def require_parent_mass_match_smiles(spectrum_in: SpectrumType,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
     # Check if parent mass matches the smiles mass
     if _check_smiles_and_parent_mass_match(spectrum.get("smiles"), spectrum.get("parent_mass"), mass_tolerance):
         return spectrum

--- a/matchms/filtering/metadata_processing/require_parent_mass_match_smiles.py
+++ b/matchms/filtering/metadata_processing/require_parent_mass_match_smiles.py
@@ -5,7 +5,8 @@ from matchms.typing import SpectrumType
 
 
 def require_parent_mass_match_smiles(spectrum_in: SpectrumType,
-                                     mass_tolerance, clone: Optional[bool] = True) -> Optional[SpectrumType]:
+                                     mass_tolerance,
+                                     clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """
     Validates if the parent mass of the given spectrum matches the mass calculated
     from its associated SMILES string within a specified tolerance.
@@ -18,6 +19,9 @@ def require_parent_mass_match_smiles(spectrum_in: SpectrumType,
     mass_tolerance: float
         The tolerance for the mass difference between the spectrum's parent mass and
         the mass calculated from its SMILES string.
+
+    clone:
+        Optionally clone the Spectrum.
 
     Returns
     -------

--- a/matchms/filtering/metadata_processing/require_parent_mass_match_smiles.py
+++ b/matchms/filtering/metadata_processing/require_parent_mass_match_smiles.py
@@ -5,8 +5,7 @@ from matchms.typing import SpectrumType
 
 
 def require_parent_mass_match_smiles(spectrum_in: SpectrumType,
-                                     mass_tolerance,
-                                     clone: Optional[bool] = True) -> Optional[SpectrumType]:
+                                     mass_tolerance) -> Optional[SpectrumType]:
     """
     Validates if the parent mass of the given spectrum matches the mass calculated
     from its associated SMILES string within a specified tolerance.
@@ -20,9 +19,6 @@ def require_parent_mass_match_smiles(spectrum_in: SpectrumType,
         The tolerance for the mass difference between the spectrum's parent mass and
         the mass calculated from its SMILES string.
 
-    clone:
-        Optionally clone the Spectrum.
-
     Returns
     -------
     Spectrum or None
@@ -32,7 +28,8 @@ def require_parent_mass_match_smiles(spectrum_in: SpectrumType,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone() if clone else spectrum_in
+    spectrum = spectrum_in
+
     # Check if parent mass matches the smiles mass
     if _check_smiles_and_parent_mass_match(spectrum.get("smiles"), spectrum.get("parent_mass"), mass_tolerance):
         return spectrum

--- a/matchms/filtering/metadata_processing/require_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/require_precursor_mz.py
@@ -10,7 +10,7 @@ def require_precursor_mz(spectrum_in: SpectrumType,
                          minimum_accepted_mz: Optional[float] = 10.0,
                          maximum_mz: Optional[float] = None,
                          clone: Optional[bool] = True
-                         ) -> Union[SpectrumType, None]:
+                         ) -> Optional[SpectrumType]:
 
     """Returns None if there is no precursor_mz or if <= minimum_accepted_mz
 

--- a/matchms/filtering/metadata_processing/require_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/require_precursor_mz.py
@@ -8,7 +8,8 @@ logger = logging.getLogger("matchms")
 
 def require_precursor_mz(spectrum_in: SpectrumType,
                          minimum_accepted_mz: Optional[float] = 10.0,
-                         maximum_mz: Optional[float] = None
+                         maximum_mz: Optional[float] = None,
+                         clone: Optional[bool] = True
                          ) -> Union[SpectrumType, None]:
 
     """Returns None if there is no precursor_mz or if <= minimum_accepted_mz
@@ -25,7 +26,7 @@ def require_precursor_mz(spectrum_in: SpectrumType,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     precursor_mz = spectrum.get("precursor_mz", None)
     if precursor_mz is None:

--- a/matchms/filtering/metadata_processing/require_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/require_precursor_mz.py
@@ -22,6 +22,8 @@ def require_precursor_mz(spectrum_in: SpectrumType,
         Set to minimum acceptable value for precursor m/z. Default is set to 10.0.
     maximum_mz:
         Set the maximum value for precursor m/z.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/require_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/require_precursor_mz.py
@@ -24,6 +24,11 @@ def require_precursor_mz(spectrum_in: SpectrumType,
         Set the maximum value for precursor m/z.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with precursor_mz, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/metadata_processing/require_precursor_mz.py
+++ b/matchms/filtering/metadata_processing/require_precursor_mz.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union
+from typing import Optional
 from matchms.typing import SpectrumType
 
 

--- a/matchms/filtering/metadata_processing/require_retention_index.py
+++ b/matchms/filtering/metadata_processing/require_retention_index.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import Optional
 from matchms.typing import SpectrumType
 
 

--- a/matchms/filtering/metadata_processing/require_retention_index.py
+++ b/matchms/filtering/metadata_processing/require_retention_index.py
@@ -5,7 +5,7 @@ from matchms.typing import SpectrumType
 
 logger = logging.getLogger("matchms")
 
-def require_retention_index(spectrum_in: SpectrumType) -> Union[SpectrumType, None]:
+def require_retention_index(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Union[SpectrumType, None]:
     """
     This function checks if the input spectrum has a 'retention_index' in its metadata.
     If the input spectrum is None or doesn't have a 'retention_index', the function returns None.
@@ -20,7 +20,7 @@ def require_retention_index(spectrum_in: SpectrumType) -> Union[SpectrumType, No
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     retention_index = spectrum.get("retention_index", None)
     if retention_index is None:

--- a/matchms/filtering/metadata_processing/require_retention_index.py
+++ b/matchms/filtering/metadata_processing/require_retention_index.py
@@ -11,8 +11,12 @@ def require_retention_index(spectrum_in: SpectrumType, clone: Optional[bool] = T
     If the input spectrum is None or doesn't have a 'retention_index', the function returns None.
     Otherwise, it returns a clone of the input spectrum.
 
-    Parameters:
-    spectrum_in (SpectrumType): The input spectrum to check.
+    Parameters
+    ----------
+    spectrum_in (SpectrumType):
+        The input spectrum to check.
+    clone:
+        Optionally clone the Spectrum.
 
     Returns:
     SpectrumType: A clone of the input spectrum if it has a 'retention_index', None otherwise.

--- a/matchms/filtering/metadata_processing/require_retention_index.py
+++ b/matchms/filtering/metadata_processing/require_retention_index.py
@@ -5,7 +5,7 @@ from matchms.typing import SpectrumType
 
 logger = logging.getLogger("matchms")
 
-def require_retention_index(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Union[SpectrumType, None]:
+def require_retention_index(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """
     This function checks if the input spectrum has a 'retention_index' in its metadata.
     If the input spectrum is None or doesn't have a 'retention_index', the function returns None.

--- a/matchms/filtering/metadata_processing/require_retention_time.py
+++ b/matchms/filtering/metadata_processing/require_retention_time.py
@@ -14,8 +14,12 @@ def require_retention_time(spectrum_in: SpectrumType,
     If the input spectrum is None or doesn't have a 'retention_time', the function returns None.
     Otherwise, it returns a clone of the input spectrum.
 
-    Parameters:
-    spectrum_in (SpectrumType): The input spectrum to check.
+    Parameters
+    ----------
+    spectrum_in (SpectrumType):
+        The input spectrum to check.
+    clone:
+        Optionally clone the Spectrum.
 
     Returns:
     SpectrumType: A clone of the input spectrum if it has a 'retention_time', None otherwise.

--- a/matchms/filtering/metadata_processing/require_retention_time.py
+++ b/matchms/filtering/metadata_processing/require_retention_time.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import Optional
 from matchms.typing import SpectrumType
 
 

--- a/matchms/filtering/metadata_processing/require_retention_time.py
+++ b/matchms/filtering/metadata_processing/require_retention_time.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("matchms")
 
 def require_retention_time(spectrum_in: SpectrumType,
                            minimum_rt=None,
-                           maximum_rt=None, clone: Optional[bool] = True) -> Union[SpectrumType, None]:
+                           maximum_rt=None, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """
     This function checks if the input spectrum has a 'retention_time' in its metadata.
     If the input spectrum is None or doesn't have a 'retention_time', the function returns None.

--- a/matchms/filtering/metadata_processing/require_retention_time.py
+++ b/matchms/filtering/metadata_processing/require_retention_time.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("matchms")
 
 def require_retention_time(spectrum_in: SpectrumType,
                            minimum_rt=None,
-                           maximum_rt=None) -> Union[SpectrumType, None]:
+                           maximum_rt=None, clone: Optional[bool] = True) -> Union[SpectrumType, None]:
     """
     This function checks if the input spectrum has a 'retention_time' in its metadata.
     If the input spectrum is None or doesn't have a 'retention_time', the function returns None.
@@ -23,7 +23,7 @@ def require_retention_time(spectrum_in: SpectrumType,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     retention_time = spectrum.get("retention_time", None)
     if retention_time is None:

--- a/matchms/filtering/metadata_processing/require_valid_annotation.py
+++ b/matchms/filtering/metadata_processing/require_valid_annotation.py
@@ -1,8 +1,10 @@
 import logging
+from typing import Optional
 from matchms import Spectrum
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     convert_inchi_to_inchikey, convert_smiles_to_inchi, is_valid_inchi,
     is_valid_inchikey, is_valid_smiles)
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/metadata_processing/require_valid_annotation.py
+++ b/matchms/filtering/metadata_processing/require_valid_annotation.py
@@ -8,7 +8,7 @@ from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
 logger = logging.getLogger("matchms")
 
 
-def require_valid_annotation(spectrum: Spectrum):
+def require_valid_annotation(spectrum: Spectrum) -> Optional[SpectrumType]:
     """Removes spectra that are not fully annotated (correct and matching, smiles, inchi and inchikey)"""
     if spectrum is None:
         return None

--- a/matchms/filtering/peak_processing/normalize_intensities.py
+++ b/matchms/filtering/peak_processing/normalize_intensities.py
@@ -8,7 +8,15 @@ logger = logging.getLogger("matchms")
 
 
 def normalize_intensities(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
-    """Normalize intensities of peaks to unit height."""
+    """Normalize intensities of peaks to unit height.
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    clone:
+        Optionally clone the Spectrum.
+    """
 
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/normalize_intensities.py
+++ b/matchms/filtering/peak_processing/normalize_intensities.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 import numpy as np
 from matchms.typing import SpectrumType
 from ...Fragments import Fragments

--- a/matchms/filtering/peak_processing/normalize_intensities.py
+++ b/matchms/filtering/peak_processing/normalize_intensities.py
@@ -7,13 +7,13 @@ from ...Fragments import Fragments
 logger = logging.getLogger("matchms")
 
 
-def normalize_intensities(spectrum_in: SpectrumType) -> SpectrumType:
+def normalize_intensities(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
     """Normalize intensities of peaks to unit height."""
 
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if len(spectrum.peaks) == 0:
         return spectrum

--- a/matchms/filtering/peak_processing/normalize_intensities.py
+++ b/matchms/filtering/peak_processing/normalize_intensities.py
@@ -7,7 +7,7 @@ from ...Fragments import Fragments
 logger = logging.getLogger("matchms")
 
 
-def normalize_intensities(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> SpectrumType:
+def normalize_intensities(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Normalize intensities of peaks to unit height.
 
     Parameters

--- a/matchms/filtering/peak_processing/normalize_intensities.py
+++ b/matchms/filtering/peak_processing/normalize_intensities.py
@@ -16,6 +16,11 @@ def normalize_intensities(spectrum_in: SpectrumType, clone: Optional[bool] = Tru
         Input spectrum.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with mormalized Intensities, or `None` if not present.
     """
 
     if spectrum_in is None:

--- a/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("matchms")
 
 
 def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 0, n_max: int = np.inf,
-                              ratio_desired: Optional[float] = None, clone: Optional[bool] = True) -> SpectrumType:
+                              ratio_desired: Optional[float] = None, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Lowest intensity peaks will be removed when it has more peaks than desired.
 
     Parameters

--- a/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("matchms")
 
 
 def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 0, n_max: int = np.inf,
-                              ratio_desired: Optional[float] = None) -> SpectrumType:
+                              ratio_desired: Optional[float] = None, clone: Optional[bool] = True) -> SpectrumType:
     """Lowest intensity peaks will be removed when it has more peaks than desired.
 
     Parameters
@@ -47,7 +47,7 @@ def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 0, n_
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if spectrum.peaks.intensities.size < n_required:
         logger.info("Spectrum with %s (<%s) peaks was set to None.",

--- a/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
@@ -29,6 +29,11 @@ def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 0, n_
         Default is None.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with reduced lowest peaks, or `None` if not present.
     """
     def _set_maximum_number_of_peaks_to_keep():
         parent_mass = spectrum.get("parent_mass", None)

--- a/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/reduce_to_number_of_peaks.py
@@ -15,7 +15,7 @@ def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 0, n_
 
     Parameters
     ----------
-    spectrum_in
+    spectrum_in:
         Input spectrum.
     n_required:
         Number of minimum required peaks. Spectra with fewer peaks will be set
@@ -27,6 +27,8 @@ def reduce_to_number_of_peaks(spectrum_in: SpectrumType, n_required: int = 0, n_
         For spectra without parent mass (e.g. GCMS spectra) this will raise an
         error when ratio_desired is used.
         Default is None.
+    clone:
+        Optionally clone the Spectrum.
     """
     def _set_maximum_number_of_peaks_to_keep():
         parent_mass = spectrum.get("parent_mass", None)

--- a/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
+++ b/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
@@ -1,7 +1,9 @@
 import logging
+from typing import Optional
 import numpy as np
 from matchms.Fragments import Fragments
 from matchms.Spectrum import Spectrum
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
+++ b/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("matchms")
 
 def remove_noise_below_frequent_intensities(spectrum_in: Spectrum,
                                             min_count_of_frequent_intensities: int = 5,
-                                            noise_level_multiplier: float = 2.0, clone: Optional[bool] = True):
+                                            noise_level_multiplier: float = 2.0, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Removes noise if intensities exactly match frequently
 
     When no noise filtering has been applied to a spectrum, many spectra show repeating intensities.

--- a/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
+++ b/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
@@ -30,6 +30,11 @@ def remove_noise_below_frequent_intensities(spectrum_in: Spectrum,
         The noise level is set to this intensity * noise_level_multiplier.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with removed intensities, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
+++ b/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
@@ -7,9 +7,9 @@ from matchms.Spectrum import Spectrum
 logger = logging.getLogger("matchms")
 
 
-def remove_noise_below_frequent_intensities(spectrum: Spectrum,
+def remove_noise_below_frequent_intensities(spectrum_in: Spectrum,
                                             min_count_of_frequent_intensities: int = 5,
-                                            noise_level_multiplier: float = 2.0):
+                                            noise_level_multiplier: float = 2.0, clone: Optional[bool] = True):
     """Removes noise if intensities exactly match frequently
 
     When no noise filtering has been applied to a spectrum, many spectra show repeating intensities.
@@ -29,9 +29,10 @@ def remove_noise_below_frequent_intensities(spectrum: Spectrum,
         From all intensities that repeat more than min_count_of_frequent_intensities the highest is selected.
     The noise level is set to this intensity * noise_level_multiplier.
     """
-    if spectrum is None:
+    if spectrum_in is None:
         return None
-    spectrum = spectrum.clone()
+
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     highest_frequent_peak = _select_highest_frequent_peak(spectrum.intensities, min_count_of_frequent_intensities)
     if highest_frequent_peak != -1:

--- a/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
+++ b/matchms/filtering/peak_processing/remove_noise_below_frequent_intensities.py
@@ -21,13 +21,15 @@ def remove_noise_below_frequent_intensities(spectrum_in: Spectrum,
 
     Parameters
     ----------
-    spectrum
+    spectrum_in:
         Input spectrum.
     min_count_of_frequent_intensities:
         Minimum number of repeating intensities.
     noise_level_multiplier:
         From all intensities that repeat more than min_count_of_frequent_intensities the highest is selected.
-    The noise level is set to this intensity * noise_level_multiplier.
+        The noise level is set to this intensity * noise_level_multiplier.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
+++ b/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import numpy as np
 from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType

--- a/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
+++ b/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
@@ -3,7 +3,7 @@ from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType
 
 
-def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: float = 17, clone: Optional[bool] = True) -> SpectrumType:
+def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: float = 17, clone: Optional[bool] = True) -> Optional[SpectrumType]:
 
     """Remove peaks that are within mz_tolerance (in Da) of
        the precursor mz, exlcuding the precursor peak.

--- a/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
+++ b/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
@@ -3,7 +3,7 @@ from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType
 
 
-def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: float = 17) -> SpectrumType:
+def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: float = 17, clone: Optional[bool] = True) -> SpectrumType:
 
     """Remove peaks that are within mz_tolerance (in Da) of
        the precursor mz, exlcuding the precursor peak.
@@ -19,7 +19,7 @@ def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: fl
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     precursor_mz = spectrum.get("precursor_mz", None)
     assert precursor_mz is not None, "Precursor mz absent."

--- a/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
+++ b/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
@@ -17,6 +17,11 @@ def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: fl
         within the precursor mz. Default is 17 Da.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with removed peaks, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
+++ b/matchms/filtering/peak_processing/remove_peaks_around_precursor_mz.py
@@ -15,6 +15,8 @@ def remove_peaks_around_precursor_mz(spectrum_in: SpectrumType, mz_tolerance: fl
     mz_tolerance:
         Tolerance of mz values that are not allowed to lie
         within the precursor mz. Default is 17 Da.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
+++ b/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import numpy as np
 from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType

--- a/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
+++ b/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
@@ -4,7 +4,7 @@ from matchms.typing import SpectrumType
 
 
 def remove_peaks_outside_top_k(spectrum_in: SpectrumType, k: int = 6,
-                               mz_window: float = 50) -> SpectrumType:
+                               mz_window: float = 50, clone: Optional[bool] = True) -> SpectrumType:
 
     """Remove all peaks which are not within *mz_window* of at least one
        of the *k* highest intensity peaks of the spectrum.
@@ -22,7 +22,7 @@ def remove_peaks_outside_top_k(spectrum_in: SpectrumType, k: int = 6,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     assert k >= 1, "k must be a positive nonzero integer."
     assert mz_window >= 0, "mz_window must be a positive scalar."

--- a/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
+++ b/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
@@ -18,6 +18,8 @@ def remove_peaks_outside_top_k(spectrum_in: SpectrumType, k: int = 6,
     mz_window:
         Window of mz values (in Da) that are allowed to lie within
         the top k peaks. Default is 50 Da.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
+++ b/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
@@ -4,7 +4,7 @@ from matchms.typing import SpectrumType
 
 
 def remove_peaks_outside_top_k(spectrum_in: SpectrumType, k: int = 6,
-                               mz_window: float = 50, clone: Optional[bool] = True) -> SpectrumType:
+                               mz_window: float = 50, clone: Optional[bool] = True) -> Optional[SpectrumType]:
 
     """Remove all peaks which are not within *mz_window* of at least one
        of the *k* highest intensity peaks of the spectrum.

--- a/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
+++ b/matchms/filtering/peak_processing/remove_peaks_outside_top_k.py
@@ -20,6 +20,11 @@ def remove_peaks_outside_top_k(spectrum_in: SpectrumType, k: int = 6,
         the top k peaks. Default is 50 Da.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with removed peaks, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/remove_profiled_spectra.py
+++ b/matchms/filtering/peak_processing/remove_profiled_spectra.py
@@ -6,7 +6,7 @@ from matchms.Spectrum import Spectrum
 logger = logging.getLogger("matchms")
 
 
-def remove_profiled_spectra(spectrum: Spectrum, mz_window=0.5):
+def remove_profiled_spectra(spectrum_in: Spectrum, mz_window=0.5, clone: Optional[bool] = True):
     """Remove profiled spectra
 
     Spectra are removed if within the mz_window of 0.5 of the highest peak at least 2 peaks next to the main peak are of
@@ -15,8 +15,11 @@ def remove_profiled_spectra(spectrum: Spectrum, mz_window=0.5):
     Reproduced from MZmine.
     https://github.com/mzmine/mzmine3/blob/master/src/main/java/io/github/mzmine/util/scans/ScanUtils.java#L609
     """
-    if spectrum is None:
+    if spectrum_in is None:
         return None
+
+    spectrum = spectrum_in.clone() if clone else spectrum_in
+
     peaks_n = spectrum.mz.shape[0]
     if peaks_n < 3:
         return spectrum

--- a/matchms/filtering/peak_processing/remove_profiled_spectra.py
+++ b/matchms/filtering/peak_processing/remove_profiled_spectra.py
@@ -14,6 +14,16 @@ def remove_profiled_spectra(spectrum_in: Spectrum, mz_window=0.5, clone: Optiona
 
     Reproduced from MZmine.
     https://github.com/mzmine/mzmine3/blob/master/src/main/java/io/github/mzmine/util/scans/ScanUtils.java#L609
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    mz_window:
+        Window of mz values (in Da) that are allowed to lie within
+        the top k peaks. Default is 50 Da.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/remove_profiled_spectra.py
+++ b/matchms/filtering/peak_processing/remove_profiled_spectra.py
@@ -6,7 +6,7 @@ from matchms.Spectrum import Spectrum
 logger = logging.getLogger("matchms")
 
 
-def remove_profiled_spectra(spectrum_in: Spectrum, mz_window=0.5, clone: Optional[bool] = True):
+def remove_profiled_spectra(spectrum_in: Spectrum, mz_window=0.5, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Remove profiled spectra
 
     Spectra are removed if within the mz_window of 0.5 of the highest peak at least 2 peaks next to the main peak are of

--- a/matchms/filtering/peak_processing/remove_profiled_spectra.py
+++ b/matchms/filtering/peak_processing/remove_profiled_spectra.py
@@ -24,6 +24,11 @@ def remove_profiled_spectra(spectrum_in: Spectrum, mz_window=0.5, clone: Optiona
         the top k peaks. Default is 50 Da.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        None if the spectrum is likely profile data, else the input spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/remove_profiled_spectra.py
+++ b/matchms/filtering/peak_processing/remove_profiled_spectra.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Optional
 import numpy as np
 from matchms.Spectrum import Spectrum
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")

--- a/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 from matchms.Spectrum import Spectrum
+from matchms.typing import SpectrumType
 
 
 logger = logging.getLogger("matchms")
@@ -30,9 +31,9 @@ def require_maximum_number_of_peaks(spectrum_in: Spectrum,
 
     spectrum = spectrum_in.clone() if clone else spectrum_in
 
-    if spectrum_in.peaks.intensities.size > maximum_number_of_fragments:
+    if spectrum.peaks.intensities.size > maximum_number_of_fragments:
         logger.info("Spectrum with %s (>%s) peaks was set to None.",
-                    str(spectrum_in.peaks.intensities.size), str(maximum_number_of_fragments))
+                    str(spectrum.peaks.intensities.size), str(maximum_number_of_fragments))
         return None
 
-    return spectrum_in
+    return spectrum

--- a/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
@@ -7,7 +7,7 @@ logger = logging.getLogger("matchms")
 
 
 def require_maximum_number_of_peaks(spectrum_in: Spectrum,
-                                    maximum_number_of_fragments: int = 1000) -> Optional[Spectrum]:
+                                    maximum_number_of_fragments: int = 1000, clone: Optional[bool] = True) -> Optional[Spectrum]:
     """Spectrum will be set to None when it has more peaks than maximum_number_of_fragments.
 
     Parameters
@@ -20,6 +20,8 @@ def require_maximum_number_of_peaks(spectrum_in: Spectrum,
     """
     if spectrum_in is None:
         return None
+
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     if spectrum_in.peaks.intensities.size > maximum_number_of_fragments:
         logger.info("Spectrum with %s (>%s) peaks was set to None.",

--- a/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
@@ -19,6 +19,11 @@ def require_maximum_number_of_peaks(spectrum_in: Spectrum,
         to 'None'.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Untouched Spectrum or 'None'.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
@@ -17,6 +17,8 @@ def require_maximum_number_of_peaks(spectrum_in: Spectrum,
     maximum_number_of_fragments:
         Number of minimum required peaks. Spectra with fewer peaks will be set
         to 'None'.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
@@ -7,7 +7,7 @@ logger = logging.getLogger("matchms")
 
 
 def require_maximum_number_of_peaks(spectrum_in: Spectrum,
-                                    maximum_number_of_fragments: int = 1000, clone: Optional[bool] = True) -> Optional[Spectrum]:
+                                    maximum_number_of_fragments: int = 1000, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Spectrum will be set to None when it has more peaks than maximum_number_of_fragments.
 
     Parameters

--- a/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
@@ -27,6 +27,11 @@ def require_minimum_number_of_high_peaks(spectrum_in: SpectrumType, no_peaks: in
         peaks that are searched. Default is 2.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Untouched Spectrum or 'None'.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional
+
 from matchms.typing import SpectrumType
 from .select_by_relative_intensity import select_by_relative_intensity
 
@@ -7,7 +9,7 @@ logger = logging.getLogger("matchms")
 
 
 def require_minimum_number_of_high_peaks(spectrum_in: SpectrumType, no_peaks: int = 5,
-                                  intensity_percent: float = 2.0) -> SpectrumType:
+                                  intensity_percent: float = 2.0, clone: Optional[bool] = True) -> SpectrumType:
 
     """Returns None if the number of peaks with relative intensity
        above or equal to intensity_percent is less than no_peaks.
@@ -27,7 +29,7 @@ def require_minimum_number_of_high_peaks(spectrum_in: SpectrumType, no_peaks: in
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     assert no_peaks >= 1, "no_peaks must be a positive nonzero integer."
     assert 0 <= intensity_percent <= 100, "intensity_percent must be a scalar between 0-100."

--- a/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
@@ -24,7 +24,9 @@ def require_minimum_number_of_high_peaks(spectrum_in: SpectrumType, no_peaks: in
         Default is 5.
     intensity_percent:
         Minimum relative intensity (as a percentage between 0-100) for
-        peaks that are searched. Default is 2
+        peaks that are searched. Default is 2.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Optional
-
 from matchms.typing import SpectrumType
 from .select_by_relative_intensity import select_by_relative_intensity
 

--- a/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("matchms")
 
 
 def require_minimum_number_of_high_peaks(spectrum_in: SpectrumType, no_peaks: int = 5,
-                                  intensity_percent: float = 2.0, clone: Optional[bool] = True) -> SpectrumType:
+                                  intensity_percent: float = 2.0, clone: Optional[bool] = True) -> Optional[SpectrumType]:
 
     """Returns None if the number of peaks with relative intensity
        above or equal to intensity_percent is less than no_peaks.

--- a/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
@@ -22,7 +22,8 @@ def require_minimum_number_of_peaks(spectrum_in: SpectrumType,
     ratio_required:
         Set desired ratio between minimum number of peaks and parent mass.
         Default is None.
-
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
@@ -24,6 +24,11 @@ def require_minimum_number_of_peaks(spectrum_in: SpectrumType,
         Default is None.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Untouched Spectrum or 'None'.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("matchms")
 
 def require_minimum_number_of_peaks(spectrum_in: SpectrumType,
                                     n_required: int = 10,
-                                    ratio_required: Optional[float] = None) -> SpectrumType:
+                                    ratio_required: Optional[float] = None, clone: Optional[bool] = True) -> SpectrumType:
     """Spectrum will be set to None when it has fewer peaks than required.
 
     Parameters
@@ -27,7 +27,7 @@ def require_minimum_number_of_peaks(spectrum_in: SpectrumType,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     parent_mass = spectrum.get("parent_mass", None)
     if parent_mass and ratio_required:

--- a/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("matchms")
 
 def require_minimum_number_of_peaks(spectrum_in: SpectrumType,
                                     n_required: int = 10,
-                                    ratio_required: Optional[float] = None, clone: Optional[bool] = True) -> SpectrumType:
+                                    ratio_required: Optional[float] = None, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Spectrum will be set to None when it has fewer peaks than required.
 
     Parameters

--- a/matchms/filtering/peak_processing/select_by_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_intensity.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import numpy as np
 from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType

--- a/matchms/filtering/peak_processing/select_by_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_intensity.py
@@ -19,6 +19,11 @@ def select_by_intensity(spectrum_in: SpectrumType, intensity_from: float = 10.0,
         Set upper threshold for peak intensity. Default is 200.0.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with peaks within the specified intensity range, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/select_by_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_intensity.py
@@ -11,10 +11,14 @@ def select_by_intensity(spectrum_in: SpectrumType, intensity_from: float = 10.0,
 
     Parameters
     ----------
+    spectrum_in:
+        Input spectrum.
     intensity_from:
         Set lower threshold for peak intensity. Default is 10.0.
     intensity_to:
         Set upper threshold for peak intensity. Default is 200.0.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/select_by_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_intensity.py
@@ -4,7 +4,7 @@ from matchms.typing import SpectrumType
 
 
 def select_by_intensity(spectrum_in: SpectrumType, intensity_from: float = 10.0,
-                        intensity_to: float = 200.0, clone: Optional[bool] = True) -> SpectrumType:
+                        intensity_to: float = 200.0, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Keep only peaks within set intensity range (keep if
     intensity_from >= intensity >= intensity_to). In most cases it is adviced to
     use :py:func:`select_by_relative_intensity` function instead.

--- a/matchms/filtering/peak_processing/select_by_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_intensity.py
@@ -4,7 +4,7 @@ from matchms.typing import SpectrumType
 
 
 def select_by_intensity(spectrum_in: SpectrumType, intensity_from: float = 10.0,
-                        intensity_to: float = 200.0) -> SpectrumType:
+                        intensity_to: float = 200.0, clone: Optional[bool] = True) -> SpectrumType:
     """Keep only peaks within set intensity range (keep if
     intensity_from >= intensity >= intensity_to). In most cases it is adviced to
     use :py:func:`select_by_relative_intensity` function instead.
@@ -19,7 +19,7 @@ def select_by_intensity(spectrum_in: SpectrumType, intensity_from: float = 10.0,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     assert intensity_from <= intensity_to, "'intensity_from' should be smaller than or equal to 'intensity_to'."
 

--- a/matchms/filtering/peak_processing/select_by_mz.py
+++ b/matchms/filtering/peak_processing/select_by_mz.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import numpy as np
 from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType

--- a/matchms/filtering/peak_processing/select_by_mz.py
+++ b/matchms/filtering/peak_processing/select_by_mz.py
@@ -9,10 +9,14 @@ def select_by_mz(spectrum_in: SpectrumType, mz_from: float = 0.0,
 
     Parameters
     ----------
+    spectrum_in:
+        Input spectrum.
     mz_from:
         Set lower threshold for m/z peak positions. Default is 0.0.
     mz_to:
         Set upper threshold for m/z peak positions. Default is 1000.0.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/select_by_mz.py
+++ b/matchms/filtering/peak_processing/select_by_mz.py
@@ -4,7 +4,7 @@ from matchms.typing import SpectrumType
 
 
 def select_by_mz(spectrum_in: SpectrumType, mz_from: float = 0.0,
-                 mz_to: float = 1000.0, clone: Optional[bool] = True) -> SpectrumType:
+                 mz_to: float = 1000.0, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Keep only peaks between mz_from and mz_to (keep if mz_from >= m/z >= mz_to).
 
     Parameters

--- a/matchms/filtering/peak_processing/select_by_mz.py
+++ b/matchms/filtering/peak_processing/select_by_mz.py
@@ -17,6 +17,11 @@ def select_by_mz(spectrum_in: SpectrumType, mz_from: float = 0.0,
         Set upper threshold for m/z peak positions. Default is 1000.0.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with peaks within the specified mz range, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/select_by_mz.py
+++ b/matchms/filtering/peak_processing/select_by_mz.py
@@ -4,7 +4,7 @@ from matchms.typing import SpectrumType
 
 
 def select_by_mz(spectrum_in: SpectrumType, mz_from: float = 0.0,
-                 mz_to: float = 1000.0) -> SpectrumType:
+                 mz_to: float = 1000.0, clone: Optional[bool] = True) -> SpectrumType:
     """Keep only peaks between mz_from and mz_to (keep if mz_from >= m/z >= mz_to).
 
     Parameters
@@ -17,7 +17,7 @@ def select_by_mz(spectrum_in: SpectrumType, mz_from: float = 0.0,
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     assert mz_from <= mz_to, "'mz_from' should be smaller than or equal to 'mz_to'."
 

--- a/matchms/filtering/peak_processing/select_by_relative_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_relative_intensity.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import numpy as np
 from matchms.Fragments import Fragments
 from matchms.typing import SpectrumType

--- a/matchms/filtering/peak_processing/select_by_relative_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_relative_intensity.py
@@ -4,7 +4,7 @@ from matchms.typing import SpectrumType
 
 
 def select_by_relative_intensity(spectrum_in: SpectrumType, intensity_from: float = 0.0,
-                                 intensity_to: float = 1.0) -> SpectrumType:
+                                 intensity_to: float = 1.0, clone: Optional[bool] = True) -> SpectrumType:
     """Keep only peaks within set relative intensity range (keep if
     intensity_from >= intensity >= intensity_to).
 
@@ -18,7 +18,7 @@ def select_by_relative_intensity(spectrum_in: SpectrumType, intensity_from: floa
     if spectrum_in is None:
         return None
 
-    spectrum = spectrum_in.clone()
+    spectrum = spectrum_in.clone() if clone else spectrum_in
 
     assert intensity_from >= 0.0, "'intensity_from' should be larger than or equal to 0."
     assert intensity_to <= 1.0, "'intensity_to' should be smaller than or equal to 1.0."

--- a/matchms/filtering/peak_processing/select_by_relative_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_relative_intensity.py
@@ -18,6 +18,11 @@ def select_by_relative_intensity(spectrum_in: SpectrumType, intensity_from: floa
         Set upper threshold for relative peak intensity. Default is 1.0.
     clone:
         Optionally clone the Spectrum.
+
+    Returns
+    -------
+    Spectrum or None
+        Spectrum with peaks within the relative intensity range, or `None` if not present.
     """
     if spectrum_in is None:
         return None

--- a/matchms/filtering/peak_processing/select_by_relative_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_relative_intensity.py
@@ -4,7 +4,7 @@ from matchms.typing import SpectrumType
 
 
 def select_by_relative_intensity(spectrum_in: SpectrumType, intensity_from: float = 0.0,
-                                 intensity_to: float = 1.0, clone: Optional[bool] = True) -> SpectrumType:
+                                 intensity_to: float = 1.0, clone: Optional[bool] = True) -> Optional[SpectrumType]:
     """Keep only peaks within set relative intensity range (keep if
     intensity_from >= intensity >= intensity_to).
 

--- a/matchms/filtering/peak_processing/select_by_relative_intensity.py
+++ b/matchms/filtering/peak_processing/select_by_relative_intensity.py
@@ -10,10 +10,14 @@ def select_by_relative_intensity(spectrum_in: SpectrumType, intensity_from: floa
 
     Parameters
     ----------
+    spectrum_in:
+        Input spectrum.
     intensity_from:
         Set lower threshold for relative peak intensity. Default is 0.0.
     intensity_to:
         Set upper threshold for relative peak intensity. Default is 1.0.
+    clone:
+        Optionally clone the Spectrum.
     """
     if spectrum_in is None:
         return None

--- a/tests/filtering/test_all_filter_order.py
+++ b/tests/filtering/test_all_filter_order.py
@@ -67,11 +67,17 @@ def test_all_filter_order(early_filters: List[Callable], later_filters: List[Cal
     """Tests if early_filter is run before later_filter"""
     for early_filter in early_filters:
         for later_filter in later_filters:
+            early_filter_index = None
+            later_filter_index = None
+
             for filter_index, filter_function in enumerate(ALL_FILTERS):
                 if early_filter == filter_function:
                     early_filter_index = filter_index
                 if later_filter == filter_function:
                     later_filter_index = filter_index
+
+            assert early_filter_index is not None, f"{early_filter.__name__} not found in ALL_FILTERS"
+            assert later_filter_index is not None, f"{later_filter.__name__} not found in ALL_FILTERS"
             assert later_filter_index > early_filter_index, \
                 f"The filter {early_filter.__name__} should be before {later_filter.__name__}"
 

--- a/tests/filtering/test_derive_annotation_from_compound_name.py
+++ b/tests/filtering/test_derive_annotation_from_compound_name.py
@@ -62,7 +62,7 @@ def test_repair_smiles_from_compound_name_skip_already_correct():
 def test_repair_smiles_from_compound_name(compound_name, parent_mass, smiles,
                                           expected_smiles,
                                           csv_file_with_real_compound_names, tmp_path):
-    #pylint: disable=too-many-arguments, too-many-positional-arguments
+    #pylint: disable=too-many-arguments
     builder = SpectrumBuilder()
     spectrum_in = builder.with_metadata({"compound_name": compound_name,
                                          "parent_mass": parent_mass,

--- a/tests/filtering/test_derive_annotation_from_compound_name.py
+++ b/tests/filtering/test_derive_annotation_from_compound_name.py
@@ -62,7 +62,7 @@ def test_repair_smiles_from_compound_name_skip_already_correct():
 def test_repair_smiles_from_compound_name(compound_name, parent_mass, smiles,
                                           expected_smiles,
                                           csv_file_with_real_compound_names, tmp_path):
-    #pylint: disable=too-many-arguments
+    #pylint: disable=too-many-arguments, too-many-positional-arguments
     builder = SpectrumBuilder()
     spectrum_in = builder.with_metadata({"compound_name": compound_name,
                                          "parent_mass": parent_mass,

--- a/tests/filtering/test_repair_not_matching_annotation.py
+++ b/tests/filtering/test_repair_not_matching_annotation.py
@@ -38,7 +38,7 @@ def test_repair_not_matching_annotation_repair_inchikey(smile, inchi, inchikey, 
 ])
 def test_repair_not_matching_annotation_repair_smiles_inchi(smile, inchi, inchikey, parent_mass,
                                                      correct_smiles, correct_inchi, correct_inchikey):
-    # pylint: disable=too-many-arguments, too-many-positional-arguments
+    # pylint: disable=too-many-arguments
     builder = SpectrumBuilder()
     spectrum_in = builder.with_metadata({"smiles": smile,
                                          "inchi": inchi,

--- a/tests/filtering/test_repair_not_matching_annotation.py
+++ b/tests/filtering/test_repair_not_matching_annotation.py
@@ -38,7 +38,7 @@ def test_repair_not_matching_annotation_repair_inchikey(smile, inchi, inchikey, 
 ])
 def test_repair_not_matching_annotation_repair_smiles_inchi(smile, inchi, inchikey, parent_mass,
                                                      correct_smiles, correct_inchi, correct_inchikey):
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     builder = SpectrumBuilder()
     spectrum_in = builder.with_metadata({"smiles": smile,
                                          "inchi": inchi,

--- a/tests/filtering/test_repair_parent_mass_from_smiles/test_repair_parent_mass_is_molar_mass.py
+++ b/tests/filtering/test_repair_parent_mass_from_smiles/test_repair_parent_mass_is_molar_mass.py
@@ -15,7 +15,7 @@ from tests.builder_Spectrum import SpectrumBuilder
                           ("CN1CCCC1C2=CN=CC=C2", "[M-H]-", 10, 162.23, 10, 162.115698455),
                           ])
 def test_repair_parent_mass_is_molar_mass(smiles, adduct, precursor_mz, parent_mass, expected_precursor_mz, expected_parent_mass):
-    # pylint: disable=too-many-arguments, too-many-positional-arguments
+    # pylint: disable=too-many-arguments
     pytest.importorskip("rdkit")
     spectrum_in = SpectrumBuilder().with_metadata({"smiles": smiles,
                                                    "adduct": adduct,

--- a/tests/filtering/test_repair_parent_mass_from_smiles/test_repair_parent_mass_is_molar_mass.py
+++ b/tests/filtering/test_repair_parent_mass_from_smiles/test_repair_parent_mass_is_molar_mass.py
@@ -15,7 +15,7 @@ from tests.builder_Spectrum import SpectrumBuilder
                           ("CN1CCCC1C2=CN=CC=C2", "[M-H]-", 10, 162.23, 10, 162.115698455),
                           ])
 def test_repair_parent_mass_is_molar_mass(smiles, adduct, precursor_mz, parent_mass, expected_precursor_mz, expected_parent_mass):
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     pytest.importorskip("rdkit")
     spectrum_in = SpectrumBuilder().with_metadata({"smiles": smiles,
                                                    "adduct": adduct,

--- a/tests/filtering/test_repair_parent_mass_from_smiles/test_repair_parent_mass_match_smiles_wrapper.py
+++ b/tests/filtering/test_repair_parent_mass_from_smiles/test_repair_parent_mass_match_smiles_wrapper.py
@@ -19,7 +19,7 @@ from tests.builder_Spectrum import SpectrumBuilder
 def test_repair_parent_mass_match_smiles_wrapper(smiles, parent_mass, precursor_mz, adduct,
                                                  expected_smiles, expected_parent_mass,
                                                  expected_precursor_mz, expected_adduct):
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     pytest.importorskip("rdkit")
     spectrum_in = SpectrumBuilder().with_metadata({"smiles": smiles,
                                                    "precursor_mz": precursor_mz,

--- a/tests/filtering/test_repair_parent_mass_from_smiles/test_repair_parent_mass_match_smiles_wrapper.py
+++ b/tests/filtering/test_repair_parent_mass_from_smiles/test_repair_parent_mass_match_smiles_wrapper.py
@@ -19,7 +19,7 @@ from tests.builder_Spectrum import SpectrumBuilder
 def test_repair_parent_mass_match_smiles_wrapper(smiles, parent_mass, precursor_mz, adduct,
                                                  expected_smiles, expected_parent_mass,
                                                  expected_precursor_mz, expected_adduct):
-    # pylint: disable=too-many-arguments, too-many-positional-arguments
+    # pylint: disable=too-many-arguments
     pytest.importorskip("rdkit")
     spectrum_in = SpectrumBuilder().with_metadata({"smiles": smiles,
                                                    "precursor_mz": precursor_mz,

--- a/tests/filtering/test_spectrum_processor.py
+++ b/tests/filtering/test_spectrum_processor.py
@@ -61,8 +61,8 @@ def test_filter_sorting_and_output():
                           'estimate_from_charge': True, 'clone': True})],
     ["derive_adduct_from_name",
      ('derive_adduct_from_name', {'remove_adduct_from_name': True, 'clone': True})],
-    [("require_correct_ionmode", {"ion_mode_to_keep": "both", "clone": True}),
-     ("require_correct_ionmode", {"ion_mode_to_keep": "both", "clone": True})],
+    [("require_correct_ionmode", {"ion_mode_to_keep": "both"}),
+     ("require_correct_ionmode", {"ion_mode_to_keep": "both"})],
 ])
 def test_overwrite_default_settings(filter_step: str, expected):
     """Test if both default settings and set settings are returned in processing steps"""

--- a/tests/filtering/test_spectrum_processor.py
+++ b/tests/filtering/test_spectrum_processor.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import numpy as np
@@ -43,22 +44,25 @@ def test_filter_sorting_and_output():
     actual_filters = [x.__name__ for x in processing.filters]
     assert actual_filters == expected_filters
     # 2nd way to access the filter names via processing_steps attribute:
-    expected_filters = ['make_charge_int',
-                        ('derive_adduct_from_name', {'remove_adduct_from_name': True}),
-                        'interpret_pepmass',
-                        'derive_ionmode',
-                        'correct_charge']
+    expected_filters = [
+        ('make_charge_int', {'clone': True}),
+        ('derive_adduct_from_name', {'remove_adduct_from_name': True, 'clone': True}),
+        ('interpret_pepmass', {'clone': True}),
+        ('derive_ionmode', {'clone': True}),
+        ('correct_charge', {'clone': True}),
+    ]
+
     assert processing.processing_steps == expected_filters
 
 
 @pytest.mark.parametrize("filter_step, expected", [
-    [("add_parent_mass", {'estimate_from_adduct': False}),
+    [("add_parent_mass", {'estimate_from_adduct': False, 'clone': True}),
      ('add_parent_mass', {'estimate_from_adduct': False, 'overwrite_existing_entry': False,
-                          'estimate_from_charge': True})],
+                          'estimate_from_charge': True, 'clone': True})],
     ["derive_adduct_from_name",
-     ('derive_adduct_from_name', {'remove_adduct_from_name': True})],
-    [("require_correct_ionmode", {"ion_mode_to_keep": "both"}),
-     ("require_correct_ionmode", {"ion_mode_to_keep": "both"})],
+     ('derive_adduct_from_name', {'remove_adduct_from_name': True, 'clone': True})],
+    [("require_correct_ionmode", {"ion_mode_to_keep": "both", "clone": True}),
+     ("require_correct_ionmode", {"ion_mode_to_keep": "both", "clone": True})],
 ])
 def test_overwrite_default_settings(filter_step: str, expected):
     """Test if both default settings and set settings are returned in processing steps"""
@@ -85,8 +89,9 @@ def test_string_output():
                                             "derive_ionmode",
                                             "correct_charge",
                                             ])
-    expected_str = "Processing steps:\n- make_charge_int\n- interpret_pepmass" \
-                   "\n- derive_ionmode\n- correct_charge\n"
+    expected_str = "Processing steps:\n- - make_charge_int\n  - clone: true\n- - interpret_pepmass\n  - clone: true" \
+                   "\n- - derive_ionmode\n  - clone: true\n- - correct_charge\n  - clone: true\n"
+
     assert str(processing) == expected_str
 
 
@@ -103,12 +108,13 @@ def test_filter_spectra(spectra):
                                            "derive_ionmode",
                                            "correct_charge",
                                            ])
-    spectra, _ = processor.process_spectra(spectra)
+    spectra, report = processor.process_spectra(spectra)
 
     assert len(spectra) == 3
     actual_masses = [s.get("precursor_mz") for s in spectra]
     expected_masses = [100, 102, 104]
     assert actual_masses == expected_masses
+    assert report is None
 
 
 def test_filter_spectra_report(spectra):
@@ -118,7 +124,7 @@ def test_filter_spectra_report(spectra):
                                            "correct_charge",
                                            ])
     processor.parse_and_add_filter(filter_description=("require_minimum_number_of_peaks", {"n_required": 2}))
-    spectra, report = processor.process_spectra(spectra)
+    spectra, report = processor.process_spectra(spectra, create_report=True)
     assert len(spectra) == 2
     actual_masses = [s.get("precursor_mz") for s in spectra]
     expected_masses = [100, 102]
@@ -157,7 +163,7 @@ def test_processing_report_class(spectra):
     assert re.search(expected_repr_parts, repr(processing_report)) is not None
 
 
-def test_adding_custom_filter(spectra):
+def test_filter_report_filter_does_not_support_cloning(spectra, caplog):
     def nonsense_inchikey(s):
         s_in = s.clone()
         s_in.set("inchikey", "NONSENSE")
@@ -169,9 +175,40 @@ def test_adding_custom_filter(spectra):
                                            "correct_charge",
                                            ])
     processor.parse_and_add_filter(nonsense_inchikey)
+
+    with caplog.at_level(logging.ERROR):
+        spectra, report = processor.process_spectra(spectra, create_report=True)
+
+    assert report is not None
+    assert "Processing report is set to True, but the filter function nonsense_inchikey does not support cloning." in caplog.text
+
+
+def test_filter_no_report_filter_skip_cloning(spectra):
+    def test_filter(s, clone=True):
+        assert clone is False, f"Expected clone=False in Filter, but got {clone}"
+        return s
+
+    processor = SpectrumProcessor(filters=())
+    processor.parse_and_add_filter(test_filter)
+    spectra, report = processor.process_spectra(spectra, create_report=False)
+    assert report is None
+
+
+def test_adding_custom_filter(spectra):
+    def nonsense_inchikey(s, clone=True):
+        s_in = s.clone() if clone else s
+        s_in.set("inchikey", "NONSENSE")
+        return s_in
+
+    processor = SpectrumProcessor(filters=["make_charge_int",
+                                           "interpret_pepmass",
+                                           "derive_ionmode",
+                                           "correct_charge",
+                                           ])
+    processor.parse_and_add_filter(nonsense_inchikey)
     filters = processor.filters
     assert filters[-1].__name__ == "nonsense_inchikey"
-    spectra, report = processor.process_spectra(spectra)
+    spectra, report = processor.process_spectra(spectra, create_report=True)
     assert report.counter_number_processed == 3
     assert report.counter_changed_metadata == {'make_charge_int': 2, 'interpret_pepmass': 3,
                                                'derive_ionmode': 3, 'nonsense_inchikey': 3}
@@ -179,8 +216,8 @@ def test_adding_custom_filter(spectra):
 
 
 def test_adding_custom_filter_with_parameters(spectra):
-    def nonsense_inchikey_multiple(s, number):
-        s_in = s.clone()
+    def nonsense_inchikey_multiple(s, number, clone=True):
+        s_in = s.clone() if clone else s
         s_in.set("inchikey", number * "NONSENSE")
         return s_in
 
@@ -192,7 +229,7 @@ def test_adding_custom_filter_with_parameters(spectra):
     processor.parse_and_add_filter((nonsense_inchikey_multiple, {"number": 2}))
     filters = processor.filters
     assert filters[-1].__name__ == "nonsense_inchikey_multiple"
-    spectra, report = processor.process_spectra(spectra)
+    spectra, report = processor.process_spectra(spectra, create_report=True)
     assert report.counter_number_processed == 3
     assert report.counter_changed_metadata == {'make_charge_int': 2, 'interpret_pepmass': 3,
                                                'derive_ionmode': 3, 'nonsense_inchikey_multiple': 3}
@@ -242,7 +279,8 @@ def test_add_matchms_filter_in_position():
 
 
 def test_add_custom_filter_with_parameters(spectra):
-    def nonsense_inchikey_multiple(s, number):
+    def nonsense_inchikey_multiple(s, number, clone=True):
+        s = s.clone() if clone else s
         s.set("inchikey", number * "NONSENSE")
         return s
 
@@ -255,7 +293,7 @@ def test_add_custom_filter_with_parameters(spectra):
     filters = processor.filters
 
     assert filters[-1].__name__ == "nonsense_inchikey_multiple"
-    spectra, _ = processor.process_spectra(spectra)
+    spectra, _ = processor.process_spectra(spectra, create_report=True)
     assert spectra[0].get("inchikey") == "NONSENSENONSENSE", "Custom filter not executed properly"
 
 
@@ -278,7 +316,7 @@ def test_add_matchms_filter(filter_description, spectra):
 
 
 @pytest.mark.parametrize("filter_description", [
-    ("derive_adduct_from_name", {"remove_adduct_from_name": False}),
+    ("derive_adduct_from_name", {"remove_adduct_from_name": False, "clone": True}),
 ])
 def test_add_duplicated_filter_to_existing_pipeline(filter_description):
     """Tests if adding a filter that is already in the basic pipeline is overwritten and not duplicated"""
@@ -295,16 +333,17 @@ def test_add_filter_twice():
     processor = SpectrumProcessor(filters=())
     processor.parse_and_add_filter(("derive_adduct_from_name", {"remove_adduct_from_name": False}))
     processor.parse_and_add_filter("derive_adduct_from_name")
-    assert processor.processing_steps == [("derive_adduct_from_name", {"remove_adduct_from_name": True})]
+    assert processor.processing_steps == [("derive_adduct_from_name", {"remove_adduct_from_name": True, 'clone': True})]
 
 
 def test_add_all_filter_types(spectra):
-    def nonsense_inchikey_multiple(s, number):
+    def nonsense_inchikey_multiple(s, number, clone=True):
+        s = s.clone() if clone else s
         s.set("inchikey", number * "NONSENSE")
         return s
 
-    def nonsense_inchikey(s):
-        s_in = s.clone()
+    def nonsense_inchikey(s, clone=True):
+        s_in = s.clone() if clone else s
         s_in.set("inchikey", "NONSENSE")
         return s_in
 


### PR DESCRIPTION
- This adds the parameter to all filters to clone the spectrum in the filter, defaulting to True in the filter.
- SpectrumProcessor will clone each spectrum just once and disables cloning in each filter.

- ProcessingReport relies in cloning of spectrum inside the filter, therefore the param `create_report` is added to `process_spectra` is added, defaulting to False.

- Adds better type hinting for the filters and improved docstrings.