### PR TITLE
add general spectra-collection importer and exporter

### DIFF
--- a/integration-tests/test_clean_peaks_workflow.py
+++ b/integration-tests/test_clean_peaks_workflow.py
@@ -1,0 +1,29 @@
+import os
+import numpy as np
+from matchms import Pipeline
+from matchms.importing import load_ms2_dataset, load_from_mgf
+from matchms import SpectraCollectionProcessor, SpectrumProcessor
+from matchms.filtering.default_pipelines import CLEAN_PEAKS
+
+
+def test_clean_peaks_workflow_on_collection_and_spectra_list():
+    module_root = os.path.join(os.path.dirname(__file__), "..")
+    spectra_file = os.path.join(module_root, "tests", "testdata", "pesticides.mgf")
+
+    # load collection
+    collection = load_ms2_dataset(spectra_file)
+
+    # load spectra list
+    spectra_list = list(load_from_mgf(spectra_file))
+
+    # run processor on collection
+    processor = SpectraCollectionProcessor(CLEAN_PEAKS)
+    processed_collection = processor.process_collection(collection)
+
+    # run processor on spectra list
+    processor = SpectrumProcessor(CLEAN_PEAKS)
+    processed_spectra_list = processor.process_spectra(spectra_list)[0]
+
+    assert processed_collection.n_spectra == len(processed_spectra_list)
+    num_peaks_in_lst = np.sum([s.fragments.mz.shape[0] for s in processed_spectra_list])
+    assert processed_collection.fragments.count().sum() == num_peaks_in_lst

--- a/matchms/MetadataCollection.py
+++ b/matchms/MetadataCollection.py
@@ -2,7 +2,10 @@ import logging
 import re
 import numpy as np
 import pandas as pd
-from matchms.filtering.filter_utils.metadata_conversions import NO_METADATA_UPDATE
+from matchms.filtering.filter_utils.metadata_conversions import (
+    NO_METADATA_UPDATE,
+    is_missing_metadata_value,
+)
 from .utils import load_known_key_conversions
 
 
@@ -26,6 +29,17 @@ def _needs_object_dtype(target_column: pd.Series, values: pd.Series) -> bool:
         return not pd.api.types.is_numeric_dtype(values.dtype)
 
     return True
+
+
+def _to_python_metadata_value(value):
+    """Convert pandas/numpy metadata values to JSON-friendly Python values."""
+    if is_missing_metadata_value(value):
+        return None
+
+    if isinstance(value, np.generic):
+        return value.item()
+
+    return value
 
 
 def harmonize_metadata_column_name(column_name: str) -> str:
@@ -211,6 +225,21 @@ class MetadataCollection(pd.DataFrame):
         )
 
         return self._finalize_apply_to_rows(target, inplace=inplace)
+
+
+    @staticmethod
+    def row_to_dict(row: pd.Series) -> dict:
+        """Convert a metadata row to a plain Python metadata dict.
+
+        Pandas missing values such as ``NaN`` and ``pd.NA`` are converted to
+        ``None``. NumPy scalar values such as ``np.int64`` and ``np.float64`` are
+        converted to native Python scalars so reconstructed Spectrum objects can
+        be exported to JSON.
+        """
+        return {
+            key: _to_python_metadata_value(value)
+            for key, value in row.items()
+        }
 
 
     def _validate_metadata_updates(

--- a/matchms/SpectraCollection.py
+++ b/matchms/SpectraCollection.py
@@ -1,13 +1,18 @@
-from __future__ import annotations
+import logging
+import os
 from collections.abc import Generator
 from functools import cached_property
 import numpy as np
 import pandas as pd
+from matchms.exporting import save_as_json, save_as_mgf, save_as_msp
 from matchms.MetadataCollection import MetadataCollection, harmonize_metadata_collection_columns
 from matchms.Spectrum import Spectrum
 from .FragmentCollection import CSRFragmentCollection, FragmentCollection
 from .hashing import compute_combined_hashes
 from .typing import SpectraCollectionType
+
+
+logger = logging.getLogger("matchms")
 
 
 class SpectraCollection:
@@ -503,6 +508,95 @@ class SpectraCollection:
             The mz values at the center of specified bins.
         """
         return self._fragments.bin_to_mz(bin_idx)
+
+    def to_json(
+        self,
+        file: str,
+        export_style: str = "matchms",
+        append: bool = False,
+    ) -> None:
+        """Export the spectra collection to a JSON file.
+
+        Parameters
+        ----------
+        file
+            Path to the output file.
+        export_style
+            Metadata key style used during export. One of ``"matchms"``,
+            ``"massbank"``, ``"nist"``, ``"riken"``, or ``"gnps"``.
+            Default is ``"matchms"``.
+        append
+            JSON export does not support appending. If ``True``, a
+            ``ValueError`` is raised.
+        """
+        self._check_export_file(file, append=append, allowed_append_types=())
+
+        if append:
+            raise ValueError("Appending is not supported for JSON export.")
+
+        save_as_json(list(self), file, export_style)
+
+    def to_mgf(
+        self,
+        file: str,
+        export_style: str = "matchms",
+        append: bool = False,
+    ) -> None:
+        """Export the spectra collection to an MGF file.
+
+        Parameters
+        ----------
+        file
+            Path to the output file.
+        export_style
+            Metadata key style used during export. One of ``"matchms"``,
+            ``"massbank"``, ``"nist"``, ``"riken"``, or ``"gnps"``.
+            Default is ``"matchms"``.
+        append
+            If ``True``, append to an existing file. Default is ``False``.
+        """
+        self._check_export_file(file, append=append, allowed_append_types=("mgf",))
+
+        save_as_mgf(list(self), file, export_style)
+
+    def to_msp(
+        self,
+        file: str,
+        export_style: str = "matchms",
+        append: bool = False,
+    ) -> None:
+        """Export the spectra collection to an MSP file.
+
+        Parameters
+        ----------
+        file
+            Path to the output file.
+        export_style
+            Metadata key style used during export. One of ``"matchms"``,
+            ``"massbank"``, ``"nist"``, ``"riken"``, or ``"gnps"``.
+            Default is ``"matchms"``.
+        append
+            If ``True``, append to an existing file. Default is ``False``.
+        """
+        self._check_export_file(file, append=append, allowed_append_types=("msp",))
+
+        mode = "a" if append else "w"
+        save_as_msp(list(self), file, style=export_style, mode=mode)
+
+    @staticmethod
+    def _check_export_file(
+        file: str,
+        append: bool,
+        allowed_append_types: tuple[str, ...],
+    ) -> None:
+        """Validate output file path and append settings."""
+        ftype = os.path.splitext(file)[1].lower()[1:]
+
+        if os.path.exists(file) and not append:
+            raise FileExistsError(f"The specified file: {file} already exists.")
+
+        if append and ftype not in allowed_append_types:
+            raise ValueError(f"{ftype} isn't supported for when `append` is True")
 
     def describe(self) -> pd.DataFrame:
         """

--- a/matchms/SpectraCollection.py
+++ b/matchms/SpectraCollection.py
@@ -154,7 +154,7 @@ class SpectraCollection:
         return Spectrum(
             mz=mz,
             intensities=intensities,
-            metadata=self._metadata.iloc[int(idx)].to_dict(),
+            metadata=MetadataCollection.row_to_dict(self._metadata.iloc[int(idx)]),
             metadata_harmonization=False,
         )
 
@@ -174,7 +174,7 @@ class SpectraCollection:
                 return Spectrum(
                     mz=mz,
                     intensities=intensities,
-                    metadata=self._metadata.iloc[row_idx].to_dict(),
+                    metadata=MetadataCollection.row_to_dict(self._metadata.iloc[row_idx]),
                     metadata_harmonization=False,
                 )
 
@@ -557,7 +557,8 @@ class SpectraCollection:
         """
         self._check_export_file(file, append=append, allowed_append_types=("mgf",))
 
-        save_as_mgf(list(self), file, export_style)
+        mode = "a" if append else "w"
+        save_as_mgf(list(self), file, export_style, file_mode=mode)
 
     def to_msp(
         self,
@@ -581,7 +582,7 @@ class SpectraCollection:
         self._check_export_file(file, append=append, allowed_append_types=("msp",))
 
         mode = "a" if append else "w"
-        save_as_msp(list(self), file, style=export_style, mode=mode)
+        save_as_msp(list(self), file, style=export_style, file_mode=mode)
 
     @staticmethod
     def _check_export_file(

--- a/matchms/exporting/save_as_json.py
+++ b/matchms/exporting/save_as_json.py
@@ -1,10 +1,13 @@
 import json
 from ..Spectrum import Spectrum
-from ..utils import filter_empty_spectra, fingerprint_export_warning, rename_deprecated_params
+from ..utils import filter_empty_spectra, fingerprint_export_warning
 
 
-@rename_deprecated_params(param_mapping={"spectrums": "spectra"}, version="0.26.5")
-def save_as_json(spectra: list[Spectrum], filename: str, export_style: str = "matchms"):
+def save_as_json(
+    spectra: list[Spectrum],
+    filename: str,
+    export_style: str = "matchms"
+    ) -> None:
     """Save spectrum(s) as json file.
 
     Example:

--- a/matchms/exporting/save_as_mgf.py
+++ b/matchms/exporting/save_as_mgf.py
@@ -1,13 +1,12 @@
 import logging
 import pyteomics.mgf as py_mgf
 from ..Spectrum import Spectrum
-from ..utils import filter_empty_spectra, fingerprint_export_warning, rename_deprecated_params
+from ..utils import filter_empty_spectra, fingerprint_export_warning
 
 
 logger = logging.getLogger("matchms")
 
 
-@rename_deprecated_params(param_mapping={"spectrums": "spectra"}, version="0.26.5")
 def save_as_mgf(
     spectra: list[Spectrum] | Spectrum,
     filename: str,

--- a/matchms/exporting/save_as_msp.py
+++ b/matchms/exporting/save_as_msp.py
@@ -7,7 +7,6 @@ from ..utils import (
     filter_empty_spectra,
     fingerprint_export_warning,
     load_export_key_conversions,
-    rename_deprecated_params,
 )
 
 
@@ -15,7 +14,6 @@ logger = logging.getLogger("matchms")
 _extensions_not_allowed = ["mzml", "mzxml", "json", "mgf"]
 
 
-@rename_deprecated_params(param_mapping={"spectrums": "spectra"}, version="0.26.5")
 def save_as_msp(
     spectra: list[Spectrum],
     filename: str,

--- a/matchms/exporting/save_as_msp.py
+++ b/matchms/exporting/save_as_msp.py
@@ -18,7 +18,7 @@ def save_as_msp(
     spectra: list[Spectrum],
     filename: str,
     write_peak_comments: bool = True,
-    mode: str = "a",
+    file_mode: str = "a",
     style: str = "matchms",
     peak_sep: str = "\t"
 ):
@@ -33,11 +33,15 @@ def save_as_msp(
         from matchms.exporting import save_as_msp
 
         # Create dummy spectrum
-        spectrum = Spectrum(mz=np.array([100, 200, 300], dtype="float"),
-                            intensities=np.array([10, 10, 500], dtype="float"),
-                            metadata={"charge": -1,
-                                      "inchi": '"InChI=1S/C6H12"',
-                                      "precursor_mz": 222.2})
+        spectrum = Spectrum(
+            mz=np.array([100, 200, 300], dtype="float"),
+            intensities=np.array([10, 10, 500], dtype="float"),
+            metadata={
+                "charge": -1,
+                "inchi": '"InChI=1S/C6H12"',
+                "precursor_mz": 222.2
+            }
+        )
 
         # Write spectrum to test file
         save_as_msp(spectrum, "test.msp")
@@ -51,7 +55,7 @@ def save_as_msp(
     write_peak_comments:
         Writes peak comments to individual peaks after the respective mz/intensity pair
         when set to True. Default is True.
-    mode:
+    file_mode:
         Mode on how to write to file. One of ["w", "a"] (write/append). Default is append.
     style:
         Converts the keys to required Export style. One of ["massbank", "nist", "riken", "gnps"].
@@ -59,7 +63,6 @@ def save_as_msp(
     peak_sep:
         Separator to use for writing the msp file.
     """
-    # pylint: disable=too-many-arguments
     if not isinstance(spectra, list):
         # Assume that input was a single Spectrum.
         spectra = [spectra]
@@ -77,7 +80,7 @@ def save_as_msp(
             filename.split(".")[-1],
         )
 
-    with open(filename, mode, encoding="utf-8") as outfile:
+    with open(filename, file_mode, encoding="utf-8") as outfile:
         for spectrum in spectra:
             _write_spectrum(spectrum, outfile, write_peak_comments, style, peak_sep)
 

--- a/matchms/exporting/save_as_mzspeclib.py
+++ b/matchms/exporting/save_as_mzspeclib.py
@@ -31,7 +31,10 @@ STANDARDIZED_SPECTRUM_ATTRIBUTES = {
 }
 
 
-def save_as_mzspeclib(spectra: list[Spectrum], filename: str) -> None:
+def save_as_mzspeclib(
+    spectra: list[Spectrum],
+    filename: str
+) -> None:
     """
     Save a list of spectra to a file in mzSpecLib format.
 
@@ -43,6 +46,7 @@ def save_as_mzspeclib(spectra: list[Spectrum], filename: str) -> None:
         _write_header(filename, file)
         for idx, spectrum in enumerate(spectra):
             _write_spectrum(file, idx, spectrum)
+
 
 def _write_spectrum(file: TextIO, idx: int, spectrum: Spectrum) -> None:
     """
@@ -60,6 +64,7 @@ def _write_spectrum(file: TextIO, idx: int, spectrum: Spectrum) -> None:
     _write_peaks(file, spectrum)
     print("", file=file)
 
+
 def _write_analyte(file: TextIO, spectrum: Spectrum) -> None:
     """
     Write analyte information for a spectrum to the file.
@@ -73,6 +78,7 @@ def _write_analyte(file: TextIO, spectrum: Spectrum) -> None:
         value = spectrum.get(key)
         if value is not None:
             print(f"{attribute}={value}", file=file)
+
 
 def _write_spectrum_attributes(file: TextIO, spectrum: Spectrum) -> None:
     """
@@ -97,6 +103,7 @@ def _write_spectrum_attributes(file: TextIO, spectrum: Spectrum) -> None:
 
     print(f"MS:1003059|number of peaks={len(spectrum.peaks)}", file=file)
 
+
 def _write_other_spectrum_attribute(file: TextIO, spectrum: Spectrum, attr_counter: int, attr: str) -> None:
     """
     Write other spectrum attributes to the file.
@@ -110,6 +117,7 @@ def _write_other_spectrum_attribute(file: TextIO, spectrum: Spectrum, attr_count
     value = spectrum.get(attr)
     print(f"[{attr_counter}]MS:1003275|other attribute name={attr}", file=file)
     print(f"[{attr_counter}]MS:1003276|other attribute value={value}", file=file)
+
 
 def _write_spectrum_attribute_with_unit(file: TextIO, spectrum: Spectrum, attr_counter: int, attr: str) -> None:
     """
@@ -127,6 +135,7 @@ def _write_spectrum_attribute_with_unit(file: TextIO, spectrum: Spectrum, attr_c
     print(f"[{attr_counter}]{term}={value}", file=file)
     print(f"[{attr_counter}]UO:0000000|unit={unit}", file=file)
 
+
 def _extract_numeric_value(value: str) -> str:
     """
     Extract numeric value from a string.
@@ -139,6 +148,7 @@ def _extract_numeric_value(value: str) -> str:
     """
     value = re.findall("[\\d]+[.,\\d]+|[\\d]*[.][\\d]+|[\\d]+", value)[0]
     return value
+
 
 def _write_defined_spectrum_attributes(file: TextIO, spectrum: Spectrum) -> None:
     """
@@ -154,6 +164,7 @@ def _write_defined_spectrum_attributes(file: TextIO, spectrum: Spectrum) -> None
             value = MAPPED_SPECTRUM_ATTRIBUTES[attribute].get(value)        
         if value is not None:
             print(f"{attribute}={value}", file=file)
+
 
 def _write_peaks(file: TextIO, spectrum: Spectrum) -> None:
     """
@@ -171,6 +182,7 @@ def _write_peaks(file: TextIO, spectrum: Spectrum) -> None:
         comment = peak_comments.get(mz, "?")
         print(f"{mz}\t{intensities}\t{comment}", file=file)
 
+
 def _has_analyte(spectrum: Spectrum) -> bool:
     """
     Check if a spectrum has analyte information.
@@ -182,6 +194,7 @@ def _has_analyte(spectrum: Spectrum) -> bool:
     bool: True if the spectrum has analyte information, False otherwise.
     """
     return any(spectrum.get(key) for key in ANALYTE_ATTRIBUTES)
+
 
 def _write_header(filename: str, file: TextIO) -> None:
     """

--- a/matchms/exporting/save_spectra.py
+++ b/matchms/exporting/save_spectra.py
@@ -51,9 +51,11 @@ def save_spectra(
     if ftype == "json":
         save_as_json(spectra, file, export_style)
     elif ftype == "mgf":
-        save_as_mgf(spectra, file, export_style)
+        file_mode = "a" if append else "w"
+        save_as_mgf(spectra, file, export_style, file_mode=file_mode)
     elif ftype == "msp":
-        save_as_msp(spectra, file, style=export_style, mode="a")
+        file_mode = "a" if append else "w"
+        save_as_msp(spectra, file, style=export_style, file_mode=file_mode)
     elif ftype == "pickle":
         if export_style != "matchms":
             logger.error(

--- a/matchms/exporting/save_spectra.py
+++ b/matchms/exporting/save_spectra.py
@@ -3,13 +3,12 @@ import os
 import pickle
 from matchms.exporting import save_as_json, save_as_mgf, save_as_msp
 from matchms.Spectrum import Spectrum
-from matchms.utils import filter_empty_spectra, rename_deprecated_params
+from matchms.utils import filter_empty_spectra
 
 
 logger = logging.getLogger("matchms")
 
 
-@rename_deprecated_params(param_mapping={"spectrums": "spectra"}, version="0.26.5")
 def save_spectra(
     spectra: list[Spectrum],
     file: str,

--- a/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_maximum_number_of_peaks.py
@@ -56,13 +56,16 @@ def _require_maximum_number_of_peaks_collection(
     clone: bool | None = True,
 ) -> SpectraCollection | None:
     """Drop spectra with more peaks than maximum_number_of_fragments."""
-    peak_counts = spectrum_in.fragments.count(axis=1)
+    target = spectrum_in.copy() if clone else spectrum_in
+
+    peak_counts = target.fragments.count(axis=1)
     keep_mask = peak_counts <= maximum_number_of_fragments
 
     if not keep_mask.any():
         return None
 
-    return spectrum_in.filter(keep_mask, inplace=not clone)
+    target.filter(keep_mask, inplace=True)
+    return target
 
 
 require_maximum_number_of_peaks = collection_filter(

--- a/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_high_peaks.py
@@ -83,7 +83,9 @@ def _require_minimum_number_of_high_peaks_collection(
     """Drop spectra with fewer than no_peaks high relative-intensity peaks."""
     _validate_minimum_high_peaks_parameters(no_peaks, intensity_percent)
 
-    high_peak_counts = spectrum_in.fragments.count_peaks_above_relative_intensity(
+    target = spectrum_in.copy() if clone else spectrum_in
+
+    high_peak_counts = target.fragments.count_peaks_above_relative_intensity(
         intensity_from=intensity_percent / 100,
     )
 
@@ -92,7 +94,8 @@ def _require_minimum_number_of_high_peaks_collection(
     if not keep_mask.any():
         return None
 
-    return spectrum_in.filter(keep_mask, inplace=not clone)
+    target.filter(keep_mask, inplace=True)
+    return target
 
 
 require_minimum_number_of_high_peaks = collection_filter(

--- a/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
+++ b/matchms/filtering/peak_processing/require_minimum_number_of_peaks.py
@@ -66,12 +66,14 @@ def _require_minimum_number_of_peaks_collection(
     clone: bool | None = True,
 ) -> SpectraCollection | None:
     """Drop spectra with fewer peaks than required."""
-    peak_counts = spectrum_in.fragments.count(axis=1)
-    thresholds = np.full(len(spectrum_in), n_required, dtype=np.int64)
+    target = spectrum_in.copy() if clone else spectrum_in
 
-    if ratio_required is not None and "parent_mass" in spectrum_in.metadata.columns:
+    peak_counts = target.fragments.count(axis=1)
+    thresholds = np.full(len(target), n_required, dtype=np.int64)
+
+    if ratio_required is not None and "parent_mass" in target.metadata.columns:
         parent_mass = pd.to_numeric(
-            spectrum_in.metadata["parent_mass"],
+            target.metadata["parent_mass"],
             errors="coerce",
         )
 
@@ -88,7 +90,8 @@ def _require_minimum_number_of_peaks_collection(
     if not keep_mask.any():
         return None
 
-    return spectrum_in.filter(keep_mask, inplace=not clone)
+    target.filter(keep_mask, inplace=True)
+    return target
 
 
 require_minimum_number_of_peaks = collection_filter(

--- a/matchms/importing/__init__.py
+++ b/matchms/importing/__init__.py
@@ -2,17 +2,24 @@
 Functions for importing mass spectral data
 ##########################################
 
-Matchms provides a import functions for several commonly used data types, such
-as *.mzML*, *.mzXML*, *.mgf*, or *.msp*. It is also possible to load data from
-*.json* files (tested for json files from GNPS or json files made with matchms).
-Another option is to load spectra based on a unique identifier (USI)
-(:meth:`~matchms.importing.load_from_usi`).
+Matchms provides import functions for several commonly used mass spectral data
+formats, such as *.mzML*, *.mzXML*, *.mgf*, or *.msp*. It is also possible to
+load spectra from *.json* files (tested for json files from GNPS or json files
+made with matchms), from pickle files, or based on a unique spectrum identifier
+(USI) (:meth:`~matchms.importing.load_from_usi`).
 
-For more extensive import options we recommend building custom importers using `pyteomics
-<https://github.com/levitsky/pyteomics>`_ or `pymzml <https://github.com/pymzml/pymzML>`_.
+The individual ``load_from_*`` functions and :meth:`~matchms.importing.load_spectra`
+return spectra as :class:`~matchms.Spectrum.Spectrum` objects or iterables of
+Spectrum objects. For collection-based workflows, use
+:meth:`~matchms.importing.load_ms2_dataset` to directly load a file as a
+:class:`~matchms.SpectraCollection.SpectraCollection`.
 
-To process spectrum metadata, matchms can also make use of known adduct information
-which is imported via :mod:`~matchms.importing.load_adducts`.
+For more extensive import options we recommend building custom importers using
+`pyteomics <https://github.com/levitsky/pyteomics>`_ or
+`pymzml <https://github.com/pymzml/pymzML>`_.
+
+To process spectrum metadata, matchms can also make use of known adduct
+information which is imported via :mod:`~matchms.importing.load_adducts`.
 """
 
 from .load_from_json import load_from_json
@@ -22,7 +29,7 @@ from .load_from_mzml import load_from_mzml
 from .load_from_mzxml import load_from_mzxml
 from .load_from_pickle import load_from_pickle
 from .load_from_usi import load_from_usi
-from .load_spectra import load_spectra
+from .load_spectra import load_ms2_dataset, load_spectra
 
 
 __all__ = [
@@ -34,4 +41,5 @@ __all__ = [
     "load_from_usi",
     "load_spectra",
     "load_from_pickle",
+    "load_ms2_dataset",
 ]

--- a/matchms/importing/load_spectra.py
+++ b/matchms/importing/load_spectra.py
@@ -9,25 +9,39 @@ from matchms.importing import (
     load_from_mzxml,
     load_from_pickle,
 )
+from matchms.SpectraCollection import SpectraCollection
 from matchms.Spectrum import Spectrum
 
 
 def load_spectra(
-    file: str, metadata_harmonization: bool = True, ftype: str | None = None
+    file: str,
+    metadata_harmonization: bool = True,
+    ftype: str | None = "auto",
 ) -> list[Spectrum] | Generator[Spectrum, None, None]:
-    """Loads spectra from your spectrum file into memory as matchms Spectrum object
+    """Load spectra from a file as matchms Spectrum objects.
 
-    The following file extensions can be loaded in with this function:
-    "mzML", "json", "mgf", "msp", "mzxml", "usi" and "pickle".
-    A pickled file is expected to directly contain a list of matchms spectrum objects.
+    The following file extensions can be loaded with this function:
+    ``mzML``, ``json``, ``mgf``, ``msp``, ``mzxml`` and ``pickle``.
 
-    Args:
-    -----
-    file:
-        Path to file containing spectra, with file extension "mzML", "json", "mgf", "msp",
-        "mzxml" or "pickle"
-    ftype:
-        Optional. Filetype
+    A pickled file is expected to directly contain a list of matchms Spectrum
+    objects.
+
+    Parameters
+    ----------
+    file
+        Path to file containing spectra.
+    metadata_harmonization
+        If True, harmonize metadata during import.
+    ftype
+        File type to use for import. By default, ``"auto"`` guesses the file
+        type from the file extension. Alternatively, pass an explicit file type,
+        for example ``"mzml"``, ``"json"``, ``"mgf"``, ``"msp"``, ``"mzxml"``,
+        or ``"pickle"``.
+
+    Returns
+    -------
+    list[Spectrum] or Generator[Spectrum, None, None]
+        Imported spectra.
     """
     assert os.path.exists(file), f"The specified file: {file} does not exists"
 
@@ -50,6 +64,39 @@ def load_spectra(
         return load_from_pickle(file, metadata_harmonization)
 
     raise TypeError(f"File extension of file: {file} is not recognized")
+
+
+def load_ms2_dataset(
+    file: str,
+    metadata_harmonization: bool = True,
+    ftype: str = "auto",
+) -> SpectraCollection:
+    """Load spectra from a file as a SpectraCollection.
+
+    Parameters
+    ----------
+    file
+        Path to file containing spectra.
+    metadata_harmonization
+        If True, harmonize metadata during import.
+    ftype
+        File type to use for import. By default, ``"auto"`` guesses the file
+        type from the file extension. Alternatively, pass an explicit file type,
+        for example ``"mzml"``, ``"json"``, ``"mgf"``, ``"msp"``, ``"mzxml"``,
+        or ``"pickle"``.
+
+    Returns
+    -------
+    SpectraCollection
+        Imported spectra as a collection.
+    """
+    return SpectraCollection(
+        load_spectra(
+            file,
+            metadata_harmonization=metadata_harmonization,
+            ftype=ftype,
+        )
+    )
 
 
 def load_list_of_spectrum_files(

--- a/matchms/importing/load_spectra.py
+++ b/matchms/importing/load_spectra.py
@@ -45,7 +45,7 @@ def load_spectra(
     """
     assert os.path.exists(file), f"The specified file: {file} does not exists"
 
-    if ftype is None:
+    if ftype is None or ftype == "auto":
         ftype = os.path.splitext(file)[1].lower()[1:]
     else:
         ftype = ftype.lower()

--- a/tests/exporting/test_save_as_msp.py
+++ b/tests/exporting/test_save_as_msp.py
@@ -161,8 +161,8 @@ def test_num_peaks_last_metadata_field(filename, data):
 @pytest.mark.parametrize("test_file", ["MoNA-export-GC-MS-first10.msp", "massbank_five_spectra.msp"])
 def test_write_append(test_file, filename):
     expected = load_test_spectra_file(test_file)
-    save_as_msp(expected[:2], filename, mode = "a")
-    save_as_msp(expected[2:], filename, mode = "a")
+    save_as_msp(expected[:2], filename, file_mode = "a")
+    save_as_msp(expected[2:], filename, file_mode = "a")
 
     actual = list(load_from_msp(filename))
 
@@ -174,7 +174,7 @@ def test_write_append(test_file, filename):
 def test_save_as_msp_export_style(test_file, expected_file, style, filename):
     expected = load_test_spectra_file(expected_file)
     data = load_test_spectra_file(test_file)
-    save_as_msp(data, filename, mode="w", style=style)
+    save_as_msp(data, filename, file_mode="w", style=style)
     actual = list(load_from_msp(filename))
     assert expected == actual
 
@@ -185,7 +185,7 @@ def test_save_as_msp_from_mgf(test_file, expected_file, filename):
     spectra_file = os.path.join(module_root, "testdata", test_file)
     actual = list(load_from_mgf(spectra_file))
     expected = load_test_spectra_file(expected_file)
-    save_as_msp(actual, filename, mode="w", write_peak_comments=True)
+    save_as_msp(actual, filename, file_mode="w", write_peak_comments=True)
     actual = list(load_from_msp(filename))
     assert expected == actual
 

--- a/tests/exporting/test_save_spectra.py
+++ b/tests/exporting/test_save_spectra.py
@@ -1,123 +1,204 @@
-import logging
-import os
-import re
-import tempfile
+import importlib
+import pickle
+import numpy as np
 import pytest
+from matchms import Spectrum
 from matchms.exporting.save_spectra import save_as_pickled_file, save_spectra
-from matchms.importing import load_from_mgf, load_spectra
 
 
-def load_test_spectra_file():
-    module_root = os.path.join(os.path.dirname(__file__), "..")
-    spectra_file = os.path.join(module_root, "testdata", "testdata.mgf")
-    spectra = list(load_from_mgf(spectra_file))
-    return spectra
+save_spectra_module = importlib.import_module("matchms.exporting.save_spectra")
 
 
-@pytest.mark.parametrize("file_name",
-                         ["spectra.msp",
-                          "spectra.mgf",
-                          "spectra.json",
-                          "spectra.pickle"])
-def test_spectra(file_name, caplog):
-    """ Utility function to save spectra to msp and load them again.
-
-    Params:
-    -------
-    spectra: Spectra objects to store
-
-    Returns:
-    --------
-    reloaded_spectra: Spectra loaded from saved msp file.
-    """
-    spectrum_list = load_test_spectra_file()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        filename = os.path.join(temp_dir, file_name)
-        save_spectra(spectrum_list, filename)
-        assert os.path.exists(filename)
-        reloaded_spectra = list(load_spectra(filename))
-    assert len(reloaded_spectra) == len(spectrum_list)
-    for i, spectrum in enumerate(spectrum_list):
-        reloaded_spectrum = reloaded_spectra[i]
-        # Num_peaks is sometimes added during saving. So to be able to compare it is set to None
-        spectrum.set("num_peaks", None)
-        reloaded_spectrum.set("num_peaks", None)
-        assert spectrum == reloaded_spectrum
-
-    # Test file exists error
-    with tempfile.TemporaryDirectory() as temp_dir:
-        filename = os.path.join(temp_dir, file_name)
-
-        with open(filename, "w", encoding="utf-8") as file:
-            file.write("content")
-        assert os.path.exists(filename)
-
-        with pytest.raises(FileExistsError, match=re.escape(f"The specified file: {filename} already exists.")):
-            save_spectra(spectrum_list, filename)
-
-    # Test append to different filetype not supported error
-    ftype = os.path.splitext(file_name)[1].lower()[1:]
-    if ftype in ["json", "pickle"]:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            filename = os.path.join(temp_dir, file_name)
-
-            with pytest.raises(ValueError, match=re.escape(f"{ftype} isn't supported for when `append` is True")):
-                save_spectra(spectra=spectrum_list, file=filename, append=True)
-
-    # Test logger warning when using pickle
-    if ftype == "pickle":
-        with caplog.at_level(logging.ERROR):
-            with tempfile.TemporaryDirectory() as temp_dir:
-                filename = os.path.join(temp_dir, file_name)
-                save_spectra(spectra=spectrum_list, file=filename, export_style="invalid")
-
-        assert "The only available export style for pickle is 'matchms', your export style invalid" in caplog.text
+def _make_spectrum():
+    return Spectrum(
+        mz=np.array([100.0, 200.0], dtype="float"),
+        intensities=np.array([0.5, 1.0], dtype="float"),
+        metadata={"precursor_mz": 201.0, "compound_name": "test compound"},
+    )
 
 
-def test_spectra_invalid_ext():
-    spectrum_list = load_test_spectra_file()
+def test_save_spectra_unknown_file_extension(tmp_path):
+    spectrum = _make_spectrum()
+    filename = tmp_path / "spectra.unknown"
 
-    # Test invalid file ext
-    with tempfile.TemporaryDirectory() as temp_dir:
-        filename = os.path.join(temp_dir, "invalid.txt")
-
-        with pytest.raises(TypeError, match=re.escape(f"File extension of file: {filename} is not recognized")):
-            save_spectra(spectrum_list, filename)
+    with pytest.raises(TypeError, match="File extension"):
+        save_spectra([spectrum], str(filename))
 
 
-@pytest.mark.parametrize("file_name", ["spectra.pickle"])
-def test_save_as_pickled_file_none_spectra(file_name):
-    """ Tests only pickled file saving with filtered None valued spectra
+def test_save_spectra_does_not_overwrite_existing_file(tmp_path):
+    spectrum = _make_spectrum()
+    filename = tmp_path / "spectra.mgf"
+    filename.write_text("already exists", encoding="utf-8")
 
-    Params:
-    -------
-    spectra: Spectra objects to store
+    with pytest.raises(FileExistsError):
+        save_spectra([spectrum], str(filename))
 
-    Returns:
-    --------
-    reloaded_spectra: Spectra loaded from saved msp file.
-    """
-    spectrum_list = load_test_spectra_file()
 
-    # Test file exists error
-    with tempfile.TemporaryDirectory() as temp_dir:
-        filename = os.path.join(temp_dir, file_name)
+@pytest.mark.parametrize("extension", ["json", "pickle"])
+def test_save_spectra_append_raises_for_unsupported_filetypes(tmp_path, extension):
+    spectrum = _make_spectrum()
+    filename = tmp_path / f"spectra.{extension}"
 
-        with open(filename, "w", encoding="utf-8") as file:
-            file.write("content")
-        assert os.path.exists(filename)
+    with pytest.raises(ValueError, match="append"):
+        save_spectra([spectrum], str(filename), append=True)
 
-        with pytest.raises(FileExistsError, match=re.escape(f"The file '{filename}' already exists.")):
-            save_as_pickled_file(spectrum_list, filename)
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        filename = os.path.join(temp_dir, file_name)
+def test_save_spectra_empty_list_creates_empty_file(tmp_path):
+    filename = tmp_path / "empty.mgf"
 
-        # Test no spectra list
-        with pytest.raises(TypeError, match="Expected list of spectra"):
-            save_as_pickled_file("invalid", filename)
+    save_spectra([], str(filename))
 
-        # Test empty spectra list
-        spectrum_list = [None]
-        with pytest.raises(TypeError, match="Expected list of spectra"):
-            save_as_pickled_file(spectrum_list, filename)
+    assert filename.exists()
+    assert filename.read_text(encoding="utf-8") == ""
+
+
+def test_save_spectra_json_dispatches_to_save_as_json(monkeypatch, tmp_path):
+    spectrum = _make_spectrum()
+    filename = tmp_path / "spectra.json"
+    calls = {}
+
+    def mock_save_as_json(spectra, file, export_style):
+        calls["spectra"] = spectra
+        calls["file"] = file
+        calls["export_style"] = export_style
+
+    monkeypatch.setattr(save_spectra_module, "save_as_json", mock_save_as_json)
+
+    save_spectra([spectrum], str(filename), export_style="gnps")
+
+    assert calls["spectra"] == [spectrum]
+    assert calls["file"] == str(filename)
+    assert calls["export_style"] == "gnps"
+
+
+@pytest.mark.parametrize(
+    "append, expected_file_mode",
+    [
+        (False, "w"),
+        (True, "a"),
+    ],
+)
+def test_save_spectra_mgf_dispatches_with_file_mode(
+    monkeypatch,
+    tmp_path,
+    append,
+    expected_file_mode,
+):
+    spectrum = _make_spectrum()
+    filename = tmp_path / "spectra.mgf"
+    calls = {}
+
+    if append:
+        filename.write_text("existing content\n", encoding="utf-8")
+
+    def mock_save_as_mgf(spectra, file, export_style, file_mode="w"):
+        calls["spectra"] = spectra
+        calls["file"] = file
+        calls["export_style"] = export_style
+        calls["file_mode"] = file_mode
+
+    monkeypatch.setattr(save_spectra_module, "save_as_mgf", mock_save_as_mgf)
+
+    save_spectra([spectrum], str(filename), export_style="matchms", append=append)
+
+    assert calls["spectra"] == [spectrum]
+    assert calls["file"] == str(filename)
+    assert calls["export_style"] == "matchms"
+    assert calls["file_mode"] == expected_file_mode
+
+
+@pytest.mark.parametrize(
+    "append, expected_file_mode",
+    [
+        (False, "w"),
+        (True, "a"),
+    ],
+)
+def test_save_spectra_msp_dispatches_with_file_mode(
+    monkeypatch,
+    tmp_path,
+    append,
+    expected_file_mode,
+):
+    spectrum = _make_spectrum()
+    filename = tmp_path / "spectra.msp"
+    calls = {}
+
+    if append:
+        filename.write_text("existing content\n", encoding="utf-8")
+
+    def mock_save_as_msp(spectra, file, style="matchms", file_mode="w"):
+        calls["spectra"] = spectra
+        calls["file"] = file
+        calls["style"] = style
+        calls["file_mode"] = file_mode
+
+    monkeypatch.setattr(save_spectra_module, "save_as_msp", mock_save_as_msp)
+
+    save_spectra([spectrum], str(filename), export_style="nist", append=append)
+
+    assert calls["spectra"] == [spectrum]
+    assert calls["file"] == str(filename)
+    assert calls["style"] == "nist"
+    assert calls["file_mode"] == expected_file_mode
+
+
+def test_save_spectra_accepts_single_spectrum(monkeypatch, tmp_path):
+    spectrum = _make_spectrum()
+    filename = tmp_path / "single.mgf"
+    calls = {}
+
+    def mock_save_as_mgf(spectra, file, export_style, file_mode="w"):
+        calls["spectra"] = spectra
+        calls["file"] = file
+        calls["export_style"] = export_style
+        calls["file_mode"] = file_mode
+
+    monkeypatch.setattr(save_spectra_module, "save_as_mgf", mock_save_as_mgf)
+
+    save_spectra(spectrum, str(filename))
+
+    assert calls["spectra"] == [spectrum]
+    assert calls["file"] == str(filename)
+    assert calls["export_style"] == "matchms"
+    assert calls["file_mode"] == "w"
+
+
+def test_save_spectra_pickle_export(tmp_path):
+    spectrum = _make_spectrum()
+    filename = tmp_path / "spectra.pickle"
+
+    save_spectra([spectrum], str(filename))
+
+    assert filename.exists()
+
+    with open(filename, "rb") as file:
+        loaded = pickle.load(file)
+
+    assert len(loaded) == 1
+    assert isinstance(loaded[0], Spectrum)
+    assert loaded[0] == spectrum
+
+
+def test_save_as_pickled_file_requires_list(tmp_path):
+    spectrum = _make_spectrum()
+    filename = tmp_path / "spectra.pickle"
+
+    with pytest.raises(TypeError, match="Expected list of spectra"):
+        save_as_pickled_file(spectrum, str(filename))
+
+
+def test_save_as_pickled_file_requires_list_of_spectra(tmp_path):
+    filename = tmp_path / "spectra.pickle"
+
+    with pytest.raises(TypeError, match="Expected list of spectra"):
+        save_as_pickled_file(["not a spectrum"], str(filename))
+
+
+def test_save_as_pickled_file_does_not_overwrite_existing_file(tmp_path):
+    spectrum = _make_spectrum()
+    filename = tmp_path / "spectra.pickle"
+    filename.write_bytes(b"already exists")
+
+    with pytest.raises(FileExistsError):
+        save_as_pickled_file([spectrum], str(filename))

--- a/tests/importing/test_load_spectra.py
+++ b/tests/importing/test_load_spectra.py
@@ -1,31 +1,71 @@
 import os
 import pytest
-from matchms import Spectrum
-from matchms.importing.load_spectra import load_spectra
+from matchms import SpectraCollection, Spectrum
+from matchms.importing.load_spectra import load_ms2_dataset, load_spectra
 
 
 def test_load_spectra_unknown_file(tmp_path):
-    """Tests if unknown file raises an Assertion error"""
+    """Tests if unknown file raises an AssertionError."""
     with pytest.raises(AssertionError):
         load_spectra(os.path.join(tmp_path, "file_that_does_not_exist.json"))
 
 
-@pytest.mark.parametrize("filename, ftype, metadata_harmonization, expected_num_spectra", [
-    ["pesticides.mgf", None, True, 76],
-    ["testdata.mgf", "mgf", True, 30],
-    ["testdata.mgf", "mgf", False, 30],
-    ["testdata.mzml", None, True, 10],
-    ["testdata.mzXML", None, True, 1],
-    ["massbank_five_spectra.msp", None, True, 5]
-])
+@pytest.mark.parametrize(
+    "filename, ftype, metadata_harmonization, expected_num_spectra",
+    [
+        ["pesticides.mgf", None, True, 76],
+        ["pesticides.mgf", "auto", True, 76],
+        ["testdata.mgf", "mgf", True, 30],
+        ["testdata.mgf", "auto", True, 30],
+        ["testdata.mgf", "mgf", False, 30],
+        ["testdata.mzml", None, True, 10],
+        ["testdata.mzml", "auto", True, 10],
+        ["testdata.mzXML", None, True, 1],
+        ["testdata.mzXML", "auto", True, 1],
+        ["massbank_five_spectra.msp", None, True, 5],
+        ["massbank_five_spectra.msp", "auto", True, 5],
+    ],
+)
 def test_load_spectra(filename, ftype, metadata_harmonization, expected_num_spectra):
-    """Test if pickled file is loaded in correctly"""
+    """Test if spectrum files are loaded correctly."""
     tests_root = os.path.join(os.path.dirname(__file__), "../testdata")
     file = os.path.join(tests_root, filename)
-    actual = list(load_spectra(file, metadata_harmonization=metadata_harmonization, ftype=ftype))
-   
-        
+
+    actual = list(
+        load_spectra(
+            file,
+            metadata_harmonization=metadata_harmonization,
+            ftype=ftype,
+        )
+    )
+
     assert isinstance(actual, list), "expected list of spectra"
     assert len(actual) == expected_num_spectra
     for spectrum in actual:
         assert isinstance(spectrum, Spectrum)
+
+
+@pytest.mark.parametrize(
+    "filename, ftype, metadata_harmonization, expected_num_spectra",
+    [
+        ["pesticides.mgf", "auto", True, 76],
+        ["testdata.mgf", "mgf", True, 30],
+        ["testdata.mgf", "auto", False, 30],
+        ["testdata.mzml", "auto", True, 10],
+        ["testdata.mzXML", "auto", True, 1],
+        ["massbank_five_spectra.msp", "auto", True, 5],
+    ],
+)
+def test_load_ms2_dataset(filename, ftype, metadata_harmonization, expected_num_spectra):
+    """Test if spectrum files are loaded as SpectraCollection."""
+    tests_root = os.path.join(os.path.dirname(__file__), "../testdata")
+    file = os.path.join(tests_root, filename)
+
+    actual = load_ms2_dataset(
+        file,
+        metadata_harmonization=metadata_harmonization,
+        ftype=ftype,
+    )
+
+    assert isinstance(actual, SpectraCollection)
+    assert len(actual) == expected_num_spectra

--- a/tests/test_metadata_collection.py
+++ b/tests/test_metadata_collection.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 from matchms import SpectraCollection
 from matchms.MetadataCollection import (
+    MetadataCollection,
     harmonize_metadata_collection_columns,
     harmonize_metadata_column_name,
 )
@@ -160,3 +161,25 @@ def test_metadata_apply_to_rows_without_mask_updates_all_rows():
     result = collection.metadata.apply_to_rows(update_all_rows)
 
     assert result["value"].tolist() == [10, 20]
+
+
+def test_row_to_dict_converts_missing_and_numpy_scalars():
+    row = pd.Series(
+        {
+            "scan_number": np.int64(0),
+            "precursor_mz": np.float64(123.4),
+            "ionmode": np.nan,
+            "compound_name": "test",
+        }
+    )
+
+    metadata = MetadataCollection.row_to_dict(row)
+
+    assert metadata == {
+        "scan_number": 0,
+        "precursor_mz": 123.4,
+        "ionmode": None,
+        "compound_name": "test",
+    }
+    assert isinstance(metadata["scan_number"], int)
+    assert isinstance(metadata["precursor_mz"], float)

--- a/tests/test_spectra_collection_import_export.py
+++ b/tests/test_spectra_collection_import_export.py
@@ -1,0 +1,161 @@
+import os
+import pytest
+from matchms import SpectraCollection, Spectrum
+from matchms.importing.load_spectra import load_ms2_dataset
+
+
+def _testdata_file(filename):
+    tests_root = os.path.join(os.path.dirname(__file__), "testdata")
+    return os.path.join(tests_root, filename)
+
+
+def _assert_collection_contains_spectra(collection, expected_num_spectra):
+    assert isinstance(collection, SpectraCollection)
+    assert len(collection) == expected_num_spectra
+
+    for spectrum in collection:
+        assert isinstance(spectrum, Spectrum)
+
+
+@pytest.mark.parametrize(
+    "filename, expected_num_spectra",
+    [
+        ("pesticides.mgf", 76),
+        ("testdata.mgf", 30),
+        ("testdata.mzml", 10),
+        ("testdata.mzXML", 1),
+        ("massbank_five_spectra.msp", 5),
+    ],
+)
+def test_load_ms2_dataset_returns_spectra_collection(filename, expected_num_spectra):
+    file = _testdata_file(filename)
+
+    collection = load_ms2_dataset(file)
+
+    _assert_collection_contains_spectra(collection, expected_num_spectra)
+
+
+@pytest.mark.parametrize(
+    "filename, ftype, expected_num_spectra",
+    [
+        ("testdata.mgf", "auto", 30),
+        ("testdata.mgf", "mgf", 30),
+        ("testdata.mzml", "auto", 10),
+        ("testdata.mzml", "mzml", 10),
+        ("testdata.mzXML", "auto", 1),
+        ("testdata.mzXML", "mzxml", 1),
+        ("massbank_five_spectra.msp", "auto", 5),
+        ("massbank_five_spectra.msp", "msp", 5),
+    ],
+)
+def test_load_ms2_dataset_with_auto_and_explicit_filetype(filename, ftype, expected_num_spectra):
+    file = _testdata_file(filename)
+
+    collection = load_ms2_dataset(file, ftype=ftype)
+
+    _assert_collection_contains_spectra(collection, expected_num_spectra)
+
+
+def test_spectra_collection_to_mgf_roundtrip(tmp_path):
+    input_file = _testdata_file("massbank_five_spectra.msp")
+    output_file = tmp_path / "exported.mgf"
+
+    collection = load_ms2_dataset(input_file)
+    collection.to_mgf(str(output_file))
+
+    assert output_file.exists()
+
+    imported = load_ms2_dataset(str(output_file))
+
+    assert isinstance(imported, SpectraCollection)
+    assert len(imported) == len(collection)
+
+
+def test_spectra_collection_to_msp_roundtrip(tmp_path):
+    input_file = _testdata_file("testdata.mgf")
+    output_file = tmp_path / "exported.msp"
+
+    collection = load_ms2_dataset(input_file)
+    collection.to_msp(str(output_file))
+
+    assert output_file.exists()
+
+    imported = load_ms2_dataset(str(output_file))
+
+    assert isinstance(imported, SpectraCollection)
+    assert len(imported) == len(collection)
+
+
+def test_spectra_collection_to_json_roundtrip(tmp_path):
+    input_file = _testdata_file("testdata.mgf")
+    output_file = tmp_path / "exported.json"
+
+    collection = load_ms2_dataset(input_file)
+    collection.to_json(str(output_file))
+
+    assert output_file.exists()
+
+    imported = load_ms2_dataset(str(output_file))
+
+    assert isinstance(imported, SpectraCollection)
+    assert len(imported) == len(collection)
+
+
+@pytest.mark.parametrize(
+    "export_method, extension",
+    [
+        ("to_mgf", "mgf"),
+        ("to_msp", "msp"),
+        ("to_json", "json"),
+    ],
+)
+def test_spectra_collection_export_does_not_overwrite_existing_file(
+    tmp_path,
+    export_method,
+    extension,
+):
+    input_file = _testdata_file("massbank_five_spectra.msp")
+    output_file = tmp_path / f"exported.{extension}"
+    output_file.write_text("already exists", encoding="utf-8")
+
+    collection = load_ms2_dataset(input_file)
+
+    with pytest.raises(FileExistsError):
+        getattr(collection, export_method)(str(output_file))
+
+
+@pytest.mark.parametrize(
+    "export_method, extension",
+    [
+        ("to_mgf", "mgf"),
+        ("to_msp", "msp"),
+    ],
+)
+def test_spectra_collection_export_append_supported_for_mgf_and_msp(
+    tmp_path,
+    export_method,
+    extension,
+):
+    input_file = _testdata_file("massbank_five_spectra.msp")
+    output_file = tmp_path / f"exported.{extension}"
+
+    collection = load_ms2_dataset(input_file)
+
+    getattr(collection, export_method)(str(output_file))
+    getattr(collection, export_method)(str(output_file), append=True)
+
+    imported = load_ms2_dataset(str(output_file))
+
+    assert isinstance(imported, SpectraCollection)
+    assert len(imported) == 2 * len(collection)
+
+
+def test_spectra_collection_to_json_append_not_supported(tmp_path):
+    input_file = _testdata_file("massbank_five_spectra.msp")
+    output_file = tmp_path / "exported.json"
+
+    collection = load_ms2_dataset(input_file)
+    collection.to_json(str(output_file))
+
+    with pytest.raises(ValueError, match="Appending is not supported|append"):
+        collection.to_json(str(output_file), append=True)


### PR DESCRIPTION
Add importing and exporting methods for `SpectraCollection`.

Importing datasets can then be done using
```python
from matchms.importing import load_ms2_dataset

sc = load_ms2_dataset("my_data_file.mgf")  # can also be a mzml, mzxml, json, or msp file
```

Exporting can be done directly from the collection itself:
```python
sc.to_mgf("my_cleaned_data.mgf")
```

There are also `.to_msp()` and `.to_json()` methods.

### Note:
Currently, this uses the "old" importers and exporters internally, so this means that internally everything is first loaded as list of `Spectrum` objects, or first converted to such a list. In the future, we might want to refactor this, for instance to make things faster.