### PR TITLE
Update BinnedEmbeddingSimilarity.py

### DIFF
--- a/matchms/similarity/BinnedEmbeddingSimilarity.py
+++ b/matchms/similarity/BinnedEmbeddingSimilarity.py
@@ -18,11 +18,19 @@ class BinnedEmbeddingSimilarity(BaseEmbeddingSimilarity):
         The maximum m/z value to consider when binning. Default is 1005.
     bin_width : float, optional
         The width of each bin in m/z units. Default is 1.
+    intensity_power:
+        The power to raise the peak intensities. Default is 1.
     """
-    def __init__(self, similarity: str = "cosine", max_mz: float = 1005, bin_width: float = 1):
+    def __init__(
+        self, similarity: str = "cosine",
+        max_mz: float = 1005,
+        bin_width: float = 1,
+        intensity_power: float = 1
+    ):
         super().__init__(similarity=similarity)
         self.max_mz = max_mz
         self.bin_width = bin_width
+        self.intensity_power = intensity_power
 
     def _bin_spectrum(self, spectrum: SpectrumType) -> np.ndarray:
         """Bin a spectrum's peaks into fixed-width m/z bins.
@@ -39,7 +47,7 @@ class BinnedEmbeddingSimilarity(BaseEmbeddingSimilarity):
         """
         # NOTE: copypaste from https://github.com/pluskal-lab/MassSpecGym/blob/f525a5e55a39ec4caa4f1a51e64acd046713179e/massspecgym/data/transforms.py#L97
         mzs = spectrum.peaks.mz
-        intensities = spectrum.peaks.intensities
+        intensities = spectrum.peaks.intensities ** self.intensity_power
 
         # Calculate the number of bins
         num_bins = int(np.ceil(self.max_mz / self.bin_width))


### PR DESCRIPTION
Add `intensity_power` parameter to `BinnedEmbeddingSimilarity` to allow scaling of peak intensities.