### PR TITLE
Calling Ghostbusters on phantom pairs

### DIFF
--- a/matchms/similarity/CosineGreedy.py
+++ b/matchms/similarity/CosineGreedy.py
@@ -27,9 +27,11 @@ class CosineGreedy(BaseSimilarity):
         from matchms.similarity import CosineGreedy
 
         reference = Spectrum(mz=np.array([100, 150, 200.]),
-                             intensities=np.array([0.7, 0.2, 0.1]))
+                             intensities=np.array([0.7, 0.2, 0.1]),
+                             metadata={"precursor_mz": 200.0})
         query = Spectrum(mz=np.array([100, 140, 190.]),
-                         intensities=np.array([0.4, 0.2, 0.1]))
+                         intensities=np.array([0.4, 0.2, 0.1]),
+                         metadata={"precursor_mz": 190.0})
 
         # Use factory to construct a similarity function
         cosine_greedy = CosineGreedy(tolerance=0.2)

--- a/matchms/similarity/CosineHungarian.py
+++ b/matchms/similarity/CosineHungarian.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import List, Optional, Tuple
 import numpy as np
 from scipy.optimize import linear_sum_assignment
 from matchms.similarity.spectrum_similarity_functions import collect_peak_pairs
@@ -7,20 +7,20 @@ from .BaseSimilarity import BaseSimilarity
 
 
 class CosineHungarian(BaseSimilarity):
-    """Calculate 'cosine similarity score' between two spectra (using Hungarian algorithm).
+    """Calculate 'cosine similarity score' between two spectra using the Hungarian algorithm.
 
-    The cosine score aims at quantifying the similarity between two mass spectra.
-    The score is calculated by finding best possible matches between peaks
-    of two spectra. Two peaks are considered a potential match if their
-    m/z ratios lie within the given 'tolerance'.
-    The underlying peak assignment problem is here solved using the Hungarian algorithm.
-    This can perform notably slower than the 'greedy' implementation in
-    :class:`~matchms.similarity.CosineGreedy`, but does represent a mathematically proper
-    solution to the problem.
+    The cosine score quantifies the similarity between two mass spectra by finding
+    the optimal one-to-one matching between their peaks. Two peaks are considered a
+    potential match if their m/z ratios lie within the given *tolerance*.
+
+    The peak assignment is solved using the Hungarian algorithm
+    (``scipy.optimize.linear_sum_assignment``), which finds the assignment that
+    maximises the sum of intensity products. This is mathematically optimal but can
+    be notably slower than the greedy heuristic in
+    :class:`~matchms.similarity.CosineGreedy`.
     """
-    # Set key characteristics as class attributes
+
     is_commutative = True
-    # Set output data type, e.g. ("score", "float") or [("score", "float"), ("matches", "int")]
     score_datatype = [("score", np.float64), ("matches", "int")]
 
     def __init__(self, tolerance: float = 0.1, mz_power: float = 0.0,
@@ -50,13 +50,15 @@ class CosineHungarian(BaseSimilarity):
         query
             Single query spectrum.
 
-        Returns:
-        --------
-
+        Returns
+        -------
         Tuple with cosine score and number of matched peaks.
         """
-        def get_matching_pairs():
-            """Get pairs of peaks that match within the given tolerance."""
+        def get_matching_pairs() -> Optional[np.ndarray]:
+            """Find all within-tolerance peak pairs, sorted by descending intensity product.
+
+            Returns ``None`` when no peaks fall within *tolerance*.
+            """
             matching_pairs = collect_peak_pairs(spec1, spec2, self.tolerance, shift=0.0,
                                                 mz_power=self.mz_power,
                                                 intensity_power=self.intensity_power)
@@ -65,41 +67,76 @@ class CosineHungarian(BaseSimilarity):
             matching_pairs = matching_pairs[np.argsort(matching_pairs[:, 2], kind='mergesort')[::-1], :]
             return matching_pairs
 
-        def get_matching_pairs_matrix():
-            """Create matrix of multiplied intensities of all matching pairs
-            between spectrum1 and spectrum2.
+        def get_matching_pairs_matrix() -> Tuple[
+            Optional[List[float]], Optional[List[float]], Optional[np.ndarray]
+        ]:
+            """Build a cost matrix for the Hungarian algorithm.
+
+            Rows correspond to the unique reference peaks that participate in at
+            least one within-tolerance pair; columns correspond to the unique query
+            peaks. The matrix is initialised to ``1.0`` (maximum cost) and actual
+            within-tolerance pairs are set to ``1 - intensity_product``.
+
             Returns
-            paired_peaks1:
-                list of paired peaks of spectrum1
-            paired_peaks2:
-                list of paired peaks of spectrum2
-            matching_pairs_matrix:
-                Array of multiplied intensities between all matching peaks.
+            -------
+            paired_peaks1
+                Unique reference-peak indices involved in at least one match.
+            paired_peaks2
+                Unique query-peak indices involved in at least one match.
+            cost_matrix
+                Cost matrix of shape ``(len(paired_peaks1), len(paired_peaks2))``.
+                Cells that remain ``1.0`` have **no** real within-tolerance pair.
             """
             if matching_pairs is None:
                 return None, None, None
             paired_peaks1 = list(set(matching_pairs[:, 0]))
             paired_peaks2 = list(set(matching_pairs[:, 1]))
             matrix_size = (len(paired_peaks1), len(paired_peaks2))
-            matching_pairs_matrix = np.ones(matrix_size)
+            cost_matrix = np.ones(matrix_size)
             for i in range(matching_pairs.shape[0]):
-                matching_pairs_matrix[paired_peaks1.index(matching_pairs[i, 0]),
-                                      paired_peaks2.index(matching_pairs[i, 1])] = 1 - matching_pairs[i, 2]
-            return paired_peaks1, paired_peaks2, matching_pairs_matrix
+                cost_matrix[paired_peaks1.index(matching_pairs[i, 0]),
+                            paired_peaks2.index(matching_pairs[i, 1])] = 1 - matching_pairs[i, 2]
+            return paired_peaks1, paired_peaks2, cost_matrix
 
-        def solve_hungarian():
-            """Use hungarian algorithm to solve the linear sum assignment problem."""
+        def solve_hungarian() -> Tuple[float, List[Tuple[int, int]]]:
+            """Solve the optimal peak assignment via the Hungarian algorithm.
+
+            The algorithm assigns ``min(rows, cols)`` pairs. Some of those
+            assignments may land on cells that were never overwritten from the
+            initial ``1.0`` — i.e. peak pairs that are **not** within tolerance
+            ("phantom pairs"). These contribute ``1 - 1.0 = 0`` to the score, so
+            the score is unaffected, but they must be excluded from the match count.
+
+            The score formula ``len(row_ind) - sum(costs)`` relies on phantoms
+            contributing exactly ``1.0`` to the sum, so the score line must use
+            **all** assignments (including phantoms).
+
+            Returns
+            -------
+            score
+                Un-normalised cosine score (sum of intensity products for matched
+                peaks).
+            used_matches
+                List of ``(reference_peak_idx, query_peak_idx)`` tuples for the
+                real (non-phantom) matched pairs only.
+            """
             row_ind, col_ind = linear_sum_assignment(matching_pairs_matrix)
+            # Score uses ALL assignments: phantoms add 1.0 to the sum, cancelling
+            # with the len(row_ind) term and contributing 0 to the score.
             score = len(row_ind) - matching_pairs_matrix[row_ind, col_ind].sum()
-            used_matches = [(paired_peaks1[x], paired_peaks2[y]) for (x, y) in zip(row_ind, col_ind)]
+            # Match count excludes phantoms (cells still at 1.0).
+            used_matches = [
+                (int(paired_peaks1[x]), int(paired_peaks2[y]))
+                for (x, y) in zip(row_ind, col_ind)
+                if matching_pairs_matrix[x, y] < 1.0
+            ]
             return score, used_matches
 
-        def calc_score():
-            """Calculate cosine similarity score."""
+        def calc_score() -> np.ndarray:
+            """Compute the normalised cosine score and match count."""
             if matching_pairs_matrix is None:
                 return np.asarray((0.0, 0), dtype=self.score_datatype)
             score, used_matches = solve_hungarian()
-            # Normalize score:
             spec1_power = np.power(spec1[:, 0], self.mz_power) \
                 * np.power(spec1[:, 1], self.intensity_power)
             spec2_power = np.power(spec2[:, 0], self.mz_power) \

--- a/tests/similarity/test_cosine_hungarian.py
+++ b/tests/similarity/test_cosine_hungarian.py
@@ -2,134 +2,246 @@ import numpy as np
 import pytest
 from matchms import Spectrum
 from matchms.similarity import CosineHungarian
+from matchms.reference_spectra import cocaine, glucose, phenylalanine, hydroxy_cholesterol
+
+
+def test_cosine_hungarian_cocaine_glucose():
+    """Compare output cosine score with own calculation on reference spectra."""
+    glucose_spectrum = glucose()
+    cocaine_spectrum = cocaine()
+
+    cosine_hungarian = CosineHungarian(tolerance=0.1, mz_power=1.0, intensity_power=1.0)
+
+    (similarity, shared_peaks) = cosine_hungarian.pair(glucose_spectrum, cocaine_spectrum)[()]
+    assert similarity == 0.0
+    assert shared_peaks == 0
+
+    cosine_hungarian = CosineHungarian(tolerance=5.0, mz_power=0.0, intensity_power=1.0)
+
+    (similarity, shared_peaks) = cosine_hungarian.pair(glucose_spectrum, cocaine_spectrum)[()]
+    assert similarity == 0.453757948440651, "Expected different cosine score: {}".format(similarity)
+    assert shared_peaks == 5, "Expected different number of matching peaks: {}".format(
+        shared_peaks
+    )
+
+def test_cosine_hungarian_phenylalanine_hydroxy_cholesterol():
+    """Compare output cosine score with own calculation on reference spectra."""
+    phenylalanine_spectrum = phenylalanine()
+    hydroxy_cholesterol_spectrum = hydroxy_cholesterol()
+
+    cosine_hungarian = CosineHungarian(tolerance=0.1, mz_power=1.0, intensity_power=1.0)
+
+    (similarity, shared_peaks) = cosine_hungarian.pair(phenylalanine_spectrum, hydroxy_cholesterol_spectrum)[()]
+    assert similarity < 0.0001
+    assert shared_peaks == 3
+
+    cosine_hungarian = CosineHungarian(tolerance=5.0, mz_power=0.0, intensity_power=1.0)
+
+    (similarity, shared_peaks) = cosine_hungarian.pair(phenylalanine_spectrum, hydroxy_cholesterol_spectrum)[()]
+    assert similarity < 0.01, "Expected different cosine score: {}".format(similarity)
+    assert shared_peaks == 19, "Expected different number of matching peaks: {}".format(
+        shared_peaks
+    )
 
 
 def test_cosine_hungarian_without_parameters():
     """Compare output cosine score with own calculation on simple dummy spectra."""
-    spectrum_1 = Spectrum(mz=np.array([100, 200, 300, 500, 510], dtype="float"),
-                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(
+        mz=np.array([100, 200, 300, 500, 510], dtype="float"),
+        intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"),
+    )
 
-    spectrum_2 = Spectrum(mz=np.array([100, 200, 290, 490, 510], dtype="float"),
-                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_2 = Spectrum(
+        mz=np.array([100, 200, 290, 490, 510], dtype="float"),
+        intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"),
+    )
     cosine_hungarian = CosineHungarian()
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     # Derive expected cosine score
-    expected_matches = [0, 1, 4]  # Those peaks have matching mz values (within given tolerance)
-    multiply_matching_intensities = spectrum_1.peaks.intensities[expected_matches] \
+    expected_matches = [
+        0,
+        1,
+        4,
+    ]  # Those peaks have matching mz values (within given tolerance)
+    multiply_matching_intensities = (
+        spectrum_1.peaks.intensities[expected_matches]
         * spectrum_2.peaks.intensities[expected_matches]
-    denominator = np.sqrt((spectrum_1.peaks.intensities ** 2).sum()) \
-        * np.sqrt((spectrum_2.peaks.intensities ** 2).sum())
+    )
+    denominator = np.sqrt((spectrum_1.peaks.intensities**2).sum()) * np.sqrt(
+        (spectrum_2.peaks.intensities**2).sum()
+    )
     expected_score = multiply_matching_intensities.sum() / denominator
 
-    assert score["score"] == pytest.approx(expected_score, 0.0001), "Expected different cosine score."
-    assert score["matches"] == len(expected_matches), "Expected different number of matching peaks."
+    assert score["score"] == pytest.approx(
+        expected_score, 0.0001
+    ), "Expected different cosine score."
+    assert score["matches"] == len(
+        expected_matches
+    ), "Expected different number of matching peaks."
 
 
 def test_cosine_hungarian_matrix_without_parameters():
     """Compare output cosine score with expected scores."""
-    spectrum_1 = Spectrum(mz=np.array([100, 200, 300, 500, 510], dtype="float"),
-                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(
+        mz=np.array([100, 200, 300, 500, 510], dtype="float"),
+        intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"),
+    )
 
-    spectrum_2 = Spectrum(mz=np.array([100, 200, 290, 490, 510], dtype="float"),
-                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_2 = Spectrum(
+        mz=np.array([100, 200, 290, 490, 510], dtype="float"),
+        intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"),
+    )
     cosine_hungarian = CosineHungarian()
     scores = cosine_hungarian.matrix([spectrum_1, spectrum_2], [spectrum_1, spectrum_2])
 
-    assert scores[0, 0]["score"] == scores[1, 1]["score"] == 1., "Expected different cosine score."
-    assert scores[0, 0]["matches"] == scores[1, 1]["matches"] == 5, "Expected different cosine matches."
-    assert scores[0, 1]["score"] == scores[1, 0]["score"] == pytest.approx(0.1615384, 1e-6), \
-        "Expected different cosine score."
-    assert scores[0, 1]["matches"] == scores[1, 0]["matches"] == 3, "Expected different cosine matches."
+    assert (
+        scores[0, 0]["score"] == scores[1, 1]["score"] == 1.0
+    ), "Expected different cosine score."
+    assert (
+        scores[0, 0]["matches"] == scores[1, 1]["matches"] == 5
+    ), "Expected different cosine matches."
+    assert (
+        scores[0, 1]["score"] == scores[1, 0]["score"] == pytest.approx(0.1615384, 1e-6)
+    ), "Expected different cosine score."
+    assert (
+        scores[0, 1]["matches"] == scores[1, 0]["matches"] == 3
+    ), "Expected different cosine matches."
 
 
 def test_cosine_hungarian_with_tolerance_0_2():
     """Compare output cosine score for tolerance 0.2 with own calculation on simple dummy spectra."""
-    spectrum_1 = Spectrum(mz=np.array([100, 299, 300, 301, 510], dtype="float"),
-                          intensities=np.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(
+        mz=np.array([100, 299, 300, 301, 510], dtype="float"),
+        intensities=np.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float"),
+    )
 
-    spectrum_2 = Spectrum(mz=np.array([100, 300, 301, 511], dtype="float"),
-                          intensities=np.array([0.1, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_2 = Spectrum(
+        mz=np.array([100, 300, 301, 511], dtype="float"),
+        intensities=np.array([0.1, 1.0, 0.3, 0.4], dtype="float"),
+    )
     cosine_hungarian = CosineHungarian(tolerance=0.2)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     # Derive expected cosine score
-    expected_matches = [[0, 2, 3], [0, 1, 2]]  # Those peaks have matching mz values (within given tolerance)
-    multiply_matching_intensities = spectrum_1.peaks.intensities[expected_matches[0]] \
+    expected_matches = [
+        [0, 2, 3],
+        [0, 1, 2],
+    ]  # Those peaks have matching mz values (within given tolerance)
+    multiply_matching_intensities = (
+        spectrum_1.peaks.intensities[expected_matches[0]]
         * spectrum_2.peaks.intensities[expected_matches[1]]
-    denominator = np.sqrt((spectrum_1.peaks.intensities ** 2).sum()) \
-        * np.sqrt((spectrum_2.peaks.intensities ** 2).sum())
+    )
+    denominator = np.sqrt((spectrum_1.peaks.intensities**2).sum()) * np.sqrt(
+        (spectrum_2.peaks.intensities**2).sum()
+    )
     expected_score = multiply_matching_intensities.sum() / denominator
 
-    assert score["score"] == pytest.approx(expected_score, 0.0001), "Expected different cosine score."
-    assert score["matches"] == len(expected_matches[0]), "Expected different number of matching peaks."
+    assert score["score"] == pytest.approx(
+        expected_score, 0.0001
+    ), "Expected different cosine score."
+    assert score["matches"] == len(
+        expected_matches[0]
+    ), "Expected different number of matching peaks."
 
 
 def test_cosine_hungarian_with_tolerance_2_0():
     """Compare output cosine score for tolerance 2.0 with own calculation on simple dummy spectra."""
-    spectrum_1 = Spectrum(mz=np.array([100, 299, 300, 301, 510], dtype="float"),
-                          intensities=np.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(
+        mz=np.array([100, 299, 300, 301, 510], dtype="float"),
+        intensities=np.array([0.1, 1.0, 0.2, 0.3, 0.4], dtype="float"),
+    )
 
-    spectrum_2 = Spectrum(mz=np.array([100, 300, 301, 511], dtype="float"),
-                          intensities=np.array([0.1, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_2 = Spectrum(
+        mz=np.array([100, 300, 301, 511], dtype="float"),
+        intensities=np.array([0.1, 1.0, 0.3, 0.4], dtype="float"),
+    )
     cosine_hungarian = CosineHungarian(tolerance=2.0)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     # Derive expected cosine score
-    expected_matches = [[0, 1, 3, 4], [0, 1, 2, 3]]  # Those peaks have matching mz values (within given tolerance)
-    multiply_matching_intensities = spectrum_1.peaks.intensities[expected_matches[0]] \
+    expected_matches = [
+        [0, 1, 3, 4],
+        [0, 1, 2, 3],
+    ]  # Those peaks have matching mz values (within given tolerance)
+    multiply_matching_intensities = (
+        spectrum_1.peaks.intensities[expected_matches[0]]
         * spectrum_2.peaks.intensities[expected_matches[1]]
-    denominator = np.sqrt((spectrum_1.peaks.intensities ** 2).sum()) \
-        * np.sqrt((spectrum_2.peaks.intensities ** 2).sum())
+    )
+    denominator = np.sqrt((spectrum_1.peaks.intensities**2).sum()) * np.sqrt(
+        (spectrum_2.peaks.intensities**2).sum()
+    )
     expected_score = multiply_matching_intensities.sum() / denominator
 
-    assert score["score"] == pytest.approx(expected_score, 0.0001), "Expected different cosine score."
-    assert score["matches"] == len(expected_matches[0]), "Expected different number of matching peaks."
+    assert score["score"] == pytest.approx(
+        expected_score, 0.0001
+    ), "Expected different cosine score."
+    assert score["matches"] == len(
+        expected_matches[0]
+    ), "Expected different number of matching peaks."
 
 
 def test_cosine_hungarian_order_of_arguments():
     """Compare cosine scores for A,B versus B,A, which should give the same score."""
-    spectrum_1 = Spectrum(mz=np.array([100, 200, 299, 300, 301, 500, 510], dtype="float"),
-                          intensities=np.array([0.02, 0.02, 1.0, 0.2, 0.4, 0.04, 0.2], dtype="float"),
-                          metadata={})
+    spectrum_1 = Spectrum(
+        mz=np.array([100, 200, 299, 300, 301, 500, 510], dtype="float"),
+        intensities=np.array([0.02, 0.02, 1.0, 0.2, 0.4, 0.04, 0.2], dtype="float"),
+        metadata={},
+    )
 
-    spectrum_2 = Spectrum(mz=np.array([100, 200, 300, 301, 500, 512], dtype="float"),
-                          intensities=np.array([0.02, 0.02, 1.0, 0.2, 0.04, 0.2], dtype="float"),
-                          metadata={})
+    spectrum_2 = Spectrum(
+        mz=np.array([100, 200, 300, 301, 500, 512], dtype="float"),
+        intensities=np.array([0.02, 0.02, 1.0, 0.2, 0.04, 0.2], dtype="float"),
+        metadata={},
+    )
 
     cosine_hungarian = CosineHungarian(tolerance=2.0)
     score_1_2 = cosine_hungarian.pair(spectrum_1, spectrum_2)
     score_2_1 = cosine_hungarian.pair(spectrum_2, spectrum_1)
 
-    assert score_1_2["score"] == score_2_1["score"], "Expected that the order of the arguments would not matter."
-    assert score_1_2 == score_2_1, "Expected that the order of the arguments would not matter."
+    assert (
+        score_1_2["score"] == score_2_1["score"]
+    ), "Expected that the order of the arguments would not matter."
+    assert (
+        score_1_2 == score_2_1
+    ), "Expected that the order of the arguments would not matter."
 
 
 def test_cosine_hungarian_case_where_greedy_would_fail():
     """Test case that would fail for cosine greedy implementations."""
-    spectrum_1 = Spectrum(mz=np.array([100.005, 100.016], dtype="float"),
-                          intensities=np.array([1.0, 0.9], dtype="float"),
-                          metadata={})
+    spectrum_1 = Spectrum(
+        mz=np.array([100.005, 100.016], dtype="float"),
+        intensities=np.array([1.0, 0.9], dtype="float"),
+        metadata={},
+    )
 
-    spectrum_2 = Spectrum(mz=np.array([100.005, 100.01], dtype="float"),
-                          intensities=np.array([0.9, 1.0], dtype="float"),
-                          metadata={})
+    spectrum_2 = Spectrum(
+        mz=np.array([100.005, 100.01], dtype="float"),
+        intensities=np.array([0.9, 1.0], dtype="float"),
+        metadata={},
+    )
 
     cosine_hungarian = CosineHungarian(tolerance=0.01)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
-    assert score["score"] == pytest.approx(0.994475, 0.0001), "Expected different cosine score."
+    assert score["score"] == pytest.approx(
+        0.994475, 0.0001
+    ), "Expected different cosine score."
     assert score["matches"] == 2, "Expected different number of matching peaks."
 
 
 def test_cosine_hungarian_case_without_matches():
     """Test case for spectra without any matching peaks."""
-    spectrum_1 = Spectrum(mz=np.array([100, 200], dtype="float"),
-                          intensities=np.array([1.0, 0.1], dtype="float"),
-                          metadata={})
+    spectrum_1 = Spectrum(
+        mz=np.array([100, 200], dtype="float"),
+        intensities=np.array([1.0, 0.1], dtype="float"),
+        metadata={},
+    )
 
-    spectrum_2 = Spectrum(mz=np.array([110, 210], dtype="float"),
-                          intensities=np.array([1.0, 0.1], dtype="float"),
-                          metadata={})
+    spectrum_2 = Spectrum(
+        mz=np.array([110, 210], dtype="float"),
+        intensities=np.array([1.0, 0.1], dtype="float"),
+        metadata={},
+    )
 
     cosine_hungarian = CosineHungarian()
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
@@ -143,12 +255,18 @@ def test_cosine_hungarian_with_peak_powers():
     """
     mz_power = 0.5
     intensity_power = 2.0
-    spectrum_1 = Spectrum(mz=np.array([100, 200, 300, 500, 510], dtype="float"),
-                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
+    spectrum_1 = Spectrum(
+        mz=np.array([100, 200, 300, 500, 510], dtype="float"),
+        intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"),
+    )
 
-    spectrum_2 = Spectrum(mz=np.array([100, 200, 290, 490, 510], dtype="float"),
-                          intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"))
-    cosine_hungarian = CosineHungarian(tolerance=1.0, mz_power=mz_power, intensity_power=intensity_power)
+    spectrum_2 = Spectrum(
+        mz=np.array([100, 200, 290, 490, 510], dtype="float"),
+        intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"),
+    )
+    cosine_hungarian = CosineHungarian(
+        tolerance=1.0, mz_power=mz_power, intensity_power=intensity_power
+    )
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     # Derive expected cosine score
@@ -157,11 +275,98 @@ def test_cosine_hungarian_with_peak_powers():
     mz1 = spectrum_1.peaks.mz
     intensity2 = spectrum_2.peaks.intensities
     mz2 = spectrum_2.peaks.mz
-    multiply_matching_intensities = (mz1[matches] ** mz_power) * (intensity1[matches] ** intensity_power) \
-        * (mz2[matches] ** mz_power) * (intensity2[matches] ** intensity_power)
-    denominator = np.sqrt((((mz1 ** mz_power) * (intensity1 ** intensity_power)) ** 2).sum()) \
-        * np.sqrt((((mz2 ** mz_power) * (intensity2 ** intensity_power)) ** 2).sum())
+    multiply_matching_intensities = (
+        (mz1[matches] ** mz_power)
+        * (intensity1[matches] ** intensity_power)
+        * (mz2[matches] ** mz_power)
+        * (intensity2[matches] ** intensity_power)
+    )
+    denominator = np.sqrt(
+        (((mz1**mz_power) * (intensity1**intensity_power)) ** 2).sum()
+    ) * np.sqrt((((mz2**mz_power) * (intensity2**intensity_power)) ** 2).sum())
     expected_score = multiply_matching_intensities.sum() / denominator
 
-    assert score["score"] == pytest.approx(expected_score, 0.0001), "Expected different cosine score."
-    assert score["matches"] == len(matches), "Expected different number of matching peaks."
+    assert score["score"] == pytest.approx(
+        expected_score, 0.0001
+    ), "Expected different cosine score."
+    assert score["matches"] == len(
+        matches
+    ), "Expected different number of matching peaks."
+
+
+def test_cosine_hungarian_phantom_pair_regression():
+    """Test that phantom pairs from the Hungarian assignment are excluded from match count.
+
+    The Hungarian algorithm assigns min(rows, cols) pairs. When the optimal
+    assignment prefers a strong match that leaves another peak with no real
+    partner, the remaining assignment lands on a sentinel 1.0 cell (a "phantom
+    pair"). Phantom pairs contribute 0 to the score but must not inflate the
+    match count.
+
+    Cost matrix for this test (tolerance=2.0):
+
+        |  R1(100)  |  R2(103)
+    ----|-----------|----------
+    L1(100) |  0.9      |  1.0  (no pair: |100-103|=3 > 2)
+    L2(102) |  0.0      |  0.5
+
+    Hungarian picks L1->R2 (1.0) + L2->R1 (0.0) = total 1.0, which beats
+    L1->R1 (0.9) + L2->R2 (0.5) = total 1.4. The L1->R2 assignment is a
+    phantom. Old code reported matches=2; correct answer is matches=1.
+    """
+    spectrum_1 = Spectrum(
+        mz=np.array([100, 102], dtype="float"),
+        intensities=np.array([0.1, 1.0], dtype="float"),
+    )
+    spectrum_2 = Spectrum(
+        mz=np.array([100, 103], dtype="float"),
+        intensities=np.array([1.0, 0.5], dtype="float"),
+    )
+
+    cosine_hungarian = CosineHungarian(tolerance=2.0)
+    score = cosine_hungarian.pair(spectrum_1, spectrum_2)
+
+    assert score["matches"] == 1, (
+        f"Expected 1 real match but got {score['matches']}. "
+        "Phantom pairs from Hungarian assignment should be excluded."
+    )
+    # Score must reflect the real match (L2->R1, product=1.0) regardless of
+    # phantom filtering — phantoms contribute 0 by construction.
+    assert score["score"] > 0
+
+
+def test_cosine_hungarian_single_peak_spectra():
+    """Test with single-peak spectra that are within tolerance."""
+    spectrum_1 = Spectrum(
+        mz=np.array([100.0], dtype="float"),
+        intensities=np.array([1.0], dtype="float"),
+    )
+    spectrum_2 = Spectrum(
+        mz=np.array([100.05], dtype="float"),
+        intensities=np.array([0.8], dtype="float"),
+    )
+
+    cosine_hungarian = CosineHungarian(tolerance=0.1)
+    score = cosine_hungarian.pair(spectrum_1, spectrum_2)
+
+    assert score["matches"] == 1, "Expected exactly 1 match for single-peak spectra."
+    # Cosine similarity normalises: (1.0*0.8) / (sqrt(1.0^2) * sqrt(0.8^2)) = 1.0
+    assert score["score"] == pytest.approx(1.0, 0.0001), "Expected perfect cosine score for single matching pair."
+
+
+def test_cosine_hungarian_all_peaks_matching():
+    """Test where all peaks match (fully connected), ensuring no phantoms appear."""
+    spectrum_1 = Spectrum(
+        mz=np.array([100, 200, 300], dtype="float"),
+        intensities=np.array([0.5, 0.8, 1.0], dtype="float"),
+    )
+    spectrum_2 = Spectrum(
+        mz=np.array([100, 200, 300], dtype="float"),
+        intensities=np.array([0.5, 0.8, 1.0], dtype="float"),
+    )
+
+    cosine_hungarian = CosineHungarian(tolerance=0.1)
+    score = cosine_hungarian.pair(spectrum_1, spectrum_2)
+
+    assert score["matches"] == 3, "Expected all 3 peaks to match."
+    assert score["score"] == pytest.approx(1.0, 0.0001), "Expected perfect cosine score."

--- a/tests/similarity/test_cosine_hungarian.py
+++ b/tests/similarity/test_cosine_hungarian.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
 from matchms import Spectrum
+from matchms.reference_spectra import cocaine, glucose, hydroxy_cholesterol, phenylalanine
 from matchms.similarity import CosineHungarian
-from matchms.reference_spectra import cocaine, glucose, phenylalanine, hydroxy_cholesterol
 
 
 def test_cosine_hungarian_cocaine_glucose():


### PR DESCRIPTION
`CosineHungarian` builds a cost matrix initialised to `1.0` and overwrites cells where a real within-tolerance peak pair exists with `1 - intensity_product`. When `scipy.optimize.linear_sum_assignment` solves this matrix, it assigns exactly `min(rows, cols)` pairs. If a peak has no valid partner left, the algorithm assigns it to a cell still at `1.0` — a phantom pair.

**Before this fix**, `used_matches` included every assignment, so phantoms inflated the match count. The score was unaffected because the formula `len(row_ind) - sum(costs)` naturally cancels phantom contributions (`1 - 1.0 = 0`).

**After this fix**, `used_matches` filters out assignments where `cost_matrix[x, y] >= 1.0` (i.e., no real within-tolerance pair existed). The score calculation continues to use all assignments, preserving correctness.

### Minimal example

```
Cost matrix (tolerance=2.0):

         R1(100)    R2(103)
L1(100)   0.9       1.0  (no pair: |100-103|=3 > tolerance)
L2(102)   0.0       0.5

Hungarian picks: L1->R2 (cost 1.0) + L2->R1 (cost 0.0) = total 1.0
                 (beats L1->R1 (0.9) + L2->R2 (0.5) = total 1.4)

L1->R2 is a phantom — those peaks are not within tolerance.

Old result: matches=2 (wrong)
New result: matches=1 (correct), score unchanged
```

*Sorry for the delay on this PR btw, I had it on my desktop for a year now but life happened.*