### PR TITLE
Revert change of spectrum to Spectrum

### DIFF
--- a/matchms/typing.py
+++ b/matchms/typing.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 if TYPE_CHECKING:
-    from matchms.Spectrum import Spectrum
+    from matchms.spectrum import Spectrum
 
     SpectrumType: TypeAlias = Spectrum
 else:


### PR DESCRIPTION
I thought I fixed a bug, but the capitals were actually removed from files in the development branch. Here the change made in #935 is reverted. 