### PR TITLE
Refactor multiple scores

### DIFF
--- a/matchms/similarity/BaseSimilarity.py
+++ b/matchms/similarity/BaseSimilarity.py
@@ -24,7 +24,16 @@ class BaseSimilarity:
     is_commutative = True
     # Set output data type, e.g. "float" or [("score", "float"), ("matches", "int")]
     # If you set multiple data types, the main score should be set to "score" this is used as default for filtering.
-    score_datatype = np.float64
+    score_datatype = [("score", np.float64)]
+
+    def __init__(self, only_store_main_score: bool = True):
+        self.only_store_main_score = only_store_main_score
+        if self.only_store_main_score:
+            self.main_score_dtype = self.score_datatype[0]
+            self.main_score_name = self.score_datatype[0][0]
+        else:
+            self.main_score_dtype = self.score_datatype
+            self.main_score_name = None
 
     @abstractmethod
     def pair(self, reference: SpectrumType, query: SpectrumType) -> np.ndarray:

--- a/matchms/similarity/BaseSimilarity.py
+++ b/matchms/similarity/BaseSimilarity.py
@@ -52,6 +52,12 @@ class BaseSimilarity:
         """
         raise NotImplementedError
 
+    def select_main_score(self, score: np.ndarray) -> np.ndarray:
+        """Extracts the main score"""
+        if self.only_store_main_score:
+            return score
+        return score[self.main_score_name]
+
     def calculate_scores(self, scores: Scores,
                          filters: Tuple[FilterScoreByValue] = (),
                          name: str = None,

--- a/matchms/similarity/BaseSimilarity.py
+++ b/matchms/similarity/BaseSimilarity.py
@@ -26,14 +26,14 @@ class BaseSimilarity:
     # If you set multiple data types, the main score should be set to "score" this is used as default for filtering.
     score_datatype = [("score", np.float64)]
 
-    def __init__(self, only_store_main_score: bool = True):
-        self.only_store_main_score = only_store_main_score
-        if self.only_store_main_score:
-            self.main_score_dtype = self.score_datatype[0]
-            self.main_score_name = self.score_datatype[0][0]
-        else:
+    def __init__(self, store_multi_score: bool = False):
+        self.store_multi_score = store_multi_score
+        if self.store_multi_score:
             self.main_score_dtype = self.score_datatype
             self.main_score_name = None
+        else:
+            self.main_score_dtype = self.score_datatype[0]
+            self.main_score_name = self.score_datatype[0][0]
 
     @abstractmethod
     def pair(self, reference: SpectrumType, query: SpectrumType) -> np.ndarray:
@@ -54,7 +54,7 @@ class BaseSimilarity:
 
     def select_main_score(self, score: np.ndarray) -> np.ndarray:
         """Extracts the main score"""
-        if self.only_store_main_score:
+        if self.store_multi_score:
             return score
         return score[self.main_score_name]
 


### PR DESCRIPTION
It was often confusing that some scores return multiple values.
The use case most of the times is filtering on these scores, but after the filtering it is not necessary. 

Here a proposed solution: 
Add a parameter to BaseSimilarity (and subclasses): only_store_main_score. If this is True all matrix methods just return a single score (the main one). If False it will return all scores, e.g. including matches. If this setting is set to True both scores are still calculated and can be used with the FilterScoreByValue class (by setting score_name="nr_of_matches"), but after filtering it is not stored.

To do (after confirmation that this is a good fix) 
- [ ] Add call to super.__init__ for SimilarityScores
- [ ] Add tests testing this mechanic. 
- [ ] Add a check that filter on anything else cannot be combined if only one score is returned for the current filter after matrix compute method. This requires some fixes

**Note, some merge conflicts need to be resolved, but the check if this makes sense can still be made**