### PR TITLE
Dependency removal (for very specific dependencies)

### DIFF
--- a/.github/workflows/CI_first_code_check.yml
+++ b/.github/workflows/CI_first_code_check.yml
@@ -12,14 +12,14 @@ on:
 jobs:
 
   first_check:
-    name: first code check / python-3.12 / ubuntu-latest
+    name: first code check / python-3.13 / ubuntu-latest
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Python info
         run: |
           which python
@@ -27,7 +27,7 @@ jobs:
       - name: Build package and create dev environment
         run: |
           python -m pip install --upgrade pip poetry
-          poetry install
+          poetry install -E all
       - name: Show pip list
         run: |
           pip list

--- a/.github/workflows/CI_installation_checks.yml
+++ b/.github/workflows/CI_installation_checks.yml
@@ -21,7 +21,7 @@ jobs:
           - variant: fingerprints
             install_target: ".[fingerprints]"
             expect_chemap: "true"
-            expect_networkx: "false"
+            expect_networkx: "true"
           - variant: networking
             install_target: ".[networking]"
             expect_chemap: "false"

--- a/.github/workflows/CI_installation_checks.yml
+++ b/.github/workflows/CI_installation_checks.yml
@@ -1,0 +1,98 @@
+name: CI installation checks
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  installation_check:
+    name: install / ${{ matrix.variant }} / python-3.13
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: core
+            install_target: "."
+            expect_chemap: "false"
+            expect_networkx: "false"
+          - variant: fingerprints
+            install_target: ".[fingerprints]"
+            expect_chemap: "true"
+            expect_networkx: "false"
+          - variant: networking
+            install_target: ".[networking]"
+            expect_chemap: "false"
+            expect_networkx: "true"
+          - variant: all
+            install_target: ".[all]"
+            expect_chemap: "true"
+            expect_networkx: "true"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install matchms variant
+        run: python -m pip install "${{ matrix.install_target }}"
+
+      - name: Check dependency consistency
+        run: python -m pip check
+
+      - name: Check installation
+        env:
+          EXPECT_CHEMAP: ${{ matrix.expect_chemap }}
+          EXPECT_NETWORKX: ${{ matrix.expect_networkx }}
+        run: |
+          python - <<'PY'
+          import importlib.util
+          import os
+
+          import matchms
+
+          expect_chemap = os.environ["EXPECT_CHEMAP"] == "true"
+          expect_networkx = os.environ["EXPECT_NETWORKX"] == "true"
+
+          has_chemap = importlib.util.find_spec("chemap") is not None
+          has_networkx = importlib.util.find_spec("networkx") is not None
+
+          assert has_chemap == expect_chemap, (
+              f"chemap availability: expected {expect_chemap}, got {has_chemap}"
+          )
+          assert has_networkx == expect_networkx, (
+              f"networkx availability: expected {expect_networkx}, got {has_networkx}"
+          )
+
+          print(f"matchms imported successfully: {matchms.__file__}")
+          print(f"chemap installed: {has_chemap}")
+          print(f"networkx installed: {has_networkx}")
+          PY
+
+      - name: Check networking import
+        if: matrix.expect_networkx == 'true'
+        run: |
+          python - <<'PY'
+          from matchms.networking import SimilarityNetwork
+
+          SimilarityNetwork()
+          print("SimilarityNetwork is available.")
+          PY
+
+      - name: Check fingerprint imports
+        if: matrix.expect_chemap == 'true'
+        run: |
+          python - <<'PY'
+          import chemap
+          from matchms import Fingerprints
+
+          print("chemap and matchms.Fingerprints are available.")
+          PY

--- a/.github/workflows/CI_installation_checks.yml
+++ b/.github/workflows/CI_installation_checks.yml
@@ -2,8 +2,12 @@ name: CI installation checks
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag for manually running CI installation checks workflow
+        required: False
+        default: ''
 
 jobs:
   installation_check:

--- a/matchms/fingerprints.py
+++ b/matchms/fingerprints.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
-from chemap import FingerprintConfig, compute_fingerprints
 from rdkit import Chem
 from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
     is_valid_inchi,
@@ -17,6 +16,18 @@ from matchms.filtering.filter_utils.smile_inchi_inchikey_conversions import (
 
 if TYPE_CHECKING:
     from matchms.spectrum import Spectrum
+
+
+def _require_chemap():
+    try:
+        from chemap import FingerprintConfig, compute_fingerprints
+    except ImportError as exc:
+        raise ImportError(
+            "Fingerprint computation requires the optional 'chemap' dependency. "
+            "Install it with `pip install 'matchms[fingerprints]'`."
+        ) from exc
+
+    return FingerprintConfig, compute_fingerprints
 
 
 logger = logging.getLogger("matchms")
@@ -331,6 +342,8 @@ class Fingerprints:
 
     def _compute_from_smiles(self, smiles: list[str]):
         """Compute fingerprints from SMILES using chemap."""
+        FingerprintConfig, compute_fingerprints = _require_chemap()
+
         config = FingerprintConfig(
             count=self.count,
             folded=self.folded,

--- a/matchms/networking/similarity_network.py
+++ b/matchms/networking/similarity_network.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
-import networkx as nx
 import numpy as np
 from .networking_functions import get_top_hits
 

--- a/matchms/networking/similarity_network.py
+++ b/matchms/networking/similarity_network.py
@@ -11,6 +11,20 @@ if TYPE_CHECKING:
     from matchms import Scores
 
 
+try:
+    import networkx as nx
+except ImportError:
+    nx = None
+
+
+def _require_networkx():
+    if nx is None:
+        raise ImportError(
+            "SimilarityNetwork requires the optional 'networkx' dependency. "
+            "Install it with `pip install 'matchms[networking]'`."
+        )
+
+
 class SimilarityNetwork:
     """Create a similarity network from all-vs-all spectrum similarities.
 
@@ -86,6 +100,8 @@ class SimilarityNetwork:
             If True (default), all identifiers are included as nodes even if
             they have no edges. If False, isolated nodes are removed.
         """
+        _require_networkx()
+
         self.top_n = top_n
         self.max_links = max_links
         self.score_cutoff = score_cutoff

--- a/matchms/similarity/fingerprint_similarity.py
+++ b/matchms/similarity/fingerprint_similarity.py
@@ -11,6 +11,18 @@ from .base_similarity import BaseSimilarity
 from .vector_similarity_functions import cosine_similarity_matrix
 
 
+def _require_chemap():
+    """Require chemap package and return tanimoto_similarity_matrix function."""
+    try:
+        from chemap.metrics import tanimoto_similarity_matrixs
+    except ImportError as e:
+        raise ImportError(
+            "The 'chemap' package is required for fingerprint similarity calculations. "
+            "Please install it using 'pip install chemap'."
+        ) from e
+    return tanimoto_similarity_matrix
+
+
 class FingerprintSimilarity(BaseSimilarity):
     """Calculate similarity between molecules based on molecular fingerprints.
 
@@ -221,6 +233,8 @@ class FingerprintSimilarity(BaseSimilarity):
 
     def _compute_similarity_matrix(self, fingerprints_1, fingerprints_2) -> np.ndarray:
         """Compute similarity block between two fingerprint matrices."""
+        tanimoto_similarity_matrix = _require_chemap()
+
         if self.similarity_measure == "cosine":
             if sp.issparse(fingerprints_1):
                 fingerprints_1 = fingerprints_1.toarray()

--- a/matchms/similarity/fingerprint_similarity.py
+++ b/matchms/similarity/fingerprint_similarity.py
@@ -11,7 +11,7 @@ from .vector_similarity_functions import cosine_similarity_matrix
 def _require_chemap():
     """Require chemap package and return tanimoto_similarity_matrix function."""
     try:
-        from chemap.metrics import tanimoto_similarity_matrixs
+        from chemap.metrics import tanimoto_similarity_matrix
     except ImportError as e:
         raise ImportError(
             "The 'chemap' package is required for fingerprint similarity calculations. "

--- a/matchms/similarity/fingerprint_similarity.py
+++ b/matchms/similarity/fingerprint_similarity.py
@@ -1,9 +1,6 @@
 from collections.abc import Sequence
 import numpy as np
 import scipy.sparse as sp
-from chemap.metrics import (
-    tanimoto_similarity_matrix,
-)
 from matchms.fingerprints import Fingerprints
 from matchms.scores import Scores
 from matchms.typing import SpectrumType

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ networking = [
 ]
 
 all = [
-  "matchms[fingerprints,networking]",
+  "chemap>=0.3.5",
+  "networkx>=3.4.2,<3.5",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,11 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
 ]
+
 dependencies = [
-  "chemap>=0.3.5",
   "deprecated>=1.3.1",
   "lxml>=6.0.2",
   "matplotlib>=3.10.8",
-  "networkx>=3.4.2,<3.5",
   "numba>=0.61.2",
   "numpy>=2.0.0",
   "pandas>=2.2.3",
@@ -46,6 +45,20 @@ dependencies = [
   "scipy>=1.15.3,<1.16",
   "tqdm>=4.67.1",
 ]
+
+[project.optional-dependencies]
+fingerprints = [
+  "chemap>=0.3.5",
+]
+
+networking = [
+  "networkx>=3.4.2,<3.5",
+]
+
+all = [
+  "matchms[fingerprints,networking]",
+]
+
 [project.urls]
 repository = "https://github.com/matchms/matchms"
 documentation = "https://matchms.readthedocs.io/en/latest/"

--- a/tests/networking/test_similarity_network.py
+++ b/tests/networking/test_similarity_network.py
@@ -7,6 +7,9 @@ from matchms.networking import SimilarityNetwork
 from matchms.similarity import CosineFlash
 
 
+pytest.importorskip("networkx") # skip tests if networkx is not installed
+
+
 @pytest.fixture(params=["cyjs", "gexf", "gml", "graphml", "json"])
 def graph_format(request):
     yield request.param


### PR DESCRIPTION
- `chemap` and `networkx` were made optional dependencies (networkx is actually not a big deal, but chemap has quite some additional dependencies)
- full installation would then later become `pip install matchms[all]`