### PR TITLE
Migrate/python 313

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- support for python 3.13 [#728](https://github.com/matchms/matchms/issues/728) and [#803](https://github.com/matchms/matchms/issues/803)
+
+### Changed
+- dropped compatibility with numpy `<2.0`
+
 ## [0.29.0] - 2025-05-06
 ### Added
 - Implemented preliminary mzSpecLib export [#757](https://github.com/matchms/matchms/pull/757)

--- a/README.rst
+++ b/README.rst
@@ -116,14 +116,14 @@ Installation
 
 Prerequisites:  
 
-- Python 3.10 - 3.12, (higher versions should work as well, but are not yet tested systematically)
+- Python 3.10 - 3.13, (higher versions should work as well, but are not yet tested systematically)
 - Anaconda (recommended)
 
 We recommend installing matchms in a new virtual environment to avoid dependency clashes
 
 .. code-block:: console
 
-  conda create --name matchms python=3.11
+  conda create --name matchms python=3.12
   conda activate matchms
   conda install --channel bioconda --channel conda-forge matchms
 
@@ -318,7 +318,7 @@ To install matchms, do:
 
   git clone https://github.com/matchms/matchms.git
   cd matchms
-  conda create --name matchms-dev python=3.11
+  conda create --name matchms-dev python=3.12
   conda activate matchms-dev
 
   # If you use poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,23 +22,24 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13"
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
-numpy = ">1.24"
-scipy = "^1.14.1"
+python = ">=3.10,<3.14"
+numpy = ">=2.1.0"
+scipy = "^1.15.3"
 pandas = "^2.2.3"
 pillow = "!=9.4.0"
-lxml = "^4.9.3"
+lxml = "^5.4.0"
 matplotlib = ">=3.7"
 networkx = "^3.4.2"
-numba = "^0.60.0"
+numba = "^0.61.0"
 pickydict = ">=0.4.0"
 pyteomics = ">=4.6"
 requests = ">=2.31.0"
-sparsestack = ">=0.6.0"
+sparsestack = ">=0.7.0"
 tqdm = ">=4.65.0"
 rdkit = "^2024.3.5"
 pyyaml = ">=6.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
-numpy = ">=2.1.0"
+numpy = ">=2.0.0"
 scipy = "^1.15.3"
 pandas = "^2.2.3"
 pillow = "!=9.4.0"


### PR DESCRIPTION
This adds support for python 3.13 as mentioned in #728 and #803 and bumps some dependencies:
* numPy `>1.24` ->` >=2.0.0` (numPy 1 support is dropped!)
* scipy `^1.14.1` -> `^1.15.3`
* lxml `^4.9.3` -> `^5.4.0`
* numba `^0.60.0` -> `^0.61.0`
* sparsestack `>=0.6.0` -> `>=0.7.0` (needs to be released [PR30](https://github.com/matchms/sparsestack/pull/30))
