### PR TITLE
Adjust matchms default filter execution order

### DIFF
--- a/matchms/filtering/__init__.py
+++ b/matchms/filtering/__init__.py
@@ -47,6 +47,19 @@ Because matchms contains many filters, and because some filters should be applie
 in a particular order, the recommended way to define a processing workflow is
 with :class:`~matchms.filtering.SpectraProcessor`.
 
+The default filter order is defined in :mod:`~matchms.filtering.filter_order`. This
+order is based on the recommended order of operations for processing mass spectra and
+can be critical for the proper execution of some filters. For example, the ``require_precursor_mz`` filter
+should be applied after the ``interpret_pepmass`` filter, because the latter adds precursor m/z values
+to spectra that are missing them.
+
+Also normalization of peaks can be an execution-order-sentitive operation. For example, if a filter
+removes peaks, the normalization should usually be applied after that filter.
+
+In case you want to apply a filter in a different order, you can either create your own ``SpectraProcessor``
+with a custom filter order. Or simply apply every filter individually in the order you want, without using 
+``SpectraProcessor``.
+
 A processor is created from a list of filters. Filters can be specified by name,
 or together with a dictionary containing non-default parameters.
 

--- a/matchms/filtering/default_pipelines.py
+++ b/matchms/filtering/default_pipelines.py
@@ -49,7 +49,7 @@ REQUIRE_COMPLETE_ANNOTATION = [
     msfilters.require_matching_adduct_and_ionmode,
 ]
 CLEAN_PEAKS = [
-    (msfilters.select_by_mz, {"mz_from": 0, "mz_to": 1000}),
+    # removed in matchms_v1 (too opinionated) (msfilters.select_by_mz, {"mz_from": 0, "mz_to": 1000}),
     (msfilters.select_by_relative_intensity, {"intensity_from": 0.001}),
     msfilters.remove_peaks_relative_to_precursor_mz,
     (msfilters.reduce_to_number_of_peaks, {"n_max": 1000}),

--- a/matchms/filtering/filter_order.py
+++ b/matchms/filtering/filter_order.py
@@ -49,7 +49,6 @@ ALL_FILTERS = [
     msfilters.require_retention_time,
     msfilters.require_matching_adduct_and_ionmode,
     msfilters.remove_profiled_spectra,
-    msfilters.normalize_intensities,
     msfilters.remove_noise_below_frequent_intensities,
     msfilters.select_by_intensity,
     msfilters.select_by_mz,
@@ -57,6 +56,8 @@ ALL_FILTERS = [
     msfilters.remove_peaks_around_precursor_mz,
     msfilters.remove_peaks_relative_to_precursor_mz,
     msfilters.remove_peaks_outside_top_k,
+    # final fragment handling step since matchms_v1 (enforce max-intensity is 1.0 after all other filters):
+    msfilters.normalize_intensities,
     msfilters.reduce_to_number_of_peaks,
     msfilters.require_minimum_number_of_peaks,
     msfilters.require_maximum_number_of_peaks,

--- a/tests/test_pipeline.yaml
+++ b/tests/test_pipeline.yaml
@@ -18,7 +18,7 @@ spectra_1_filters:
 - - repair_inchi_inchikey_smiles
 - - repair_parent_mass_match_smiles_wrapper
 - - normalize_intensities
-- - select_by_intensity
+- - select_by_relative_intensity
   - intensity_from: 0.001
 
 spectra_2_filters: processing_spectra_1


### PR DESCRIPTION
- Adjust the filter order --> Now `normalize_intensities` is at the end
- Remove default `select_by_mz` from `CLEAN_PEAKS` because I would consider removing peaks above 1000 Da as too optinionated/not general enough.