### PR TITLE
Fix mzml loader

### DIFF
--- a/matchms/data/known_key_conversions.csv
+++ b/matchms/data/known_key_conversions.csv
@@ -15,6 +15,7 @@ precursor_charge,charge
 precursorcharge,charge
 ac$mass_spectrometry:charge,charge
 charge,charge
+charge_state,charge
 ms$data_processing:charge_deconvoluted,charge_deconvolved
 ch$link:chebi,chebi
 ch$link:chempdb,chempdb
@@ -149,6 +150,7 @@ precursormass,precursor_mz
 precursormz,precursor_mz
 precursor,precursor_mz
 ms$focused_ion:precursor_m/z,precursor_mz
+selected_ion_m/z,precursor_mz
 pi,principal_investigator
 comment:pi,principal_investigator
 ch$link:pubchem,pubchem
@@ -202,6 +204,7 @@ targetgaspres,target_gas_pressure
 ac$mass_spectrometry:target_gas_pressure,target_gas_pressure
 record title,title
 title,title
+spectrum_title,title
 ac$mass_spectrometry:trap_drive,trap_drive_value
 ch$link:united_nations,united_nations_number
 synon_metb_inchi,inchi
@@ -211,3 +214,4 @@ synon_metb_class,compound_class
 synon_metb_kegg,kegg
 synon_metb_n,synonyms
 synon_metb_cas,cas
+num,scan_number

--- a/matchms/filtering/metadata_processing/correct_charge.py
+++ b/matchms/filtering/metadata_processing/correct_charge.py
@@ -50,11 +50,6 @@ def correct_charge(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> O
     elif charge == 0 and ionmode == "negative":
         charge = -1
         logger.info("Guessed charge to -1 based on negative ionmode")
-    if charge == 0:
-        if spectrum.get("polarity") == "-":
-            charge = -1
-        if spectrum.get("polarity") == "+":
-            charge = 1
     # Correct charge when in conflict with ionmode (trust ionmode more!)
     if np.sign(charge) == 1 and ionmode == "negative":
         logger.info("Changed sign of given charge: %s to match negative ionmode", charge)

--- a/matchms/filtering/metadata_processing/correct_charge.py
+++ b/matchms/filtering/metadata_processing/correct_charge.py
@@ -50,7 +50,11 @@ def correct_charge(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> O
     elif charge == 0 and ionmode == "negative":
         charge = -1
         logger.info("Guessed charge to -1 based on negative ionmode")
-
+    if charge == 0:
+        if spectrum.get("polarity") == "-":
+            charge = -1
+        if spectrum.get("polarity") == "+":
+            charge = 1
     # Correct charge when in conflict with ionmode (trust ionmode more!)
     if np.sign(charge) == 1 and ionmode == "negative":
         logger.info("Changed sign of given charge: %s to match negative ionmode", charge)

--- a/matchms/filtering/metadata_processing/correct_charge.py
+++ b/matchms/filtering/metadata_processing/correct_charge.py
@@ -50,6 +50,7 @@ def correct_charge(spectrum_in: SpectrumType, clone: Optional[bool] = True) -> O
     elif charge == 0 and ionmode == "negative":
         charge = -1
         logger.info("Guessed charge to -1 based on negative ionmode")
+
     # Correct charge when in conflict with ionmode (trust ionmode more!)
     if np.sign(charge) == 1 and ionmode == "negative":
         logger.info("Changed sign of given charge: %s to match negative ionmode", charge)

--- a/matchms/importing/load_from_mzml.py
+++ b/matchms/importing/load_from_mzml.py
@@ -45,6 +45,7 @@ def load_from_mzml(
 
                 mz, intensities = sort_by_mz(mz=mz, intensities=intensities)
                 flattend_metadata = parse_metadata(pyteomics_spectrum)
+                flattend_metadata = derive_charge_from_polarity(flattend_metadata)
                 yield Spectrum(
                     mz=mz,
                     intensities=intensities,
@@ -70,6 +71,16 @@ def parse_key_value(key, value, first_level=True):
             yield from parse_key_value(k, v, False)
     else:
         yield key, value
+
+
+def derive_charge_from_polarity(flattend_metadata):
+    """This is here for historic reasons, it would fit better in the filter correct_charge,
+    but since the loader did this automatically before, we kept it here, to not break existing pipelines."""
+    if flattend_metadata["polarity"] == "-":
+        flattend_metadata["charge"] = -1
+    if flattend_metadata["polarity"] == "+":
+        flattend_metadata["charge"] = 1
+    return flattend_metadata
 
 
 def parse_metadata(metadata_dict: dict):

--- a/matchms/importing/load_from_mzml.py
+++ b/matchms/importing/load_from_mzml.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Generator, Union
 import numpy as np
 from pyteomics.mzml import read
-from matchms.importing.parsing_utils import parse_mzml_mzxml_metadata, sort_by_mz
+from matchms.importing.parsing_utils import sort_by_mz
 from matchms.Spectrum import Spectrum
 
 
@@ -40,12 +40,42 @@ def load_from_mzml(
     with read(filename, dtype=dict) as reader:
         for pyteomics_spectrum in reader:
             if "ms level" in pyteomics_spectrum and pyteomics_spectrum["ms level"] == ms_level:
-                metadata = parse_mzml_mzxml_metadata(pyteomics_spectrum)
-                mz = np.asarray(pyteomics_spectrum["m/z array"], dtype="float")
-                intensities = np.asarray(pyteomics_spectrum["intensity array"], dtype="float")
+                mz = np.asarray(pyteomics_spectrum.pop("m/z array"), dtype="float")
+                intensities = np.asarray(pyteomics_spectrum.pop("intensity array"), dtype="float")
 
                 mz, intensities = sort_by_mz(mz=mz, intensities=intensities)
-
+                flattend_metadata = parse_metadata(pyteomics_spectrum)
                 yield Spectrum(
-                    mz=mz, intensities=intensities, metadata=metadata, metadata_harmonization=metadata_harmonization
+                    mz=mz,
+                    intensities=intensities,
+                    metadata=flattend_metadata,
+                    metadata_harmonization=metadata_harmonization,
                 )
+
+
+def parse_key_value(key, value, first_level=True):
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if k == "count" and not first_level:
+                continue
+            if key is not None:
+                combined_key = key + "-" + k
+            else:
+                combined_key = k
+            yield from parse_key_value(combined_key, v, False)
+    elif isinstance(value, list):
+        if len(value) != 1:
+            raise ValueError("Expected only 1 value, for any mzml with count higher than 1, matchms has no support")
+        for k, v in value[0].items():
+            yield from parse_key_value(k, v, False)
+    else:
+        yield key, value
+
+
+def parse_metadata(metadata_dict: dict):
+    flattend_dict = {}
+    for key, value in parse_key_value(None, metadata_dict):
+        if key in flattend_dict:
+            raise ValueError(f"The key:{key} is duplicated")
+        flattend_dict[key] = value
+    return flattend_dict

--- a/matchms/importing/load_from_mzml.py
+++ b/matchms/importing/load_from_mzml.py
@@ -76,10 +76,11 @@ def parse_key_value(key, value, first_level=True):
 def derive_charge_from_polarity(flattend_metadata):
     """This is here for historic reasons, it would fit better in the filter correct_charge,
     but since the loader did this automatically before, we kept it here, to not break existing pipelines."""
-    if flattend_metadata["polarity"] == "-":
-        flattend_metadata["charge"] = -1
-    if flattend_metadata["polarity"] == "+":
-        flattend_metadata["charge"] = 1
+    if "polarity" in flattend_metadata:
+        if flattend_metadata["polarity"] == "-":
+            flattend_metadata["charge"] = -1
+        if flattend_metadata["polarity"] == "+":
+            flattend_metadata["charge"] = 1
     return flattend_metadata
 
 

--- a/matchms/importing/load_from_mzxml.py
+++ b/matchms/importing/load_from_mzxml.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 from typing import Generator, Union
-from matchms.importing.load_from_mzml import derive_charge_from_polarity, parse_metadata
 import numpy as np
 from pyteomics.mzxml import read
-from matchms.importing.parsing_utils import parse_mzml_mzxml_metadata, sort_by_mz
+from matchms.importing.load_from_mzml import derive_charge_from_polarity, parse_metadata
+from matchms.importing.parsing_utils import sort_by_mz
 from matchms.Spectrum import Spectrum
 
 

--- a/matchms/importing/load_from_mzxml.py
+++ b/matchms/importing/load_from_mzxml.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import Generator, Union
-from matchms.importing.load_from_mzml import parse_metadata
+from matchms.importing.load_from_mzml import derive_charge_from_polarity, parse_metadata
 import numpy as np
 from pyteomics.mzxml import read
 from matchms.importing.parsing_utils import parse_mzml_mzxml_metadata, sort_by_mz
@@ -51,6 +51,7 @@ def load_from_mzxml(
 
                 mz, intensities = sort_by_mz(mz=mz, intensities=intensities)
                 flattend_metadata = parse_metadata(pyteomics_spectrum)
+                flattend_metadata = derive_charge_from_polarity(flattend_metadata)
 
                 yield Spectrum(
                     mz=mz,

--- a/matchms/importing/load_from_mzxml.py
+++ b/matchms/importing/load_from_mzxml.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Generator, Union
+from matchms.importing.load_from_mzml import parse_metadata
 import numpy as np
 from pyteomics.mzxml import read
 from matchms.importing.parsing_utils import parse_mzml_mzxml_metadata, sort_by_mz
@@ -45,12 +46,15 @@ def load_from_mzxml(
                 or "msLevel" in pyteomics_spectrum
                 and pyteomics_spectrum["msLevel"] == ms_level
             ):
-                metadata = parse_mzml_mzxml_metadata(pyteomics_spectrum)
-                mz = np.asarray(pyteomics_spectrum["m/z array"], dtype="float")
-                intensities = np.asarray(pyteomics_spectrum["intensity array"], dtype="float")
+                mz = np.asarray(pyteomics_spectrum.pop("m/z array"), dtype="float")
+                intensities = np.asarray(pyteomics_spectrum.pop("intensity array"), dtype="float")
 
                 mz, intensities = sort_by_mz(mz=mz, intensities=intensities)
+                flattend_metadata = parse_metadata(pyteomics_spectrum)
 
                 yield Spectrum(
-                    mz=mz, intensities=intensities, metadata=metadata, metadata_harmonization=metadata_harmonization
+                    mz=mz,
+                    intensities=intensities,
+                    metadata=flattend_metadata,
+                    metadata_harmonization=metadata_harmonization,
                 )

--- a/tests/importing/test_load_from_mzml.py
+++ b/tests/importing/test_load_from_mzml.py
@@ -4,16 +4,19 @@ import pytest
 from matchms.importing import load_from_mzml
 
 
-@pytest.mark.parametrize("mzml_file", [
-    (os.path.join(os.path.dirname(__file__), "..", "testdata", "testdata.mzml")),
-    (Path(os.path.join(os.path.dirname(__file__), "..", "testdata", "testdata.mzml")))
-])
+@pytest.mark.parametrize(
+    "mzml_file",
+    [
+        (os.path.join(os.path.dirname(__file__), "..", "testdata", "testdata.mzml")),
+        (Path(os.path.join(os.path.dirname(__file__), "..", "testdata", "testdata.mzml"))),
+    ],
+)
 def test_load_from_mzml(mzml_file):
     """Test parsing of mzml file to spectrum objects"""
 
     spectra = list(load_from_mzml(mzml_file))
-
+    print(spectra[0].metadata)
     assert len(spectra) == 10, "Expected 10 spectra."
     assert int(spectra[5].get("precursor_mz")) == 177, "Expected different precursor m/z"
-    assert float(spectra[0].get("scan_start_time")[0]) == 0.616304, "Expected different time."
+    assert float(spectra[0].get("scan_start_time")) == 0.616304, "Expected different time."
     assert [len(x.peaks) for x in spectra] == [30, 28, 21, 70, 28, 20, 22, 27, 11, 25]


### PR DESCRIPTION
Solving #921 

The current mzml loader ignores all metadata that is not one of the 6 specified fields. 
It seemed somewhat easy to parse the data that the pyteomics reader, so that is my attempt here. 

Implemented the following:
1: mzml has hierarchical fields, this doesn't match well with matchms. So I wrote a script that flattens this hierarchy. It will just connect the different hierarchy levels with a "-". There are some cases where multiple entries are allowed. Like multiple precursor m/z, but these are (as far as I know) edge cases matchms doesn't support. 
2. Previously some parsing happened of converting to matchms key names. This happened in a separate method, now I moved it to the standard key conversions list, which also fits better with the general way this is handled in matchms.

So I think it still has all the old functionality now, with in addition the non standardized metadata keys also being loaded. 

@florian-huber What do you think. Do you know anyone that is familiar with using mzml files that could do a quick stress test? I now just tested on some files I had here and for those it worked fine. 

@hechth If I remember correctly, I think you worked with mzml files right? Would this work for you, or would this break your pipelines? 