### PR TITLE
Handle fragment precision

### DIFF
--- a/matchms/FragmentCollection.py
+++ b/matchms/FragmentCollection.py
@@ -89,49 +89,94 @@ class FragmentCollection(ABC):
         pass
 
 
+# Helper functions for peak processing filters
+def _decimal_places_from_mz_precision(mz_precision: float) -> int:
+    """Return decimal places for mz_precision.
+
+    Only powers of ten are supported, for example 1, 0.1, 0.01, 1e-4.
+    """
+    if mz_precision <= 0:
+        raise ValueError("mz_precision must be > 0.")
+
+    exponent = -np.log10(mz_precision)
+    rounded_exponent = int(round(exponent))
+
+    if not np.isclose(exponent, rounded_exponent):
+        raise ValueError(
+            "mz_precision must be a power of ten, for example "
+            "1, 0.1, 0.01, 1e-4, or 1e-5."
+        )
+
+    return max(0, rounded_exponent)
+
+
+def _floor_to_decimal_places(values, decimals: int):
+    """Floor values to a fixed number of decimal places."""
+    factor = 10**decimals
+    return np.floor(np.asarray(values, dtype=float) * factor) / factor
+
+
 class CSRFragmentCollection(FragmentCollection):
-    """CSR-backed, binned fragment storage for a spectra dataset.
+    """CSR-backed, m/z-grid fragment storage for a spectra dataset.
 
     Stores all fragments of a dataset in a sparse matrix using CSR format:
 
     - rows correspond to spectra
-    - columns correspond to discrete m/z bins
+    - columns correspond to discrete m/z grid positions
     - values correspond to peak intensities
 
-    The m/z values of input peaks are converted to integer bin indices using
-    :meth:`mz_to_bin`. This means that the original m/z values are not stored
-    directly. When spectra are reconstructed, m/z values are returned as bin
-    centers via :meth:`bin_to_mz`.
+    The m/z values of input peaks are converted to integer grid/bin indices using
+    :meth:`mz_to_bin`. The grid width is controlled by ``mz_precision``.
+
+    Parameters
+    ----------
+    spectra
+        Spectra used to construct the sparse fragment collection.
+    array
+        Existing CSR sparse array. Pass either ``spectra`` or ``array``, not both.
+    mz_precision
+        Width of one m/z grid step. For example, ``0.01`` stores m/z values at
+        two decimal places, while ``1e-6`` stores values at six decimal places.
+    mz_rounding
+        Strategy used to assign m/z values to grid positions. Supported values:
+
+        - ``"floor"``: ``123.456`` with ``mz_precision=0.01`` becomes ``123.45``.
+        - ``"round"``: ``123.456`` with ``mz_precision=0.01`` becomes ``123.46``.
 
     Notes
     -----
-    This is a binned representation and is therefore not necessarily lossless.
-    If multiple peaks from the same spectrum fall into the same m/z bin, they are
-    stored at the same sparse matrix coordinate. During sparse matrix construction,
-    such duplicate coordinates are combined by summing their intensities.
+    This is a discretized representation and is therefore not necessarily
+    lossless. If multiple peaks from the same spectrum map to the same m/z grid
+    position, they are stored at the same sparse matrix coordinate. During sparse
+    matrix construction, duplicate coordinates are combined by summing their
+    intensities.
 
-    For example, two peaks in one spectrum that map to the same m/z bin will be
-    represented as a single peak with the summed intensity when the row is
-    reconstructed.
-
-    The choice of ``bin_size`` therefore controls both mass precision and the
-    likelihood of peak merging. Smaller bin sizes preserve m/z differences more
-    closely but may create very large sparse matrix dimensions. Larger bin sizes
-    reduce the number of bins but increase the chance that neighboring peaks are
-    merged.
+    Smaller ``mz_precision`` values preserve m/z differences more closely but can
+    create much larger sparse matrices. Larger values reduce the number of grid
+    positions but increase the chance that neighboring peaks are merged.
     """
+
+    _SUPPORTED_MZ_ROUNDING = {"floor", "round"}
 
     def __init__(
         self,
         spectra: list[Spectrum] | Generator[Spectrum, None, None] | None = None,
         *,
         array: csr_array | None = None,
-        bin_size: float = 1e-6,
+        mz_precision: float = 1e-6,
+        mz_rounding: str = "round",
         index_dtype: np.dtype = np.int64,
     ):
-        if bin_size <= 0:
-            raise ValueError("bin_size must be > 0.")
-        self.bin_size = float(bin_size)
+        self._mz_decimals = _decimal_places_from_mz_precision(mz_precision)
+
+        if mz_rounding not in self._SUPPORTED_MZ_ROUNDING:
+            raise ValueError(
+                "mz_rounding must be one of "
+                f"{sorted(self._SUPPORTED_MZ_ROUNDING)}."
+            )
+
+        self.mz_precision = float(mz_precision)
+        self.mz_rounding = mz_rounding
         self.index_dtype = index_dtype
 
         if array is not None:
@@ -150,8 +195,8 @@ class CSRFragmentCollection(FragmentCollection):
         self._array = self._construct_from_spectra_list(spectra)
 
     @classmethod
-    def from_array(cls, array: csr_array, *, bin_size: float = 1e-6) -> FragmentCollectionType:
-        return cls(array=array, bin_size=bin_size)
+    def from_array(cls, array: csr_array, *, mz_precision: float = 1e-6) -> FragmentCollectionType:
+        return cls(array=array, mz_precision=mz_precision)
 
     def _construct_from_spectra_list(self, spectra: list[Spectrum]) -> csr_array:
         lengths = np.array([len(spec.mz) for spec in spectra])
@@ -194,19 +239,40 @@ class CSRFragmentCollection(FragmentCollection):
     def __repr__(self) -> str:
         return (
             f"CSRFragmentCollection(n_spectra={self.n_spectra}, "
-            f"n_fragments={self._array.data.shape[0]}, bin_size={self.bin_size})"
+            f"n_fragments={self._array.data.shape[0]}, mz_precision={self.mz_precision})"
         )
 
     def copy(self) -> FragmentCollectionType:
-        return self.__class__.from_array(self._array.copy(), bin_size=self.bin_size)
+        return self.__class__.from_array(self._array.copy(), mz_precision=self.mz_precision)
 
     def mz_to_bin(self, mz: np.ndarray | float) -> np.ndarray:
-        """Convert m/z values to integer bins."""
-        return np.floor(np.asarray(mz) / self.bin_size).astype(self.index_dtype)
+        """Convert m/z values to integer grid/bin indices.
+
+        The m/z values are first rounded or floored to the decimal precision
+        specified by ``mz_precision`` and then converted to integer indices.
+        """
+        mz_values = np.asarray(mz, dtype=float)
+
+        if self.mz_rounding == "floor":
+            discretized_mz = _floor_to_decimal_places(mz_values, self._mz_decimals)
+        elif self.mz_rounding == "round":
+            discretized_mz = np.round(mz_values, decimals=self._mz_decimals)
+        else:
+            raise ValueError(
+                "mz_rounding must be one of "
+                f"{sorted(self._SUPPORTED_MZ_ROUNDING)}."
+            )
+
+        return np.rint(discretized_mz / self.mz_precision).astype(self.index_dtype)
 
     def bin_to_mz(self, bin_idx: np.ndarray | int) -> np.ndarray:
-        """Convert bin indices to bin-center m/z values."""
-        return (bin_idx * self.bin_size) + (self.bin_size / 2)
+        """Convert integer grid/bin indices back to m/z values.
+
+        No bin-center offset is added. Returned m/z values correspond directly
+        to the discretized grid positions.
+        """
+        mz = np.asarray(bin_idx) * self.mz_precision
+        return np.round(mz, decimals=self._mz_decimals)
 
     def get_row(self, idx: int) -> tuple[np.ndarray, np.ndarray]:
         """Return one spectrum row as (mz, intensities)."""
@@ -234,7 +300,7 @@ class CSRFragmentCollection(FragmentCollection):
     def take(self, indices: Iterable[int]) -> FragmentCollectionType:
         """Return a new collection with selected rows in the given order."""
         indices = np.asarray(list(indices), dtype=self.index_dtype)
-        return self.__class__.from_array(self._array[indices, :], bin_size=self.bin_size)
+        return self.__class__.from_array(self._array[indices, :], mz_precision=self.mz_precision)
 
     def reorder(self, indices: Iterable[int]) -> FragmentCollectionType:
         """Alias for take()."""
@@ -300,7 +366,7 @@ class CSRFragmentCollection(FragmentCollection):
             shape=self._array.shape,
         ).tocsr()
 
-        return self.__class__.from_array(new_array, bin_size=self.bin_size)
+        return self.__class__.from_array(new_array, mz_precision=self.mz_precision)
 
     def __getitem__(self, key):
         """Support row slicing and optional row/column slicing.
@@ -417,7 +483,7 @@ class CSRFragmentCollection(FragmentCollection):
             shape=self._array.shape,
         ).tocsr()
 
-        return self.__class__.from_array(new_array, bin_size=self.bin_size)
+        return self.__class__.from_array(new_array, mz_precision=self.mz_precision)
 
     def select_by_relative_intensity(
             self,
@@ -437,7 +503,7 @@ class CSRFragmentCollection(FragmentCollection):
         coo = self._array.tocoo()
 
         if coo.data.size == 0:
-            return self.__class__.from_array(self._array.copy(), bin_size=self.bin_size)
+            return self.__class__.from_array(self._array.copy(), mz_precision=self.mz_precision)
 
         row_max = self._array.max(axis=1).toarray().ravel()
 
@@ -459,7 +525,7 @@ class CSRFragmentCollection(FragmentCollection):
             shape=self._array.shape,
         ).tocsr()
 
-        return self.__class__.from_array(new_array, bin_size=self.bin_size)
+        return self.__class__.from_array(new_array, mz_precision=self.mz_precision)
 
     def keep_top_k_per_row_variable(
             self,
@@ -529,4 +595,4 @@ class CSRFragmentCollection(FragmentCollection):
             shape=csr.shape,
         )
 
-        return self.__class__.from_array(new_array, bin_size=self.bin_size)
+        return self.__class__.from_array(new_array, mz_precision=self.mz_precision)

--- a/matchms/SpectraCollection.py
+++ b/matchms/SpectraCollection.py
@@ -65,14 +65,14 @@ class SpectraCollection:
     def __init__(
         self,
         spectra: list[Spectrum] | Generator[Spectrum, None, None],
-        bin_size=0.000001,
+        mz_precision=0.000001,
     ):
         spectra = list(spectra)
 
         if not spectra:
             raise ValueError("Spectra must contain at least one Spectrum.")
 
-        self.bin_size = bin_size
+        self.mz_precision = mz_precision
         self._metadata = self._construct_metadata(spectra)
         self._fragments = self._construct_fragments(spectra)
 
@@ -84,19 +84,19 @@ class SpectraCollection:
         cls,
         metadata: pd.DataFrame | pd.Series,
         fragments: FragmentCollection,
-        bin_size: float,
+        mz_precision: float,
     ) -> SpectraCollectionType:
         if isinstance(metadata, pd.Series):
             metadata = metadata.to_frame().T
 
         obj = cls.__new__(cls)
-        obj.bin_size = bin_size
+        obj.mz_precision = mz_precision
         obj._metadata = metadata.reset_index(drop=True)
         obj._fragments = fragments
         return obj
 
     def _construct_fragments(self, spectra: list):
-        return CSRFragmentCollection(spectra, bin_size=self.bin_size)
+        return CSRFragmentCollection(spectra, mz_precision=self.mz_precision)
 
     def _construct_metadata(self, spectra):
         # data = defaultdict(list)
@@ -185,7 +185,7 @@ class SpectraCollection:
             return self.__class__._from_metadata_and_fragments(
                 metadata=new_metadata,
                 fragments=new_fragments,
-                bin_size=self.bin_size,
+                mz_precision=self.mz_precision,
             )
 
         # scalar row -> one Spectrum
@@ -467,7 +467,7 @@ class SpectraCollection:
 
     def copy(self):
         new_spec = self.__class__.__new__(self.__class__)
-        new_spec.bin_size = self.bin_size
+        new_spec.mz_precision = self.mz_precision
         new_spec._metadata = self._metadata.copy()
         new_spec._fragments = self._fragments.copy()
 
@@ -477,7 +477,7 @@ class SpectraCollection:
         """
         Convert mz values into bins.
 
-        Uses the bin_size of SpectraCollection and maps mz values into integer bins by flooring them.
+        Uses the mz_precision of SpectraCollection and maps mz values into integer bins by flooring them.
 
         Parameters
         ----------
@@ -495,7 +495,7 @@ class SpectraCollection:
         """
         Convert bin indices to mz values.
 
-        Uses the bin_size of SpectraCollection and calculates the mz value at the center of the bin.
+        Uses the mz_precision of SpectraCollection and calculates the mz value at the center of the bin.
 
         Parameters
         ----------

--- a/matchms/filtering/_dispatch.py
+++ b/matchms/filtering/_dispatch.py
@@ -359,4 +359,4 @@ def apply_spectrum_filter_to_collection(
     if len(spectra_out) == 0:
         return None
 
-    return collection.__class__(spectra_out, bin_size=collection.bin_size)
+    return collection.__class__(spectra_out, mz_precision=collection.mz_precision)

--- a/matchms/filtering/peak_processing/normalize_intensities.py
+++ b/matchms/filtering/peak_processing/normalize_intensities.py
@@ -162,7 +162,7 @@ def _normalize_intensities_collection(
 
     target._fragments = fragments.__class__.from_array(
         normalized_array,
-        bin_size=fragments.bin_size,
+        mz_precision=fragments.mz_precision,
     )
     target._clear_cache(["fragment_hashes", "spectra_hashes"])
 

--- a/matchms/importing/load_spectra.py
+++ b/matchms/importing/load_spectra.py
@@ -70,6 +70,7 @@ def load_ms2_dataset(
     file: str,
     metadata_harmonization: bool = True,
     ftype: str = "auto",
+    **kwargs,
 ) -> SpectraCollection:
     """Load spectra from a file as a SpectraCollection.
 
@@ -84,6 +85,9 @@ def load_ms2_dataset(
         type from the file extension. Alternatively, pass an explicit file type,
         for example ``"mzml"``, ``"json"``, ``"mgf"``, ``"msp"``, ``"mzxml"``,
         or ``"pickle"``.
+    **kwargs
+        Additional keyword arguments to pass to the SpectraCollection constructor,
+        for example ``mz_precision``.
 
     Returns
     -------
@@ -95,7 +99,8 @@ def load_ms2_dataset(
             file,
             metadata_harmonization=metadata_harmonization,
             ftype=ftype,
-        )
+        ),
+        **kwargs,
     )
 
 

--- a/tests/test_fragment_collection.py
+++ b/tests/test_fragment_collection.py
@@ -26,11 +26,11 @@ def sample_spectra():
 
 @pytest.fixture
 def fragments(sample_spectra):
-    return CSRFragmentCollection(sample_spectra, bin_size=0.01)
+    return CSRFragmentCollection(sample_spectra, mz_precision=0.01)
 
 
 def test_construct_from_spectra(sample_spectra):
-    fragments = CSRFragmentCollection(sample_spectra, bin_size=0.01)
+    fragments = CSRFragmentCollection(sample_spectra, mz_precision=0.01)
 
     assert len(fragments) == 3
     assert fragments.n_spectra == 3
@@ -40,21 +40,21 @@ def test_construct_from_spectra(sample_spectra):
 
 
 def test_construct_from_array(fragments):
-    cloned = CSRFragmentCollection.from_array(fragments.array, bin_size=fragments.bin_size)
+    cloned = CSRFragmentCollection.from_array(fragments.array, mz_precision=fragments.mz_precision)
 
     assert len(cloned) == len(fragments)
-    assert cloned.bin_size == fragments.bin_size
+    assert cloned.mz_precision == fragments.mz_precision
     np.testing.assert_array_equal(cloned.array.toarray(), fragments.array.toarray())
 
 
-def test_construct_invalid_bin_size_raises(sample_spectra):
-    with pytest.raises(ValueError, match="bin_size must be > 0"):
-        CSRFragmentCollection(sample_spectra, bin_size=0.0)
+def test_construct_invalid_mz_precision_raises(sample_spectra):
+    with pytest.raises(ValueError, match="mz_precision must be > 0"):
+        CSRFragmentCollection(sample_spectra, mz_precision=0.0)
 
 
 def test_construct_empty_spectra_raises():
     with pytest.raises(ValueError, match="Spectra must contain at least one Spectrum"):
-        CSRFragmentCollection([], bin_size=0.01)
+        CSRFragmentCollection([], mz_precision=0.01)
 
 
 def test_construct_missing_input_raises():
@@ -65,14 +65,14 @@ def test_construct_missing_input_raises():
 def test_construct_array_and_spectra_raises(sample_spectra):
     dummy = csr_array((2, 3))
     with pytest.raises(ValueError, match="Pass either spectra or array, not both"):
-        CSRFragmentCollection(sample_spectra, array=dummy, bin_size=0.01)
+        CSRFragmentCollection(sample_spectra, array=dummy, mz_precision=0.01)
 
 
 def test_repr(fragments):
     rep = repr(fragments)
     assert "CSRFragmentCollection" in rep
     assert "n_spectra=3" in rep
-    assert "bin_size=0.01" in rep
+    assert "mz_precision=0.01" in rep
 
 
 def test_copy(fragments):
@@ -83,14 +83,47 @@ def test_copy(fragments):
     np.testing.assert_array_equal(cloned.array.toarray(), fragments.array.toarray())
 
 
-def test_mz_bin_conversion(fragments):
+@pytest.mark.parametrize(
+    "mz_rounding, exp_bin_idx, exp_back_mz",
+    [("floor", 12345, 123.45), ("round", 12346, 123.46)]
+    )
+def test_mz_bin_conversion(sample_spectra, mz_rounding, exp_bin_idx, exp_back_mz):
+    fragments = CSRFragmentCollection(sample_spectra, mz_precision=0.01, mz_rounding=mz_rounding)
     mz = 123.456
     bin_idx = fragments.mz_to_bin(mz)
     back_mz = fragments.bin_to_mz(bin_idx)
 
-    assert bin_idx == 12345
-    assert back_mz == pytest.approx(123.455)
+    assert bin_idx == exp_bin_idx
+    assert back_mz == pytest.approx(exp_back_mz)
 
+
+@pytest.mark.parametrize(
+    "invalid_precision, part_of_msg",
+    [(0, "mz_precision must be > 0"),
+     (-1e-4, "mz_precision must be > 0"),
+     (0.05, "power of ten"),
+     (0.005, "power of ten"),
+     (2e-6, "power of ten"),
+     ]
+    )
+def test_invalid_mz_precision_raises(invalid_precision, part_of_msg):
+    with pytest.raises(ValueError, match=part_of_msg):
+        CSRFragmentCollection(
+            [Spectrum(mz=np.array([100.0]), intensities=np.array([1.0]))],
+            mz_precision=invalid_precision,
+        )
+
+
+def test_mz_to_bin_round_uses_decimal_precision():
+    fragments = CSRFragmentCollection(
+        [Spectrum(mz=np.array([123.456]), intensities=np.array([1.0]))],
+        mz_precision=0.01,
+        mz_rounding="round",
+    )
+
+    mz, _ = fragments.get_row(0)
+
+    assert mz.tolist() == [123.46]
 
 def test_get_row(fragments):
     mz, intensities = fragments.get_row(0)
@@ -147,7 +180,7 @@ def test_drop(fragments):
 
 def test_drop_empty(sample_spectra):
     empty_spec = Spectrum(mz=np.array([]), intensities=np.array([]), metadata={})
-    fragments = CSRFragmentCollection(sample_spectra + [empty_spec], bin_size=0.01)
+    fragments = CSRFragmentCollection(sample_spectra + [empty_spec], mz_precision=0.01)
 
     assert len(fragments) == 4
     cleaned = fragments.drop_empty()
@@ -250,7 +283,7 @@ def test_count_axis_0(fragments):
 
 
 def test_count_peaks_above_relative_intensity(sample_spectra):
-    fragments = CSRFragmentCollection(sample_spectra, bin_size=1e-6)
+    fragments = CSRFragmentCollection(sample_spectra, mz_precision=1e-6)
 
     counts = fragments.count_peaks_above_relative_intensity(
         intensity_from=0.5,
@@ -284,8 +317,8 @@ def test_fragment_hashes_cached_property(fragments):
 
 
 def test_fragment_hashes_equal_for_identical_input(sample_spectra):
-    fragments_1 = CSRFragmentCollection(sample_spectra, bin_size=0.01)
-    fragments_2 = CSRFragmentCollection(sample_spectra, bin_size=0.01)
+    fragments_1 = CSRFragmentCollection(sample_spectra, mz_precision=0.01)
+    fragments_2 = CSRFragmentCollection(sample_spectra, mz_precision=0.01)
 
     assert np.all(fragments_1.fragment_hashes == fragments_2.fragment_hashes)
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -93,8 +93,8 @@ def mock_bin_to_mz(bin_idx):
     return (bin_idx * 0.1) + (0.1 / 2)
 
 
-def mock_mz_to_bin(mz, bin_size):
-    return np.floor(mz / bin_size).astype(np.int64)
+def mock_mz_to_bin(mz, mz_precision):
+    return np.floor(mz / mz_precision).astype(np.int64)
 
 
 def test_spectra_hashes_consistency(sample_csr_data):
@@ -117,11 +117,11 @@ def test_spectra_hashes_custom_params(sample_csr_data):
 
 
 def test_spectra_hashes_with_collection_mock(spectrum):
-    bin_size = 0.1
+    mz_precision = 0.1
     mz = np.array([100.0, 200.0])
     intensities = np.array([1.0, 0.5])
 
-    bins = mock_mz_to_bin(mz, bin_size)
+    bins = mock_mz_to_bin(mz, mz_precision)
     csr = csr_array((intensities, bins, [0, 2]), shape=(1, 5000))
 
     hashes = spectra_hashes(csr, mock_bin_to_mz)

--- a/tests/test_spectra_collection.py
+++ b/tests/test_spectra_collection.py
@@ -28,7 +28,7 @@ def sample_spectra():
 
 @pytest.fixture
 def collection(sample_spectra):
-    return SpectraCollection(sample_spectra, bin_size=0.01)
+    return SpectraCollection(sample_spectra, mz_precision=0.01)
 
 
 def test_getitem_slice(collection):
@@ -126,7 +126,7 @@ def test_drop_spectra(collection):
 
 
 def test_drop_duplicates(sample_spectra):
-    col = SpectraCollection(sample_spectra + [sample_spectra[1]], bin_size=0.01)
+    col = SpectraCollection(sample_spectra + [sample_spectra[1]], mz_precision=0.01)
 
     assert len(col) == 4
     deduped = col.drop_duplicates()
@@ -187,7 +187,7 @@ def test_drop_inplace(collection):
 
 def test_drop_empty_spectra(sample_spectra):
     empty_spec = Spectrum(mz=np.array([]), intensities=np.array([]), metadata={"name": "empty"})
-    col = SpectraCollection(sample_spectra + [empty_spec], bin_size=1.0)
+    col = SpectraCollection(sample_spectra + [empty_spec], mz_precision=1.0)
 
     assert len(col) == 4
     clean_col = col.drop_empty_spectra()
@@ -222,13 +222,16 @@ def test_copy(collection):
     assert "new_col" not in collection.metadata.columns
 
 
-def test_mz_bin_conversion(collection):
-    mz = 123.456
+@pytest.mark.parametrize(
+    "mz, expected_bin_idx, expected_back_mz",
+    [(123.456, 12346, 123.46), (123.454, 12345, 123.45)]
+    )
+def test_mz_bin_conversion_and_rounding(collection, mz, expected_bin_idx, expected_back_mz):
     bin_idx = collection.mz_to_bin(mz)
     back_mz = collection.bin_to_mz(bin_idx)
 
-    assert bin_idx == 12345
-    assert back_mz == 123.455
+    assert bin_idx == expected_bin_idx
+    assert back_mz == expected_back_mz
 
 
 def test_describe(collection):

--- a/tests/test_spectra_collection_import_export.py
+++ b/tests/test_spectra_collection_import_export.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import pytest
 from matchms import SpectraCollection, Spectrum
 from matchms.importing.load_spectra import load_ms2_dataset
@@ -159,3 +160,23 @@ def test_spectra_collection_to_json_append_not_supported(tmp_path):
 
     with pytest.raises(ValueError, match="Appending is not supported|append"):
         collection.to_json(str(output_file), append=True)
+
+
+def test_load_ms2_dataset_passes_mz_precision_to_collection():
+    file = _testdata_file("testdata.mgf")
+
+    collection = load_ms2_dataset(
+        file,
+        mz_precision=0.01,
+    )
+
+    assert isinstance(collection, SpectraCollection)
+    assert collection.fragments.mz_precision == 0.01
+    assert collection.fragments.mz_rounding == "round"
+
+    spectrum = collection[0]
+
+    # All reconstructed m/z values should lie on the 0.01 grid.
+    scaled_mz = spectrum.peaks.mz / 0.01
+    assert np.allclose(scaled_mz, np.round(scaled_mz))
+    assert spectrum.peaks.mz[0] == pytest.approx(66.14)  # actual peak in the file is 66.137428


### PR DESCRIPTION
- rename `bin_size` to `mz_precision`
- `CSRFragmentCollection` now supports two `mz_rounding` modes: `round` (default) or `floor`
- the new rounding to set precision also avoids more decimals than the precision delivers in the final file exports