### PR TITLE
Add central similarity score default parameters

### DIFF
--- a/matchms/similarity/cosine.py
+++ b/matchms/similarity/cosine.py
@@ -5,6 +5,11 @@ from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarity
 from .cosine_greedy import CosineGreedy
 from .cosine_hungarian import CosineHungarian
+from .default_parameters import (
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+)
 from .flash_similarity import CosineFlash
 
 
@@ -35,10 +40,10 @@ class Cosine(BaseSimilarity):
 
     def __init__(
             self,
-            tolerance: float = 0.1,
-            intensity_power: float = 1.0,
+            tolerance: float = DEFAULT_MZ_TOLERANCE,
+            intensity_power: float = DEFAULT_INTENSITY_POWER,
             use_hungarian: bool = False,
-            noise_cutoff: float = 0.01,
+            noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
             ):
         """Initialize cosine score class.
 

--- a/matchms/similarity/cosine_blink.py
+++ b/matchms/similarity/cosine_blink.py
@@ -5,6 +5,12 @@ from scipy.sparse import csr_array
 from matchms.scores import Scores
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarity
+from .default_parameters import (
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_POWER,
+    DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+)
 
 
 @njit(cache=True, fastmath=True)
@@ -114,15 +120,15 @@ class CosineBlink(BaseSimilarity):
 
     def __init__(
         self,
-        tolerance: float = 0.01,
+        tolerance: float = DEFAULT_MZ_TOLERANCE,
         bin_width: float = 0.001,
-        mz_power: float = 0.0,
-        intensity_power: float = 1.0,
+        mz_power: float = DEFAULT_MZ_POWER,
+        intensity_power: float = DEFAULT_INTENSITY_POWER,
         clip_to_one: bool = True,
         # extras
         use_numba: bool = True,
         prefilter: bool = True,
-        min_relative_intensity: float = 0.01,
+        min_relative_intensity: float = DEFAULT_NOISE_CUTOFF,
         crop_above_precursor: bool = True,
         remove_zero_intensities: bool = True,
         top_k: int | None = None,

--- a/matchms/similarity/cosine_greedy.py
+++ b/matchms/similarity/cosine_greedy.py
@@ -1,6 +1,12 @@
 import numpy as np
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarityWithSparse
+from .default_parameters import (
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_POWER,
+    DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+)
 from .spectrum_similarity_functions import collect_peak_pairs, filter_noise, score_best_matches
 
 
@@ -59,16 +65,16 @@ class CosineGreedy(BaseSimilarityWithSparse):
 
 
     def __init__(
-            self, tolerance: float = 0.1,
-            mz_power: float = 0.0,
-            intensity_power: float = 1.0,
-            noise_cutoff: float = 0.01,
+            self, tolerance: float = DEFAULT_MZ_TOLERANCE,
+            mz_power: float = DEFAULT_MZ_POWER,
+            intensity_power: float = DEFAULT_INTENSITY_POWER,
+            noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
             ):
         """
         Parameters
         ----------
         tolerance:
-            Peaks will be considered a match when <= tolerance apart. Default is 0.1.
+            Peaks will be considered a match when <= tolerance apart. Default is 0.01.
         mz_power:
             The power to raise m/z to in the cosine function. The default is 0, in which
             case the peak intensity products will not depend on the m/z ratios.

--- a/matchms/similarity/cosine_hungarian.py
+++ b/matchms/similarity/cosine_hungarian.py
@@ -3,6 +3,11 @@ from scipy.optimize import linear_sum_assignment
 from matchms.similarity.spectrum_similarity_functions import collect_peak_pairs
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarityWithSparse
+from .default_parameters import (
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_POWER,
+    DEFAULT_MZ_TOLERANCE,
+)
 
 
 class CosineHungarian(BaseSimilarityWithSparse):
@@ -23,13 +28,16 @@ class CosineHungarian(BaseSimilarityWithSparse):
     score_datatype = [("score", np.float64), ("matches", "int")]
     score_fields = ("score", "matches")
 
-    def __init__(self, tolerance: float = 0.1, mz_power: float = 0.0,
-                 intensity_power: float = 1.0):
+    def __init__(
+            self, tolerance: float = DEFAULT_MZ_TOLERANCE,
+            mz_power: float = DEFAULT_MZ_POWER,
+            intensity_power: float = DEFAULT_INTENSITY_POWER
+            ):
         """
         Parameters
         ----------
         tolerance:
-            Peaks will be considered a match when <= tolerance apart. Default is 0.1.
+            Peaks will be considered a match when <= tolerance apart. Default is 0.01.
         mz_power:
             The power to raise m/z to in the cosine function. The default is 0, in which
             case the peak intensity products will not depend on the m/z ratios.

--- a/matchms/similarity/cosine_linear.py
+++ b/matchms/similarity/cosine_linear.py
@@ -5,6 +5,11 @@ from matchms.scores import Scores
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarity
 from .cosine_linear_functions import linear_cosine_score, sirius_merge_close_peaks
+from .default_parameters import (
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_POWER,
+    DEFAULT_MZ_TOLERANCE,
+)
 
 
 class CosineLinear(BaseSimilarity):
@@ -46,7 +51,12 @@ class CosineLinear(BaseSimilarity):
     score_datatype = [("score", np.float64), ("matches", "int")]  # type: ignore[assignment]
     score_fields = ("score", "matches")
 
-    def __init__(self, tolerance: float = 0.1, mz_power: float = 0.0, intensity_power: float = 1.0):
+    def __init__(
+            self,
+            tolerance: float = DEFAULT_MZ_TOLERANCE,
+            mz_power: float = DEFAULT_MZ_POWER,
+            intensity_power: float = DEFAULT_INTENSITY_POWER
+            ):
         """
         Parameters
         ----------

--- a/matchms/similarity/default_parameters.py
+++ b/matchms/similarity/default_parameters.py
@@ -1,0 +1,11 @@
+"""Default settings shared by similarity implementations."""
+
+import numpy as np
+
+
+DEFAULT_MZ_TOLERANCE = 0.01
+DEFAULT_MZ_POWER = 0.0
+DEFAULT_INTENSITY_POWER = 1.0
+DEFAULT_NOISE_CUTOFF = 0.01
+DEFAULT_USE_PPM = False
+DEFAULT_DTYPE = np.float64

--- a/matchms/similarity/entropy.py
+++ b/matchms/similarity/entropy.py
@@ -2,6 +2,10 @@ from collections.abc import Sequence
 import numpy as np
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarity
+from .default_parameters import (
+    DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+)
 from .entropy_greedy import EntropyGreedy
 from .flash_similarity import FlashEntropy
 
@@ -55,11 +59,11 @@ class Entropy(BaseSimilarity):
 
     def __init__(
         self,
-        tolerance: float = 0.02,
+        tolerance: float = DEFAULT_MZ_TOLERANCE,
         use_ppm: bool = False,
         remove_precursor: bool = False,
         precursor_window: float = 1.6,
-        noise_cutoff: float | None = 0.01,
+        noise_cutoff: float | None = DEFAULT_NOISE_CUTOFF,
         merge_within: float = 0.0,
         dtype: np.dtype = np.float64,
     ):

--- a/matchms/similarity/entropy_greedy.py
+++ b/matchms/similarity/entropy_greedy.py
@@ -1,6 +1,10 @@
 import numpy as np
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarityWithSparse
+from .default_parameters import (
+    DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+)
 from .flash_utils import _clean_and_weight
 
 
@@ -90,7 +94,7 @@ class EntropyGreedy(BaseSimilarityWithSparse):
     ----------
     tolerance
         Maximum peak m/z difference for a match. Interpreted as Da unless
-        ``use_ppm=True``. Default is 0.02.
+        ``use_ppm=True``. Default is 0.01.
     use_ppm
         If True, interpret ``tolerance`` as a symmetric ppm tolerance.
     remove_precursor
@@ -106,7 +110,7 @@ class EntropyGreedy(BaseSimilarityWithSparse):
         preprocessing. Default is 0.
     dtype
         Floating-point dtype used for preprocessing and the returned score.
-        Default is ``np.float64``.
+        Default is ``np.float``.
     """
 
     is_commutative = True
@@ -115,11 +119,11 @@ class EntropyGreedy(BaseSimilarityWithSparse):
 
     def __init__(
         self,
-        tolerance: float = 0.02,
+        tolerance: float = DEFAULT_MZ_TOLERANCE,
         use_ppm: bool = False,
         remove_precursor: bool = False,
         precursor_window: float = 1.6,
-        noise_cutoff: float | None = 0.01,
+        noise_cutoff: float | None = DEFAULT_NOISE_CUTOFF,
         merge_within: float = 0.0,
         dtype: np.dtype = np.float64,
     ):

--- a/matchms/similarity/flash_similarity.py
+++ b/matchms/similarity/flash_similarity.py
@@ -8,6 +8,12 @@ from tqdm import tqdm
 from matchms.scores import Scores
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarity
+from .default_parameters import (
+    DEFAULT_DTYPE,
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+)
 from .flash_utils import _build_library_index, _clean_and_weight
 
 
@@ -22,17 +28,17 @@ class _BaseFlashSimilarity(BaseSimilarity):
     def __init__(
         self,
         matching_mode: str = "fragment",           # 'fragment' | 'neutral_loss' | 'hybrid'
-        tolerance: float = 0.02,
+        tolerance: float = DEFAULT_MZ_TOLERANCE,
         use_ppm: bool = False,
-        intensity_power: float = 1.0,
+        intensity_power: float = DEFAULT_INTENSITY_POWER,
         remove_precursor: bool = False,
         precursor_window: float = 1.6,
-        noise_cutoff: float = 0.01,
+        noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
         normalize_to_half: bool = False,
         merge_within: float = 0,
         identity_precursor_tolerance: float | None = None,
         identity_use_ppm: bool = False,
-        dtype: np.dtype = np.float64,
+        dtype: np.dtype = DEFAULT_DTYPE,
     ):
         if matching_mode not in ("fragment", "neutral_loss", "hybrid"):
             raise ValueError("matching_mode must be 'fragment', 'neutral_loss', or 'hybrid'")
@@ -268,7 +274,7 @@ class FlashEntropy(_BaseFlashSimilarity):
         self,
         *args,
         normalize_to_half: bool = True,
-        dtype: np.dtype = np.float64,
+        dtype: np.dtype = DEFAULT_DTYPE,
         **kwargs,
     ):
         super().__init__(
@@ -408,7 +414,7 @@ class CosineFlash(_BaseFlashSimilarity):
     matching_mode:
         Matching mode: 'fragment', 'neutral_loss', or 'hybrid' (default is 'fragment').
     tolerance:
-        Matching tolerance in Da or ppm (use_ppm=True). Default is 0.02.
+        Matching tolerance in Da or ppm (use_ppm=True). Default is 0.01.
     use_ppm:
         If True, interpret `tolerance` as parts-per-million. Default is False.
     intensity_power:
@@ -442,7 +448,7 @@ class CosineFlash(_BaseFlashSimilarity):
 
     score_fields = ("score", "matches")
 
-    def __init__(self, *args, dtype: np.dtype = np.float64, **kwargs):
+    def __init__(self, *args, dtype: np.dtype = DEFAULT_DTYPE, **kwargs):
         super().__init__(*args, dtype=dtype, **kwargs)
         self.score_datatype = np.dtype(
             [("score", self.dtype), ("matches", np.int32)]

--- a/matchms/similarity/modified_cosine.py
+++ b/matchms/similarity/modified_cosine.py
@@ -3,6 +3,11 @@ from collections.abc import Sequence
 import numpy as np
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarity
+from .default_parameters import (
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+)
 from .flash_similarity import CosineFlash
 from .modified_cosine_greedy import ModifiedCosineGreedy
 from .modified_cosine_hungarian import ModifiedCosineHungarian
@@ -40,17 +45,17 @@ class ModifiedCosine(BaseSimilarity):
 
     def __init__(
             self,
-            tolerance: float = 0.1,
-            intensity_power: float = 1.0,
+            tolerance: float = DEFAULT_MZ_TOLERANCE,
+            intensity_power: float = DEFAULT_INTENSITY_POWER,
             use_hungarian: bool = False,
-            noise_cutoff: float = 0.01,
+            noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
             ):
         """Initialize the modified cosine score class.
 
         Parameters
         ----------
         tolerance:
-            Peaks will be considered a match when <= tolerance apart. Default is 0.1.
+            Peaks will be considered a match when <= tolerance apart. Default is 0.01.
         intensity_power:
             The power to raise intensity to in the cosine function. The default is 1.
         use_hungarian:

--- a/matchms/similarity/modified_cosine_greedy.py
+++ b/matchms/similarity/modified_cosine_greedy.py
@@ -4,6 +4,11 @@ from matchms.typing import SpectrumType
 from ._precursor_validation import get_valid_precursor_mz
 from .base_similarity import BaseSimilarityWithSparse
 from .cosine_greedy import CosineGreedy
+from .default_parameters import (
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+)
 from .spectrum_similarity_functions import collect_peak_pairs, filter_noise, score_best_matches
 
 
@@ -38,17 +43,17 @@ class ModifiedCosineGreedy(BaseSimilarityWithSparse):
     score_fields = ("score", "matches")
 
     def __init__(
-            self, tolerance: float = 0.1,
+            self, tolerance: float = DEFAULT_MZ_TOLERANCE,
             mz_power: float = 0.0,
-            intensity_power: float = 1.0,
-            noise_cutoff: float = 0.01,
+            intensity_power: float = DEFAULT_INTENSITY_POWER,
+            noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
             ):
         """Initialize approximate modified cosine.
 
         Parameters
         ----------
         tolerance:
-            Peaks will be considered a match when <= tolerance apart. Default is 0.1.
+            Peaks will be considered a match when <= tolerance apart. Default is 0.01.
         mz_power:
             The power to raise mz to in the cosine function. The default is 0, in which
             case the peak intensity products will not depend on the m/z ratios.

--- a/matchms/similarity/modified_cosine_hungarian.py
+++ b/matchms/similarity/modified_cosine_hungarian.py
@@ -8,8 +8,8 @@ from .base_similarity import BaseSimilarityWithSparse
 from .cosine_hungarian import CosineHungarian
 from .default_parameters import (
     DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_POWER,
     DEFAULT_MZ_TOLERANCE,
-    DEFAULT_NOISE_CUTOFF,
 )
 
 
@@ -39,7 +39,7 @@ class ModifiedCosineHungarian(BaseSimilarityWithSparse):
     def __init__(
             self,
             tolerance: float = DEFAULT_MZ_TOLERANCE,
-            mz_power: float = 0.0,
+            mz_power: float = DEFAULT_MZ_POWER,
             intensity_power: float = DEFAULT_INTENSITY_POWER
             ):
         """Initialize exact modified cosine.

--- a/matchms/similarity/modified_cosine_hungarian.py
+++ b/matchms/similarity/modified_cosine_hungarian.py
@@ -6,6 +6,11 @@ from matchms.typing import SpectrumType
 from ._precursor_validation import get_valid_precursor_mz
 from .base_similarity import BaseSimilarityWithSparse
 from .cosine_hungarian import CosineHungarian
+from .default_parameters import (
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+)
 
 
 logger = logging.getLogger("matchms")
@@ -31,13 +36,18 @@ class ModifiedCosineHungarian(BaseSimilarityWithSparse):
     score_datatype = [("score", np.float64), ("matches", "int")]
     score_fields = ("score", "matches")
 
-    def __init__(self, tolerance: float = 0.1, mz_power: float = 0.0, intensity_power: float = 1.0):
+    def __init__(
+            self,
+            tolerance: float = DEFAULT_MZ_TOLERANCE,
+            mz_power: float = 0.0,
+            intensity_power: float = DEFAULT_INTENSITY_POWER
+            ):
         """Initialize exact modified cosine.
 
         Parameters
         ----------
         tolerance:
-            Peaks will be considered a match when <= tolerance apart. Default is 0.1.
+            Peaks will be considered a match when <= tolerance apart. Default is 0.01.
         mz_power:
             The power to raise mz to in the cosine function. The default is 0, in which
             case the peak intensity products will not depend on the m/z ratios.

--- a/matchms/similarity/neutral_losses_cosine.py
+++ b/matchms/similarity/neutral_losses_cosine.py
@@ -3,6 +3,11 @@ import numpy as np
 from matchms.typing import SpectrumType
 from ._precursor_validation import get_valid_precursor_mz
 from .base_similarity import BaseSimilarityWithSparse
+from .default_parameters import (
+    DEFAULT_INTENSITY_POWER,
+    DEFAULT_MZ_POWER,
+    DEFAULT_MZ_TOLERANCE,
+)
 from .spectrum_similarity_functions import collect_peak_pairs, score_best_matches
 
 
@@ -26,8 +31,13 @@ class NeutralLossesCosine(BaseSimilarityWithSparse):
     score_datatype = [("score", np.float64), ("matches", "int")]
     score_fields = ("score", "matches")
 
-    def __init__(self,tolerance: float = 0.1, mz_power: float = 0.0,
-                 intensity_power: float = 1.0, ignore_peaks_above_precursor: bool = True):
+    def __init__(
+            self,
+            tolerance: float = DEFAULT_MZ_TOLERANCE,
+            mz_power: float = DEFAULT_MZ_POWER,
+            intensity_power: float = DEFAULT_INTENSITY_POWER,
+            ignore_peaks_above_precursor: bool = True
+            ):
         """
         Parameters
         ----------

--- a/tests/similarity/test_default_parameters.py
+++ b/tests/similarity/test_default_parameters.py
@@ -1,0 +1,26 @@
+import matchms.similarity as mssim
+from matchms.similarity.default_parameters import DEFAULT_MZ_TOLERANCE
+
+
+def test_peak_similarity_default_tolerances_are_consistent():
+    """Test that default tolerances are consistent across all similarity implementations.
+    Adjust if any of the default tolerances are changed in the future.
+    """
+    similarities = [
+        mssim.Cosine(),
+        mssim.CosineGreedy(),
+        mssim.CosineHungarian(),
+        mssim.CosineLinear(),
+        mssim.CosineFlash(),
+        mssim.ModifiedCosine(),
+        mssim.ModifiedCosineGreedy(),
+        mssim.ModifiedCosineHungarian(),
+        mssim.Entropy(),
+        mssim.EntropyGreedy(),
+        mssim.FlashEntropy(),
+    ]
+
+    assert all(
+        similarity.tolerance == DEFAULT_MZ_TOLERANCE
+        for similarity in similarities
+    )


### PR DESCRIPTION
Many of the matchms similarity scores have overlapping parameters. This PR now add a `default_parameters.py` file were central parameters can be set. This is to avoid setting slightly different defaults in different methods (which could lead to unintended variation/mistakes).

This will fix #876 