### PR TITLE
Make precursor removal the default for cosine-like similarity scores

### DIFF
--- a/matchms/filtering/peak_processing/remove_peaks_relative_to_precursor_mz.py
+++ b/matchms/filtering/peak_processing/remove_peaks_relative_to_precursor_mz.py
@@ -20,7 +20,7 @@ def _remove_peaks_relative_to_precursor_mz(
         Input spectrum.
     offset_to_precursor:
         All peaks with mz values > precursor_mz + offset_to_precursor will be removed.
-        Default is -1.6 Da based Flash Entropy article by Li and Fiehn, 2023, Nat. Comm.
+        Default is -1.6 Da based Flash Entropy article by Li and Fiehn, 2023, Nature Methods.
         (see https://www.nature.com/articles/s41592-023-02012-9)
     clone:
         Optionally clone the Spectrum.

--- a/matchms/similarity/cosine.py
+++ b/matchms/similarity/cosine.py
@@ -83,6 +83,9 @@ class Cosine(BaseSimilarity):
             cosine = CosineHungarian(
                 tolerance=self.tolerance,
                 intensity_power=self.intensity_power,
+                noise_cutoff=self.noise_cutoff,
+                remove_precursor=self.remove_precursor,
+                offset_to_precursor=self.offset_to_precursor,
             )
         else:
             cosine = CosineGreedy(
@@ -130,6 +133,9 @@ class Cosine(BaseSimilarity):
             cosine = CosineHungarian(
                 tolerance=self.tolerance,
                 intensity_power=self.intensity_power,
+                noise_cutoff=self.noise_cutoff,
+                remove_precursor=self.remove_precursor,
+                offset_to_precursor=self.offset_to_precursor,
             )
             return cosine.matrix(
                 spectra_1=spectra_1,

--- a/matchms/similarity/cosine.py
+++ b/matchms/similarity/cosine.py
@@ -9,6 +9,7 @@ from .default_parameters import (
     DEFAULT_INTENSITY_POWER,
     DEFAULT_MZ_TOLERANCE,
     DEFAULT_NOISE_CUTOFF,
+    DEFAULT_OFFSET_TO_PRECURSOR,
 )
 from .flash_similarity import CosineFlash
 
@@ -44,6 +45,8 @@ class Cosine(BaseSimilarity):
             intensity_power: float = DEFAULT_INTENSITY_POWER,
             use_hungarian: bool = False,
             noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
+            remove_precursor: bool = True,
+            offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
             ):
         """Initialize cosine score class.
 
@@ -61,11 +64,17 @@ class Cosine(BaseSimilarity):
         noise_cutoff:
             Minimum relative intensity for a peak to be considered. Default is 0.01.
             Will only be used if use_hungarian is False.
+        remove_precursor:
+            Whether to remove peaks with m/z values larger than the precursor-m/z (plus offset).
+        offset_to_precursor:
+            The offset to add to the precursor-m/z when removing peaks.
         """
         self.tolerance = tolerance
         self.intensity_power = intensity_power
         self.use_hungarian = use_hungarian
         self.noise_cutoff = noise_cutoff
+        self.remove_precursor = remove_precursor
+        self.offset_to_precursor = offset_to_precursor
 
     def pair(self, spectrum_1: SpectrumType, spectrum_2: SpectrumType) -> tuple[float, int]:
         """Calculate approximate modified cosine score between two spectra."""
@@ -80,6 +89,8 @@ class Cosine(BaseSimilarity):
                 tolerance=self.tolerance,
                 intensity_power=self.intensity_power,
                 noise_cutoff=self.noise_cutoff,
+                remove_precursor=self.remove_precursor,
+                offset_to_precursor=self.offset_to_precursor,
             )
         return cosine.pair(spectrum_1, spectrum_2)
 
@@ -132,6 +143,8 @@ class Cosine(BaseSimilarity):
             tolerance=self.tolerance,
             intensity_power=self.intensity_power,
             noise_cutoff=self.noise_cutoff,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
         )
         return cosine.matrix(
             spectra_1=spectra_1,

--- a/matchms/similarity/cosine_greedy.py
+++ b/matchms/similarity/cosine_greedy.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarityWithSparse
@@ -6,8 +7,16 @@ from .default_parameters import (
     DEFAULT_MZ_POWER,
     DEFAULT_MZ_TOLERANCE,
     DEFAULT_NOISE_CUTOFF,
+    DEFAULT_OFFSET_TO_PRECURSOR,
 )
-from .spectrum_similarity_functions import collect_peak_pairs, filter_noise, score_best_matches
+from .spectrum_similarity_functions import (
+    _process_spectrum_peaks,
+    collect_peak_pairs,
+    score_best_matches,
+)
+
+
+logger = logging.getLogger("matchms")
 
 
 class CosineGreedy(BaseSimilarityWithSparse):
@@ -69,6 +78,8 @@ class CosineGreedy(BaseSimilarityWithSparse):
             mz_power: float = DEFAULT_MZ_POWER,
             intensity_power: float = DEFAULT_INTENSITY_POWER,
             noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
+            remove_precursor: bool = True,
+            offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR
             ):
         """
         Parameters
@@ -82,11 +93,17 @@ class CosineGreedy(BaseSimilarityWithSparse):
             The power to raise intensity to in the cosine function. The default is 1.
         noise_cutoff:
             Minimum relative intensity for a peak to be considered. Default is 0.01.
+        remove_precursor:
+            Whether to remove peaks with m/z values larger than the precursor-m/z (plus offset).
+        offset_to_precursor:
+            The offset to add to the precursor-m/z when removing peaks.
         """
         self.tolerance = tolerance
         self.mz_power = mz_power
         self.intensity_power = intensity_power
         self.noise_cutoff = noise_cutoff
+        self.remove_precursor = remove_precursor
+        self.offset_to_precursor = offset_to_precursor
 
     def pair(self, spectrum_1: SpectrumType, spectrum_2: SpectrumType) -> tuple[float, int]:
         """Calculate cosine score between two spectra.
@@ -116,12 +133,18 @@ class CosineGreedy(BaseSimilarityWithSparse):
             matching_pairs = matching_pairs[np.argsort(matching_pairs[:, 2], kind="mergesort")[::-1], :]
             return matching_pairs
 
-        spec1 = spectrum_1.peaks.to_numpy
-        spec2 = spectrum_2.peaks.to_numpy
-        # Filter noise from spectra by removing peaks with intensity below a certain cutoff.
-        if self.noise_cutoff and self.noise_cutoff > 0.0:
-            spec1 = np.stack(filter_noise(spec1[:, 0], spec1[:, 1], self.noise_cutoff), axis=-1)
-            spec2 = np.stack(filter_noise(spec2[:, 0], spec2[:, 1], self.noise_cutoff), axis=-1)
+        spec1 = _process_spectrum_peaks(
+            spectrum_1,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
+        spec2 = _process_spectrum_peaks(
+            spectrum_2,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
 
         matching_pairs = get_matching_pairs()
         if matching_pairs is None:

--- a/matchms/similarity/cosine_hungarian.py
+++ b/matchms/similarity/cosine_hungarian.py
@@ -7,7 +7,10 @@ from .default_parameters import (
     DEFAULT_INTENSITY_POWER,
     DEFAULT_MZ_POWER,
     DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+    DEFAULT_OFFSET_TO_PRECURSOR,
 )
+from .spectrum_similarity_functions import _process_spectrum_peaks
 
 
 class CosineHungarian(BaseSimilarityWithSparse):
@@ -31,7 +34,10 @@ class CosineHungarian(BaseSimilarityWithSparse):
     def __init__(
             self, tolerance: float = DEFAULT_MZ_TOLERANCE,
             mz_power: float = DEFAULT_MZ_POWER,
-            intensity_power: float = DEFAULT_INTENSITY_POWER
+            intensity_power: float = DEFAULT_INTENSITY_POWER,
+            noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
+            remove_precursor: bool = True,
+            offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
             ):
         """
         Parameters
@@ -43,11 +49,21 @@ class CosineHungarian(BaseSimilarityWithSparse):
             case the peak intensity products will not depend on the m/z ratios.
         intensity_power:
             The power to raise intensity to in the cosine function. The default is 1.
-
+        noise_cutoff:
+            Minimum relative intensity for a peak to be considered. Default is 0.01.
+        remove_precursor:
+            If True and ``precursor_mz`` metadata are available, remove peaks above
+            ``precursor_mz + offset_to_precursor`` before scoring.
+        offset_to_precursor:
+            Offset used when ``remove_precursor=True``. This will only keep
+            m/z values <= precursor_mz + offset_to_precursor. Default is -1.6 Da.
         """
         self.tolerance = tolerance
         self.mz_power = mz_power
         self.intensity_power = intensity_power
+        self.noise_cutoff = noise_cutoff
+        self.remove_precursor = remove_precursor
+        self.offset_to_precursor = offset_to_precursor
 
     def pair(self, spectrum_1: SpectrumType, spectrum_2: SpectrumType) -> tuple[float, int]:
         """Calculate cosine score between two spectra.
@@ -153,8 +169,18 @@ class CosineHungarian(BaseSimilarityWithSparse):
             score = score/(np.sqrt(np.sum(spec1_power**2)) * np.sqrt(np.sum(spec2_power**2)))
             return np.asarray((score, len(used_matches)), dtype=self.score_datatype)
 
-        spec1 = spectrum_1.peaks.to_numpy
-        spec2 = spectrum_2.peaks.to_numpy
+        spec1 = _process_spectrum_peaks(
+            spectrum_1,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
+        spec2 = _process_spectrum_peaks(
+            spectrum_2,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
         matching_pairs = get_matching_pairs()
         paired_peaks1, paired_peaks2, matching_pairs_matrix = get_matching_pairs_matrix()
         return calc_score()

--- a/matchms/similarity/cosine_hungarian.py
+++ b/matchms/similarity/cosine_hungarian.py
@@ -43,6 +43,7 @@ class CosineHungarian(BaseSimilarityWithSparse):
             case the peak intensity products will not depend on the m/z ratios.
         intensity_power:
             The power to raise intensity to in the cosine function. The default is 1.
+
         """
         self.tolerance = tolerance
         self.mz_power = mz_power

--- a/matchms/similarity/cosine_linear.py
+++ b/matchms/similarity/cosine_linear.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 import numpy as np
 from tqdm import tqdm  # type: ignore[import-untyped]
 from matchms.scores import Scores
+from matchms.similarity.spectrum_similarity_functions import _process_spectrum_peaks
 from matchms.typing import SpectrumType
 from .base_similarity import BaseSimilarity
 from .cosine_linear_functions import linear_cosine_score, sirius_merge_close_peaks
@@ -9,6 +10,8 @@ from .default_parameters import (
     DEFAULT_INTENSITY_POWER,
     DEFAULT_MZ_POWER,
     DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+    DEFAULT_OFFSET_TO_PRECURSOR,
 )
 
 
@@ -55,7 +58,10 @@ class CosineLinear(BaseSimilarity):
             self,
             tolerance: float = DEFAULT_MZ_TOLERANCE,
             mz_power: float = DEFAULT_MZ_POWER,
-            intensity_power: float = DEFAULT_INTENSITY_POWER
+            intensity_power: float = DEFAULT_INTENSITY_POWER,
+            noise_cutoff: float | None = DEFAULT_NOISE_CUTOFF,
+            remove_precursor: bool = False,
+            offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR
             ):
         """
         Parameters
@@ -68,19 +74,38 @@ class CosineLinear(BaseSimilarity):
             case the peak intensity products will not depend on the m/z ratios.
         intensity_power:
             The power to raise intensity to in the cosine function. The default is 1.
+        noise_cutoff:
+            Minimum relative intensity for a peak to be considered. Default is 0.01.
+        remove_precursor:
+            Whether to remove peaks with m/z values larger than the precursor-m/z (plus offset).
+        offset_to_precursor:
+            The offset to add to the precursor-m/z when removing peaks.
         """
         self.tolerance = tolerance
         self.mz_power = mz_power
         self.intensity_power = intensity_power
+        self.noise_cutoff = noise_cutoff
+        self.remove_precursor = remove_precursor
+        self.offset_to_precursor = offset_to_precursor
 
-    def pair(self, reference: SpectrumType, query: SpectrumType) -> tuple[float, int]:
+    def _prepare_spectrum(self, spectrum: SpectrumType) -> np.ndarray:
+        """Preprocess and merge one spectrum for linear cosine scoring."""
+        peaks = _process_spectrum_peaks(
+            spectrum,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
+        return sirius_merge_close_peaks(peaks, self.tolerance)
+
+    def pair(self, spectrum_1: SpectrumType, spectrum_2: SpectrumType) -> tuple[float, int]:
         """Calculate linear cosine score between two spectra.
 
         Parameters
         ----------
-        reference
+        spectrum_1
             Single reference spectrum.
-        query
+        spectrum_2
             Single query spectrum.
 
         Returns
@@ -88,10 +113,9 @@ class CosineLinear(BaseSimilarity):
         Score
             Tuple with cosine score and number of matched peaks.
         """
-        spec1 = reference.peaks.to_numpy
-        spec2 = query.peaks.to_numpy
-        spec1 = sirius_merge_close_peaks(spec1, self.tolerance)
-        spec2 = sirius_merge_close_peaks(spec2, self.tolerance)
+        spec1 = self._prepare_spectrum(spectrum_1)
+        spec2 = self._prepare_spectrum(spectrum_2)
+
         score, matches = linear_cosine_score(
             spec1,
             spec2,
@@ -108,10 +132,23 @@ class CosineLinear(BaseSimilarity):
         score_fields: Sequence[str] | None = None,
         progress_bar: bool = True,
     ):
-        """Optimized matrix computation that precomputes merged spectra.
+        """Calculate a matrix of linear cosine scores.
 
-        Each spectrum is merged once (N+M calls to sirius_merge_close_peaks)
-        instead of 2*N*M times in the naive double-loop approach.
+        Spectra are preprocessed and merged once before pairwise scoring. This
+        avoids repeating precursor removal, noise filtering, and peak merging for
+        every spectrum pair.
+    
+        Parameters
+        ----------
+        spectra_1
+            First collection of spectra.
+        spectra_2
+            Second collection of spectra. If None, compare ``spectra_1`` against
+            itself.
+        score_fields
+            Score fields to return.
+        progress_bar
+            If True, display a progress bar.
         """
         spectra_2, is_symmetric = self._prepare_inputs(spectra_1, spectra_2)
         selected_fields = self._resolve_score_fields(score_fields)
@@ -120,12 +157,15 @@ class CosineLinear(BaseSimilarity):
         n_cols = len(spectra_2)
         result = self._create_dense_result(n_rows, n_cols, selected_fields)
 
-        merged_refs = [sirius_merge_close_peaks(r.peaks.to_numpy, self.tolerance) for r in spectra_1]
+        merged_refs = [
+            self._prepare_spectrum(spectrum)
+            for spectrum in spectra_1
+        ]
         if is_symmetric:
             merged_queries = merged_refs
         else:
             merged_queries = [
-                sirius_merge_close_peaks(spectrum.peaks.to_numpy, self.tolerance)
+                self._prepare_spectrum(spectrum)
                 for spectrum in spectra_2
             ]
 

--- a/matchms/similarity/entropy.py
+++ b/matchms/similarity/entropy.py
@@ -63,7 +63,7 @@ class Entropy(BaseSimilarity):
         self,
         tolerance: float = DEFAULT_MZ_TOLERANCE,
         use_ppm: bool = False,
-        remove_precursor: bool = False,
+        remove_precursor: bool = True,
         offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
         noise_cutoff: float | None = DEFAULT_NOISE_CUTOFF,
         merge_within: float = 0.0,

--- a/matchms/similarity/entropy_greedy.py
+++ b/matchms/similarity/entropy_greedy.py
@@ -123,7 +123,7 @@ class EntropyGreedy(BaseSimilarityWithSparse):
         self,
         tolerance: float = DEFAULT_MZ_TOLERANCE,
         use_ppm: bool = False,
-        remove_precursor: bool = False,
+        remove_precursor: bool = True,
         offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
         noise_cutoff: float | None = DEFAULT_NOISE_CUTOFF,
         merge_within: float = 0.0,

--- a/matchms/similarity/flash_similarity.py
+++ b/matchms/similarity/flash_similarity.py
@@ -32,7 +32,7 @@ class _BaseFlashSimilarity(BaseSimilarity):
         tolerance: float = DEFAULT_MZ_TOLERANCE,
         use_ppm: bool = False,
         intensity_power: float = DEFAULT_INTENSITY_POWER,
-        remove_precursor: bool = False,
+        remove_precursor: bool = True,
         offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
         noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
         normalize_to_half: bool = False,
@@ -244,7 +244,7 @@ class FlashEntropy(_BaseFlashSimilarity):
         If True, interpret `tolerance` as parts-per-million. Default is False.
     remove_precursor:
         If True, remove precursor peak and peaks within offset_to_precursor.
-        Default is False.
+        Default is True.
     offset_to_precursor:
         Offset used when ``remove_precursor=True``. This will only keep 
         mz values <= precursor_mz + offset_to_precursor. Default is -1.6 Da.
@@ -423,7 +423,7 @@ class CosineFlash(_BaseFlashSimilarity):
         The power to raise intensity to in the cosine function. The default is 1 (no weighting).
     remove_precursor:
         If True, remove precursor peak and peaks within offset_to_precursor.
-        Default is False.
+        Default is True.
     offset_to_precursor:
         If remove_precursor is True, remove peaks within this window around the precursor
         m/z. Default is 1.6 Da (as suggested by Li & Fiehn(2023)).

--- a/matchms/similarity/flash_utils.py
+++ b/matchms/similarity/flash_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .spectrum_similarity_functions import filter_noise
+from .spectrum_similarity_functions import filter_noise, filter_peaks_above_precursor
 
 
 # ===================== library index =====================
@@ -293,8 +293,12 @@ def _clean_and_weight(
 
     # (optional) remove precursor and nearby peaks
     if remove_precursor and (precursor_mz is not None):
-        mask = mz <= (precursor_mz + offset_to_precursor)
-        mz, intensities = mz[mask], intensities[mask]
+        mz, intensities = filter_peaks_above_precursor(
+            mz,
+            intensities,
+            precursor_mz,
+            offset_to_precursor,
+        )
         if mz.size == 0:
             return np.empty((0, 2), dtype=dtype)
 

--- a/matchms/similarity/modified_cosine.py
+++ b/matchms/similarity/modified_cosine.py
@@ -88,6 +88,9 @@ class ModifiedCosine(BaseSimilarity):
             modcos = ModifiedCosineHungarian(
                 tolerance=self.tolerance,
                 intensity_power=self.intensity_power,
+                noise_cutoff=self.noise_cutoff,
+                remove_precursor=self.remove_precursor,
+                offset_to_precursor=self.offset_to_precursor,
             )
         else:
             modcos = ModifiedCosineGreedy(
@@ -135,6 +138,9 @@ class ModifiedCosine(BaseSimilarity):
             modcos = ModifiedCosineHungarian(
                 tolerance=self.tolerance,
                 intensity_power=self.intensity_power,
+                noise_cutoff=self.noise_cutoff,
+                remove_precursor=self.remove_precursor,
+                offset_to_precursor=self.offset_to_precursor,
             )
 
             return modcos.matrix(

--- a/matchms/similarity/modified_cosine.py
+++ b/matchms/similarity/modified_cosine.py
@@ -7,6 +7,7 @@ from .default_parameters import (
     DEFAULT_INTENSITY_POWER,
     DEFAULT_MZ_TOLERANCE,
     DEFAULT_NOISE_CUTOFF,
+    DEFAULT_OFFSET_TO_PRECURSOR,
 )
 from .flash_similarity import CosineFlash
 from .modified_cosine_greedy import ModifiedCosineGreedy
@@ -49,6 +50,8 @@ class ModifiedCosine(BaseSimilarity):
             intensity_power: float = DEFAULT_INTENSITY_POWER,
             use_hungarian: bool = False,
             noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
+            remove_precursor: bool = True,
+            offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
             ):
         """Initialize the modified cosine score class.
 
@@ -66,11 +69,17 @@ class ModifiedCosine(BaseSimilarity):
         noise_cutoff:
             Minimum relative intensity for a peak to be considered. Default is 0.01.
             Will only be used if use_hungarian is False.
+        remove_precursor:
+            Whether to remove peaks with m/z values larger than the precursor-m/z (plus offset).
+        offset_to_precursor:
+            The offset to add to the precursor-m/z when removing peaks.
         """
         self.tolerance = tolerance
         self.intensity_power = intensity_power
         self.use_hungarian = use_hungarian
         self.noise_cutoff = noise_cutoff
+        self.remove_precursor = remove_precursor
+        self.offset_to_precursor = offset_to_precursor
 
     def pair(self, spectrum_1: SpectrumType, spectrum_2: SpectrumType) -> tuple[float, int]:
         """Calculate approximate modified cosine score between two spectra."""
@@ -85,6 +94,8 @@ class ModifiedCosine(BaseSimilarity):
                 tolerance=self.tolerance,
                 intensity_power=self.intensity_power,
                 noise_cutoff=self.noise_cutoff,
+                remove_precursor=self.remove_precursor,
+                offset_to_precursor=self.offset_to_precursor,
             )
         return modcos.pair(spectrum_1, spectrum_2)
 
@@ -137,6 +148,8 @@ class ModifiedCosine(BaseSimilarity):
             tolerance=self.tolerance,
             intensity_power=self.intensity_power,
             noise_cutoff=self.noise_cutoff,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
         )
 
         return modcos.matrix(

--- a/matchms/similarity/modified_cosine_greedy.py
+++ b/matchms/similarity/modified_cosine_greedy.py
@@ -8,8 +8,9 @@ from .default_parameters import (
     DEFAULT_INTENSITY_POWER,
     DEFAULT_MZ_TOLERANCE,
     DEFAULT_NOISE_CUTOFF,
+    DEFAULT_OFFSET_TO_PRECURSOR,
 )
-from .spectrum_similarity_functions import collect_peak_pairs, filter_noise, score_best_matches
+from .spectrum_similarity_functions import _preprocess_peak_array, collect_peak_pairs, score_best_matches
 
 
 logger = logging.getLogger("matchms")
@@ -47,6 +48,8 @@ class ModifiedCosineGreedy(BaseSimilarityWithSparse):
             mz_power: float = 0.0,
             intensity_power: float = DEFAULT_INTENSITY_POWER,
             noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
+            remove_precursor: bool = True,
+            offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR
             ):
         """Initialize approximate modified cosine.
 
@@ -61,18 +64,24 @@ class ModifiedCosineGreedy(BaseSimilarityWithSparse):
             The power to raise intensity to in the cosine function. The default is 1.
         noise_cutoff:
             Minimum relative intensity for a peak to be considered. Default is 0.01.
+        remove_precursor:
+            Whether to remove peaks with m/z values larger than the precursor-m/z (plus offset).
+        offset_to_precursor:
+            The offset to add to the precursor-m/z when removing peaks.
         """
         self.tolerance = tolerance
         self.mz_power = mz_power
         self.intensity_power = intensity_power
         self.noise_cutoff = noise_cutoff
+        self.remove_precursor = remove_precursor
+        self.offset_to_precursor = offset_to_precursor
 
     def pair(self, spectrum_1: SpectrumType, spectrum_2: SpectrumType) -> tuple[float, int]:
         """Calculate approximate modified cosine score between two spectra."""
 
-        precursor_mz_ref = get_valid_precursor_mz(spectrum_1, logger)
-        precursor_mz_query = get_valid_precursor_mz(spectrum_2, logger)
-        mass_shift = precursor_mz_ref - precursor_mz_query
+        precursor_mz_1 = get_valid_precursor_mz(spectrum_1, logger)
+        precursor_mz_2 = get_valid_precursor_mz(spectrum_2, logger)
+        mass_shift = precursor_mz_1 - precursor_mz_2
 
         if abs(mass_shift) <= self.tolerance:
             return CosineGreedy(
@@ -101,12 +110,20 @@ class ModifiedCosineGreedy(BaseSimilarityWithSparse):
                 matching_pairs = matching_pairs[np.argsort(matching_pairs[:, 2], kind="mergesort")[::-1], :]
             return matching_pairs
 
-        spec1 = spectrum_1.peaks.to_numpy
-        spec2 = spectrum_2.peaks.to_numpy
-        # Filter noise from spectra by removing peaks with intensity below a certain cutoff.
-        if self.noise_cutoff and self.noise_cutoff > 0.0:
-            spec1 = np.stack(filter_noise(spec1[:, 0], spec1[:, 1], self.noise_cutoff), axis=-1)
-            spec2 = np.stack(filter_noise(spec2[:, 0], spec2[:, 1], self.noise_cutoff), axis=-1)
+        spec1 = _preprocess_peak_array(
+            spectrum_1.peaks.to_numpy,
+            precursor_mz=precursor_mz_1,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
+        spec2 = _preprocess_peak_array(
+            spectrum_2.peaks.to_numpy,
+            precursor_mz=precursor_mz_2,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
 
         matching_pairs = get_matching_pairs()
         if matching_pairs.shape[0] == 0:

--- a/matchms/similarity/modified_cosine_greedy.py
+++ b/matchms/similarity/modified_cosine_greedy.py
@@ -88,6 +88,9 @@ class ModifiedCosineGreedy(BaseSimilarityWithSparse):
                 tolerance=self.tolerance,
                 mz_power=self.mz_power,
                 intensity_power=self.intensity_power,
+                noise_cutoff=self.noise_cutoff,
+                remove_precursor=self.remove_precursor,
+                offset_to_precursor=self.offset_to_precursor
             ).pair(spectrum_1, spectrum_2)
 
         def get_matching_pairs():

--- a/matchms/similarity/modified_cosine_hungarian.py
+++ b/matchms/similarity/modified_cosine_hungarian.py
@@ -1,7 +1,7 @@
 import logging
 import numpy as np
 from scipy.optimize import linear_sum_assignment
-from matchms.similarity.spectrum_similarity_functions import collect_peak_pairs
+from matchms.similarity.spectrum_similarity_functions import _process_spectrum_peaks, collect_peak_pairs
 from matchms.typing import SpectrumType
 from ._precursor_validation import get_valid_precursor_mz
 from .base_similarity import BaseSimilarityWithSparse
@@ -10,6 +10,8 @@ from .default_parameters import (
     DEFAULT_INTENSITY_POWER,
     DEFAULT_MZ_POWER,
     DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+    DEFAULT_OFFSET_TO_PRECURSOR,
 )
 
 
@@ -40,7 +42,10 @@ class ModifiedCosineHungarian(BaseSimilarityWithSparse):
             self,
             tolerance: float = DEFAULT_MZ_TOLERANCE,
             mz_power: float = DEFAULT_MZ_POWER,
-            intensity_power: float = DEFAULT_INTENSITY_POWER
+            intensity_power: float = DEFAULT_INTENSITY_POWER,
+            noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
+            remove_precursor: bool = True,
+            offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
             ):
         """Initialize exact modified cosine.
 
@@ -53,10 +58,21 @@ class ModifiedCosineHungarian(BaseSimilarityWithSparse):
             case the peak intensity products will not depend on the m/z ratios.
         intensity_power:
             The power to raise intensity to in the cosine function. The default is 1.
+        noise_cutoff:
+            Minimum relative intensity for a peak to be considered. Default is 0.01.
+        remove_precursor:
+            If True and ``precursor_mz`` metadata are available, remove peaks above
+            ``precursor_mz + offset_to_precursor`` before scoring.
+        offset_to_precursor:
+            Offset used when ``remove_precursor=True``. This will only keep
+            m/z values <= precursor_mz + offset_to_precursor. Default is -1.6 Da.
         """
         self.tolerance = tolerance
         self.mz_power = mz_power
         self.intensity_power = intensity_power
+        self.noise_cutoff = noise_cutoff
+        self.remove_precursor = remove_precursor
+        self.offset_to_precursor = offset_to_precursor
 
     def pair(self, spectrum_1: SpectrumType, spectrum_2: SpectrumType) -> tuple[float, int]:
         """Calculate exact modified cosine score between two spectra."""
@@ -70,6 +86,8 @@ class ModifiedCosineHungarian(BaseSimilarityWithSparse):
                 tolerance=self.tolerance,
                 mz_power=self.mz_power,
                 intensity_power=self.intensity_power,
+                remove_precursor=self.remove_precursor,
+                offset_to_precursor=self.offset_to_precursor
             ).pair(spectrum_1, spectrum_2)
 
         def get_matching_pairs():
@@ -142,8 +160,18 @@ class ModifiedCosineHungarian(BaseSimilarityWithSparse):
                     used_matches.append((i, j))
             return score, used_matches
 
-        spec1 = spectrum_1.peaks.to_numpy
-        spec2 = spectrum_2.peaks.to_numpy
+        spec1 = _process_spectrum_peaks(
+            spectrum_1,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
+        spec2 = _process_spectrum_peaks(
+            spectrum_2,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
         matching_pairs = get_matching_pairs()
 
         paired_peaks1, paired_peaks2, weights = build_weight_matrix(matching_pairs)

--- a/matchms/similarity/modified_cosine_hungarian.py
+++ b/matchms/similarity/modified_cosine_hungarian.py
@@ -86,6 +86,7 @@ class ModifiedCosineHungarian(BaseSimilarityWithSparse):
                 tolerance=self.tolerance,
                 mz_power=self.mz_power,
                 intensity_power=self.intensity_power,
+                noise_cutoff=self.noise_cutoff,
                 remove_precursor=self.remove_precursor,
                 offset_to_precursor=self.offset_to_precursor
             ).pair(spectrum_1, spectrum_2)

--- a/matchms/similarity/neutral_losses_cosine.py
+++ b/matchms/similarity/neutral_losses_cosine.py
@@ -7,8 +7,10 @@ from .default_parameters import (
     DEFAULT_INTENSITY_POWER,
     DEFAULT_MZ_POWER,
     DEFAULT_MZ_TOLERANCE,
+    DEFAULT_NOISE_CUTOFF,
+    DEFAULT_OFFSET_TO_PRECURSOR,
 )
-from .spectrum_similarity_functions import collect_peak_pairs, score_best_matches
+from .spectrum_similarity_functions import _preprocess_peak_array, collect_peak_pairs, score_best_matches
 
 
 logger = logging.getLogger("matchms")
@@ -36,7 +38,9 @@ class NeutralLossesCosine(BaseSimilarityWithSparse):
             tolerance: float = DEFAULT_MZ_TOLERANCE,
             mz_power: float = DEFAULT_MZ_POWER,
             intensity_power: float = DEFAULT_INTENSITY_POWER,
-            ignore_peaks_above_precursor: bool = True
+            noise_cutoff: float = DEFAULT_NOISE_CUTOFF,
+            remove_precursor: bool = True,
+            offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
             ):
         """
         Parameters
@@ -48,15 +52,21 @@ class NeutralLossesCosine(BaseSimilarityWithSparse):
             case the peak intensity products will not depend on the m/z ratios.
         intensity_power:
             The power to raise intensity to in the cosine function. The default is 1.
-        ignore_peaks_above_precursor:
-            By default this is set to True, meaning that peaks with m/z values larger
-            than the precursor-m/z will be ignored (since those would correspond to negative
-            "neutral losses").
+        noise_cutoff:
+            Minimum relative intensity for a peak to be considered. Default is 0.01.
+        remove_precursor:
+            If True and ``precursor_mz`` metadata are available, remove peaks above
+            ``precursor_mz + offset_to_precursor`` before scoring.
+        offset_to_precursor:
+            Offset used when ``remove_precursor=True``. This will only keep
+            m/z values <= precursor_mz + offset_to_precursor. Default is -1.6 Da.
         """
         self.tolerance = tolerance
         self.mz_power = mz_power
         self.intensity_power = intensity_power
-        self.ignore_peaks_above_precursor = ignore_peaks_above_precursor
+        self.noise_cutoff = noise_cutoff
+        self.remove_precursor = remove_precursor
+        self.offset_to_precursor = offset_to_precursor
 
     def _get_matching_pairs(self, spec1, spec2, mass_shift: float) -> np.ndarray:
         """Find all pairs of peaks that match within the given tolerance."""
@@ -87,16 +97,24 @@ class NeutralLossesCosine(BaseSimilarityWithSparse):
         Tuple with cosine score and number of matched peaks.
         """
 
-        precursor_mz_ref = get_valid_precursor_mz(spectrum_1, logger)
-        precursor_mz_query = get_valid_precursor_mz(spectrum_2, logger)
-        mass_shift = precursor_mz_ref - precursor_mz_query
+        precursor_mz_1 = get_valid_precursor_mz(spectrum_1, logger)
+        precursor_mz_2 = get_valid_precursor_mz(spectrum_2, logger)
+        mass_shift = precursor_mz_1 - precursor_mz_2
 
-        spec1 = spectrum_1.peaks.to_numpy
-        spec2 = spectrum_2.peaks.to_numpy
-        
-        if self.ignore_peaks_above_precursor:
-            spec1 = spec1[np.where(spec1[:, 0] < precursor_mz_ref)]
-            spec2 = spec2[np.where(spec2[:, 0] < precursor_mz_query)]
+        spec1 = _preprocess_peak_array(
+            spectrum_1.peaks.to_numpy,
+            precursor_mz=precursor_mz_1,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
+        spec2 = _preprocess_peak_array(
+            spectrum_2.peaks.to_numpy,
+            precursor_mz=precursor_mz_2,
+            remove_precursor=self.remove_precursor,
+            offset_to_precursor=self.offset_to_precursor,
+            noise_cutoff=self.noise_cutoff,
+        )
 
         matching_pairs = self._get_matching_pairs(spec1, spec2, mass_shift)
         if matching_pairs is None:

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -214,6 +214,9 @@ def filter_noise(
     noise_cutoff:
         Peaks with intensity below this cutoff (relative to the maximum intensity) will be removed.
     """
+    if intensities.size == 0:
+        return mz, intensities
+
     thr = intensities.max() * noise_cutoff
     mask = intensities >= thr
     return mz[mask], intensities[mask]

--- a/matchms/similarity/spectrum_similarity_functions.py
+++ b/matchms/similarity/spectrum_similarity_functions.py
@@ -1,6 +1,12 @@
+import logging
 import numpy as np
 from numba import njit
 from numba.typed import List
+from matchms.similarity._precursor_validation import get_valid_precursor_mz
+from .default_parameters import DEFAULT_OFFSET_TO_PRECURSOR
+
+
+logger = logging.getLogger("matchms")
 
 
 @njit
@@ -211,3 +217,88 @@ def filter_noise(
     thr = intensities.max() * noise_cutoff
     mask = intensities >= thr
     return mz[mask], intensities[mask]
+
+
+def filter_peaks_above_precursor(
+    mz: np.ndarray,
+    intensities: np.ndarray,
+    precursor_mz: float | None,
+    offset_to_precursor: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Remove peaks above precursor_mz + offset_to_precursor.
+
+    All peaks with mz values > precursor_mz + offset_to_precursor will be removed.
+    A frequently used value is -1.6 Da based Flash Entropy article by Li and Fiehn, 2023, Nature Methods.
+    (see https://www.nature.com/articles/s41592-023-02012-9)
+
+    If precursor_mz is None, return the input arrays unchanged.
+
+    Parameters
+    ----------
+    mz:
+        Array of m/z values. Must be the same length as intensities.
+    intensities:
+        Array of intensity values. Must be the same length as mz.
+    precursor_mz:
+        Precursor m/z value. If None, no peaks will be removed.
+    offset_to_precursor:
+        All peaks with mz values > precursor_mz + offset_to_precursor will be removed.
+    """
+    if precursor_mz is None:
+        return mz, intensities
+
+    mask = mz <= precursor_mz + offset_to_precursor
+    return mz[mask], intensities[mask]
+
+
+def _preprocess_peak_array(
+    peaks: np.ndarray,
+    *,
+    precursor_mz: float | None = None,
+    remove_precursor: bool = False,
+    offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
+    noise_cutoff: float | None = None,
+) -> np.ndarray:
+    """Return a non-mutating preprocessed peak array for similarity scoring."""
+    mz = peaks[:, 0]
+    intensities = peaks[:, 1]
+
+    if remove_precursor:
+        if precursor_mz is None:
+            raise ValueError("Cannot remove precursor peaks when precursor_mz is None.")
+        mz, intensities = filter_peaks_above_precursor(
+            mz,
+            intensities,
+            precursor_mz,
+            offset_to_precursor,
+        )
+
+    if noise_cutoff and noise_cutoff > 0:
+        mz, intensities = filter_noise(mz, intensities, noise_cutoff)
+
+    return np.column_stack((mz, intensities))
+
+
+def _process_spectrum_peaks(
+    spectrum,
+    *,
+    remove_precursor: bool = False,
+    offset_to_precursor: float = DEFAULT_OFFSET_TO_PRECURSOR,
+    noise_cutoff: float | None = None,
+) -> np.ndarray:
+    """Return a non-mutating preprocessed peak array for similarity scoring.
+    
+    This is a convenience wrapper around `_preprocess_peak_array` that extracts the
+    precursor m/z from the spectrum metadata.
+    """
+    if remove_precursor:
+        precursor_mz = get_valid_precursor_mz(spectrum, logger)
+    else:
+        precursor_mz = None
+    return _preprocess_peak_array(
+        spectrum.peaks.to_numpy,
+        precursor_mz=precursor_mz,
+        remove_precursor=remove_precursor,
+        offset_to_precursor=offset_to_precursor,
+        noise_cutoff=noise_cutoff,
+    )

--- a/tests/networking/test_networking_functions.py
+++ b/tests/networking/test_networking_functions.py
@@ -16,13 +16,13 @@ def create_dummy_spectra():
                                   intensities=np.array([0.7, 0.1 * i]),
                                   metadata={"spectrum_id": "ref_spec_"+str(i),
                                             "smiles": "C1=CC=C2C(=C1)NC(=N2)C3=CC=CO3",
-                                            "precursor_mz": 100+50*i}))
+                                            "precursor_mz": 210+50*i}))
     for i in range(3):
         spectra.append(Spectrum(mz=np.array([100 + i, 210.]),
                                   intensities=np.array([0.5, 0.1 * i]),
                                   metadata={"spectrum_id": "query_spec_"+str(i),
                                             "smiles": "CC1=C(C=C(C=C1)NC(=O)N(C)C)Cl",
-                                            "precursor_mz": 110+50*i}))
+                                            "precursor_mz": 220+50*i}))
     return spectra
 
 

--- a/tests/networking/test_similarity_network.py
+++ b/tests/networking/test_similarity_network.py
@@ -28,13 +28,13 @@ def create_dummy_spectra():
                                   intensities=np.array([0.2 * i, 0.1 * i, 1.0]),
                                   metadata={"spectrum_id": "ref_spec_"+str(i),
                                             "smiles": "C1=CC=C2C(=C1)NC(=N2)C3=CC=CO3",
-                                            "precursor_mz": 100+20*i}))
+                                            "precursor_mz": 230+20*i}))
     for i in range(3):
         spectra.append(Spectrum(mz=np.array([100., 200.01]),
                                   intensities=np.array([0.5, 0.1 * i]),
                                   metadata={"spectrum_id": "query_spec_"+str(i),
                                             "smiles": "CC1=C(C=C(C=C1)NC(=O)N(C)C)Cl",
-                                            "precursor_mz": 120+20*i}))
+                                            "precursor_mz": 250+20*i}))
     return spectra
 
 

--- a/tests/similarity/test_blink_cosine.py
+++ b/tests/similarity/test_blink_cosine.py
@@ -264,7 +264,7 @@ def test_blinkcosine_upper_bound_cosinegreedy():
     ).build()
 
     tolerance = 5.0
-    cg = CosineGreedy(tolerance=tolerance)
+    cg = CosineGreedy(tolerance=tolerance, remove_precursor=False)
     bc = CosineBlink(tolerance=tolerance, bin_width=1.0, prefilter=False)
 
     score_cg = cg.pair(spectrum_1, spectrum_2)["score"]

--- a/tests/similarity/test_cosine_greedy.py
+++ b/tests/similarity/test_cosine_greedy.py
@@ -49,7 +49,12 @@ def test_cosine_greedy_pair(peaks, tolerance, mz_power, intensity_power, expecte
     spectrum_1 = builder.with_mz(peaks[0][0]).with_intensities(peaks[0][1]).build()
     spectrum_2 = builder.with_mz(peaks[1][0]).with_intensities(peaks[1][1]).build()
 
-    cosine_greedy = CosineGreedy(tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power)
+    cosine_greedy = CosineGreedy(
+        tolerance=tolerance,
+        mz_power=mz_power,
+        intensity_power=intensity_power,
+        remove_precursor=False,  # default is true, but we don't have precursor mz in these tests
+    )
     score = cosine_greedy.pair(spectrum_1, spectrum_2)
 
     expected_score = compute_expected_score(mz_power, intensity_power, spectrum_1, spectrum_2, expected_matches)
@@ -68,7 +73,7 @@ def test_cosine_greedy_matrix(symmetric):
         np.array([0.5, 0.2, 1.0], dtype="float")).build()
 
     spectra = [spectrum_1, spectrum_2]
-    cosine_greedy = CosineGreedy()
+    cosine_greedy = CosineGreedy(remove_precursor=False)
     if symmetric:
         scores = cosine_greedy.matrix(spectra)
     else:
@@ -90,5 +95,5 @@ def test_cosine_greedy_matrix_none_matching():
     spectrum_2 = builder.with_mz(np.array([50, 60, 70], dtype="float")).with_intensities(
         np.array([0.5, 0.2, 1.0], dtype="float")).build()
     
-    scores = CosineGreedy().matrix([spectrum_1], [spectrum_2])
+    scores = CosineGreedy(remove_precursor=False).matrix([spectrum_1], [spectrum_2])
     assert scores["score"][0][0] == 0.0, "Expected a single score of exactly 0.0."

--- a/tests/similarity/test_cosine_hungarian.py
+++ b/tests/similarity/test_cosine_hungarian.py
@@ -10,13 +10,19 @@ def test_cosine_hungarian_cocaine_glucose():
     glucose_spectrum = glucose()
     cocaine_spectrum = cocaine()
 
-    cosine_hungarian = CosineHungarian(tolerance=0.1, mz_power=1.0, intensity_power=1.0)
+    cosine_hungarian = CosineHungarian(
+        tolerance=0.1, mz_power=1.0, intensity_power=1.0,
+        remove_precursor=False, noise_cutoff=None,  # Do not remove precursor peaks for this test
+        )
 
     (similarity, shared_peaks) = cosine_hungarian.pair(glucose_spectrum, cocaine_spectrum)[()]
     assert similarity == 0.0
     assert shared_peaks == 0
 
-    cosine_hungarian = CosineHungarian(tolerance=5.0, mz_power=0.0, intensity_power=1.0)
+    cosine_hungarian = CosineHungarian(
+        tolerance=5.0, mz_power=0.0, intensity_power=1.0,
+        remove_precursor=False, noise_cutoff=None,  # Do not remove precursor peaks for this test
+        )
 
     (similarity, shared_peaks) = cosine_hungarian.pair(glucose_spectrum, cocaine_spectrum)[()]
     assert similarity == 0.453757948440651, f"Expected different cosine score: {similarity}"
@@ -27,13 +33,19 @@ def test_cosine_hungarian_phenylalanine_hydroxy_cholesterol():
     phenylalanine_spectrum = phenylalanine()
     hydroxy_cholesterol_spectrum = hydroxy_cholesterol()
 
-    cosine_hungarian = CosineHungarian(tolerance=0.1, mz_power=1.0, intensity_power=1.0)
+    cosine_hungarian = CosineHungarian(
+        tolerance=0.1, mz_power=1.0, intensity_power=1.0,
+        remove_precursor=False, noise_cutoff=None,  # Do not remove precursor peaks for this test
+        )
 
     (similarity, shared_peaks) = cosine_hungarian.pair(phenylalanine_spectrum, hydroxy_cholesterol_spectrum)[()]
     assert similarity < 0.0001
     assert shared_peaks == 3
 
-    cosine_hungarian = CosineHungarian(tolerance=5.0, mz_power=0.0, intensity_power=1.0)
+    cosine_hungarian = CosineHungarian(
+        tolerance=5.0, mz_power=0.0, intensity_power=1.0,
+        remove_precursor=False, noise_cutoff=None,  # Do not remove precursor peaks for this test
+        )
 
     (similarity, shared_peaks) = cosine_hungarian.pair(phenylalanine_spectrum, hydroxy_cholesterol_spectrum)[()]
     assert similarity < 0.01, f"Expected different cosine score: {similarity}"
@@ -51,7 +63,7 @@ def test_cosine_hungarian_without_parameters():
         mz=np.array([100, 200, 290, 490, 510], dtype="float"),
         intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"),
     )
-    cosine_hungarian = CosineHungarian()
+    cosine_hungarian = CosineHungarian(remove_precursor=False, noise_cutoff=None)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     # Derive expected cosine score
@@ -88,7 +100,7 @@ def test_cosine_hungarian_matrix_without_parameters():
         mz=np.array([100, 200, 290, 490, 510], dtype="float"),
         intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"),
     )
-    cosine_hungarian = CosineHungarian()
+    cosine_hungarian = CosineHungarian(remove_precursor=False, noise_cutoff=None)
     scores = cosine_hungarian.matrix([spectrum_1, spectrum_2], [spectrum_1, spectrum_2])
 
     assert (
@@ -116,7 +128,7 @@ def test_cosine_hungarian_with_tolerance_0_2():
         mz=np.array([100, 300, 301, 511], dtype="float"),
         intensities=np.array([0.1, 1.0, 0.3, 0.4], dtype="float"),
     )
-    cosine_hungarian = CosineHungarian(tolerance=0.2)
+    cosine_hungarian = CosineHungarian(tolerance=0.2, remove_precursor=False, noise_cutoff=None)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     # Derive expected cosine score
@@ -152,7 +164,7 @@ def test_cosine_hungarian_with_tolerance_2_0():
         mz=np.array([100, 300, 301, 511], dtype="float"),
         intensities=np.array([0.1, 1.0, 0.3, 0.4], dtype="float"),
     )
-    cosine_hungarian = CosineHungarian(tolerance=2.0)
+    cosine_hungarian = CosineHungarian(tolerance=2.0, remove_precursor=False, noise_cutoff=None)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     # Derive expected cosine score
@@ -191,7 +203,7 @@ def test_cosine_hungarian_order_of_arguments():
         metadata={},
     )
 
-    cosine_hungarian = CosineHungarian(tolerance=2.0)
+    cosine_hungarian = CosineHungarian(tolerance=2.0, remove_precursor=False, noise_cutoff=None)
     score_1_2 = cosine_hungarian.pair(spectrum_1, spectrum_2)
     score_2_1 = cosine_hungarian.pair(spectrum_2, spectrum_1)
 
@@ -217,7 +229,7 @@ def test_cosine_hungarian_case_where_greedy_would_fail():
         metadata={},
     )
 
-    cosine_hungarian = CosineHungarian(tolerance=0.01)
+    cosine_hungarian = CosineHungarian(tolerance=0.01, remove_precursor=False, noise_cutoff=None)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
     assert score["score"] == pytest.approx(
         0.994475, 0.0001
@@ -239,7 +251,7 @@ def test_cosine_hungarian_case_without_matches():
         metadata={},
     )
 
-    cosine_hungarian = CosineHungarian()
+    cosine_hungarian = CosineHungarian(remove_precursor=False, noise_cutoff=None)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
     assert score["score"] == 0.0, "Expected different cosine score."
     assert score["matches"] == 0, "Expected different number of matching peaks."
@@ -261,7 +273,8 @@ def test_cosine_hungarian_with_peak_powers():
         intensities=np.array([0.1, 0.2, 1.0, 0.3, 0.4], dtype="float"),
     )
     cosine_hungarian = CosineHungarian(
-        tolerance=1.0, mz_power=mz_power, intensity_power=intensity_power
+        tolerance=1.0, mz_power=mz_power, intensity_power=intensity_power,
+        remove_precursor=False, noise_cutoff=None,  # Do not remove precursor peaks for this test
     )
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
@@ -319,7 +332,7 @@ def test_cosine_hungarian_phantom_pair_regression():
         intensities=np.array([1.0, 0.5], dtype="float"),
     )
 
-    cosine_hungarian = CosineHungarian(tolerance=2.0)
+    cosine_hungarian = CosineHungarian(tolerance=2.0, remove_precursor=False, noise_cutoff=None)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     assert score["matches"] == 1, (
@@ -342,7 +355,7 @@ def test_cosine_hungarian_single_peak_spectra():
         intensities=np.array([0.8], dtype="float"),
     )
 
-    cosine_hungarian = CosineHungarian(tolerance=0.1)
+    cosine_hungarian = CosineHungarian(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     assert score["matches"] == 1, "Expected exactly 1 match for single-peak spectra."
@@ -361,7 +374,7 @@ def test_cosine_hungarian_all_peaks_matching():
         intensities=np.array([0.5, 0.8, 1.0], dtype="float"),
     )
 
-    cosine_hungarian = CosineHungarian(tolerance=0.1)
+    cosine_hungarian = CosineHungarian(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     score = cosine_hungarian.pair(spectrum_1, spectrum_2)
 
     assert score["matches"] == 3, "Expected all 3 peaks to match."

--- a/tests/similarity/test_cosine_linear.py
+++ b/tests/similarity/test_cosine_linear.py
@@ -2,6 +2,7 @@ import json
 import os
 import numpy as np
 import pytest
+from matchms import Spectrum
 from matchms.similarity import CosineHungarian, CosineLinear, get_similarity_function_by_name
 from matchms.similarity.cosine_linear_functions import (
     linear_cosine_score,
@@ -101,7 +102,10 @@ def test_pairwise_scores(param_idx, left, right, expected_score, expected_matche
         .build()
     )
 
-    linear_cosine = CosineLinear(tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power)
+    linear_cosine = CosineLinear(
+        tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power,
+        remove_precursor=False, noise_cutoff=None,
+        )
     result = linear_cosine.pair(spec_left, spec_right)
 
     assert result["matches"] == expected_matches, f"Expected {expected_matches} matches, got {result['matches']}"
@@ -118,7 +122,10 @@ def test_commutativity(param_idx):
     mz_power = ps["mz_power"]
     intensity_power = ps["intensity_power"]
 
-    linear_cosine = CosineLinear(tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power)
+    linear_cosine = CosineLinear(
+        tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power,
+        remove_precursor=False, noise_cutoff=None,
+    )
     builder = SpectrumBuilder()
     spectra = {}
     for name in COMPOUND_NAMES:
@@ -185,7 +192,10 @@ def test_hungarian_matches_cosine_linear_on_merged_spectra(param_idx, left, righ
     )
 
     hungarian = CosineHungarian(tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power)
-    linear = CosineLinear(tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power)
+    linear = CosineLinear(
+        tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power,
+        remove_precursor=False, noise_cutoff=None,
+        )
 
     result_hungarian = hungarian.pair(spec_left, spec_right)
     result_linear = linear.pair(spec_left, spec_right)
@@ -217,7 +227,7 @@ def test_empty_spectrum():
     """Pairing an empty spectrum with a non-empty one gives score=0, matches=0."""
     empty = _build_spectrum([], [])
     nonempty = _build_spectrum([100.0, 200.0], [0.5, 0.5])
-    lc = CosineLinear(tolerance=0.1)
+    lc = CosineLinear(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     result = lc.pair(empty, nonempty)
     assert result["score"] == 0.0
     assert result["matches"] == 0
@@ -237,7 +247,7 @@ def test_single_peak_match():
     """Two single-peak spectra within tolerance match perfectly."""
     a = _build_spectrum([100.0], [1.0])
     b = _build_spectrum([100.05], [1.0])
-    lc = CosineLinear(tolerance=0.1)
+    lc = CosineLinear(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     result = lc.pair(a, b)
     assert result["score"] == pytest.approx(1.0, abs=1e-9)
     assert result["matches"] == 1
@@ -247,7 +257,7 @@ def test_single_peak_no_match():
     """Two single-peak spectra outside tolerance don't match."""
     a = _build_spectrum([100.0], [1.0])
     b = _build_spectrum([200.0], [1.0])
-    lc = CosineLinear(tolerance=0.1)
+    lc = CosineLinear(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     result = lc.pair(a, b)
     assert result["score"] == 0.0
     assert result["matches"] == 0
@@ -257,7 +267,7 @@ def test_no_overlap():
     """Multi-peak spectra with no overlapping m/z give score=0."""
     a = _build_spectrum([100.0, 200.0, 300.0], [0.5, 0.3, 0.2])
     b = _build_spectrum([400.0, 500.0, 600.0], [0.5, 0.3, 0.2])
-    lc = CosineLinear(tolerance=0.1)
+    lc = CosineLinear(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     result = lc.pair(a, b)
     assert result["score"] == 0.0
     assert result["matches"] == 0
@@ -266,7 +276,7 @@ def test_no_overlap():
 def test_self_similarity():
     """A spectrum compared to itself should yield score=1.0."""
     spec = _build_spectrum([100.0, 200.0, 300.0], [0.7, 0.2, 0.1])
-    lc = CosineLinear(tolerance=0.1)
+    lc = CosineLinear(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     result = lc.pair(spec, spec)
     assert result["score"] == pytest.approx(1.0, abs=1e-9)
 
@@ -275,7 +285,7 @@ def test_all_zero_intensities():
     """All-zero intensities produce score=0.0, matches=0."""
     a = _build_spectrum([100.0, 200.0], [0.0, 0.0])
     b = _build_spectrum([100.0, 200.0], [0.0, 0.0])
-    lc = CosineLinear(tolerance=0.1)
+    lc = CosineLinear(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     result = lc.pair(a, b)
     assert result["score"] == 0.0
     assert result["matches"] == 0
@@ -338,7 +348,7 @@ def test_matrix_self_similarity():
         _build_spectrum([150.0, 250.0], [0.5, 0.5]),
         _build_spectrum([100.0, 300.0], [0.9, 0.1]),
     ]
-    lc = CosineLinear(tolerance=0.1)
+    lc = CosineLinear(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     result = lc.matrix(spectra, progress_bar=False)
     for i in range(len(spectra)):
         assert result[i, i]["score"] == pytest.approx(1.0, abs=1e-9)
@@ -350,7 +360,7 @@ def test_matrix_matches_pair():
         _build_spectrum([100.0, 200.0], [0.7, 0.3]),
         _build_spectrum([100.0, 250.0], [0.5, 0.5]),
     ]
-    lc = CosineLinear(tolerance=0.1)
+    lc = CosineLinear(tolerance=0.1, remove_precursor=False, noise_cutoff=None)
     mat = lc.matrix(spectra, progress_bar=False)
     for i in range(2):
         for j in range(2):
@@ -372,3 +382,34 @@ def test_to_dict_round_trip():
     assert d["tolerance"] == 0.2
     assert d["mz_power"] == 1.0
     assert d["intensity_power"] == 0.5
+
+
+def test_cosine_linear_pair_matrix_parity_with_precursor_removal():
+    spectrum_1 = Spectrum(
+        mz=np.array([100.0, 150.0, 198.4, 200.0]),
+        intensities=np.array([0.5, 0.4, 0.2, 1.0]),
+        metadata={"precursor_mz": 200.0},
+    )
+    spectrum_2 = Spectrum(
+        mz=np.array([100.0, 150.0, 198.4, 200.0]),
+        intensities=np.array([0.5, 0.4, 0.2, 0.1]),
+        metadata={"precursor_mz": 200.0},
+    )
+
+    similarity = CosineLinear(
+        remove_precursor=True,
+        offset_to_precursor=-1.6,
+        noise_cutoff=0.0,
+    )
+
+    pair_score = similarity.pair(spectrum_1, spectrum_2)
+    matrix_score = similarity.matrix(
+        [spectrum_1],
+        [spectrum_2],
+        progress_bar=False,
+    )
+
+    assert matrix_score["score"].to_array()[0, 0] == pytest.approx(
+        pair_score["score"]
+    )
+    assert matrix_score["matches"].to_array()[0, 0] == pair_score["matches"]

--- a/tests/similarity/test_cosine_linear.py
+++ b/tests/similarity/test_cosine_linear.py
@@ -191,7 +191,10 @@ def test_hungarian_matches_cosine_linear_on_merged_spectra(param_idx, left, righ
         .build()
     )
 
-    hungarian = CosineHungarian(tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power)
+    hungarian = CosineHungarian(
+        tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power,
+        remove_precursor=False, noise_cutoff=None,
+        )
     linear = CosineLinear(
         tolerance=tolerance, mz_power=mz_power, intensity_power=intensity_power,
         remove_precursor=False, noise_cutoff=None,

--- a/tests/similarity/test_modified_cosine_greedy.py
+++ b/tests/similarity/test_modified_cosine_greedy.py
@@ -71,9 +71,9 @@ def test_modified_cosine_with_mass_shift(peaks, tolerance, masses, expected_matc
     norm_spectrum_1 = normalize_intensities(spectrum_1)
     norm_spectrum_2 = normalize_intensities(spectrum_2)
     if tolerance is None:
-        modified_cosine = ModifiedCosineGreedy()
+        modified_cosine = ModifiedCosineGreedy(remove_precursor=False) # default is true, but here we use non-sensical dummy precursor_mz values
     else:
-        modified_cosine = ModifiedCosineGreedy(tolerance=tolerance)
+        modified_cosine = ModifiedCosineGreedy(tolerance=tolerance, remove_precursor=False)
 
     score = modified_cosine.pair(norm_spectrum_1, norm_spectrum_2)
     expected_score = compute_expected_score(norm_spectrum_1, norm_spectrum_2, expected_matches)
@@ -185,3 +185,50 @@ def test_modified_cosine_greedy_matches_cosine_greedy_for_negative_boundary_delt
 
     assert modified_score["score"] == pytest.approx(cosine_score["score"], abs=1e-12)
     assert modified_score["matches"] == cosine_score["matches"]
+
+
+def test_modified_cosine_remove_precursor():
+    """Test effect of explicitly enabling/disabling precursor removal."""
+    spectrum_1 = Spectrum(
+        mz=np.array([100.0, 150.0, 199.0], dtype="float"),
+        intensities=np.array([1.0, 1.0, 10.0], dtype="float"),
+        metadata={"precursor_mz": 200.0},
+    )
+    spectrum_2 = Spectrum(
+        mz=np.array([100.0, 170.0, 209.0], dtype="float"),
+        intensities=np.array([1.0, 1.0, 10.0], dtype="float"),
+        metadata={"precursor_mz": 210.0},
+    )
+
+    score_with_precursor = ModifiedCosineGreedy(
+        tolerance=0.01,
+        noise_cutoff=0.0,
+        remove_precursor=False,
+    ).pair(spectrum_1, spectrum_2)
+
+    score_without_precursor = ModifiedCosineGreedy(
+        tolerance=0.01,
+        noise_cutoff=0.0,
+        remove_precursor=True,
+        offset_to_precursor=-1.6,
+    ).pair(spectrum_1, spectrum_2)
+
+    # Without precursor removal:
+    # - 100 matches directly.
+    # - 199 matches 209 via the 10 Da precursor mass shift.
+    # - 150 and 170 remain unmatched.
+    expected_with_precursor = (1.0 + 100.0) / 102.0
+
+    # With precursor removal, 199 and 209 are removed because:
+    #   199 > 200 - 1.6
+    #   209 > 210 - 1.6
+    # Only the direct 100 <-> 100 match remains.
+    expected_without_precursor = 1.0 / 2.0
+
+    assert score_with_precursor["score"] == pytest.approx(expected_with_precursor)
+    assert score_with_precursor["matches"] == 2
+
+    assert score_without_precursor["score"] == pytest.approx(expected_without_precursor)
+    assert score_without_precursor["matches"] == 1
+
+    assert score_without_precursor["score"] < score_with_precursor["score"]

--- a/tests/similarity/test_modified_cosine_greedy.py
+++ b/tests/similarity/test_modified_cosine_greedy.py
@@ -232,3 +232,28 @@ def test_modified_cosine_remove_precursor():
     assert score_without_precursor["matches"] == 1
 
     assert score_without_precursor["score"] < score_with_precursor["score"]
+
+
+def test_modified_cosine_fallback_matches_configured_cosine_greedy():
+    reference = Spectrum(
+        mz=np.array([100.0, 200.0]),
+        intensities=np.array([1.0, 0.001]),
+        metadata={"precursor_mz": 500.0},
+    )
+    query = Spectrum(
+        mz=np.array([100.0, 200.0]),
+        intensities=np.array([1.0, 0.001]),
+        metadata={"precursor_mz": 500.5},
+    )
+
+    kwargs = {
+        "tolerance": 1.0,
+        "noise_cutoff": None,
+        "remove_precursor": False,
+    }
+
+    modified = ModifiedCosineGreedy(**kwargs).pair(reference, query)
+    cosine = CosineGreedy(**kwargs).pair(reference, query)
+
+    assert modified["score"] == pytest.approx(cosine["score"])
+    assert modified["matches"] == cosine["matches"]

--- a/tests/similarity/test_modified_cosine_hungarian.py
+++ b/tests/similarity/test_modified_cosine_hungarian.py
@@ -199,8 +199,12 @@ def test_modified_cosine_hungarian_matches_cosine_hungarian_when_precursor_delta
         metadata={"precursor_mz": query_precursor_mz},
     )
 
-    modified_score = ModifiedCosineHungarian(tolerance=tolerance).pair(reference, query)
-    cosine_score = CosineHungarian(tolerance=tolerance).pair(reference, query)
+    modified_score = ModifiedCosineHungarian(
+        tolerance=tolerance, remove_precursor=False, noise_cutoff=None
+    ).pair(reference, query)
+    cosine_score = CosineHungarian(
+        tolerance=tolerance, remove_precursor=False, noise_cutoff=None
+    ).pair(reference, query)
 
     assert modified_score["score"] == pytest.approx(cosine_score["score"], abs=1e-12)
     assert modified_score["matches"] == cosine_score["matches"]
@@ -220,8 +224,10 @@ def test_modified_cosine_hungarian_matches_cosine_hungarian_for_negative_boundar
         metadata={"precursor_mz": 500.0},
     )
 
-    modified_score = ModifiedCosineHungarian(tolerance=tolerance).pair(reference, query)
-    cosine_score = CosineHungarian(tolerance=tolerance).pair(reference, query)
+    modified_score = ModifiedCosineHungarian(
+        tolerance=tolerance, remove_precursor=False, noise_cutoff=None).pair(reference, query)
+    cosine_score = CosineHungarian(
+        tolerance=tolerance, remove_precursor=False, noise_cutoff=None).pair(reference, query)
 
     assert modified_score["score"] == pytest.approx(cosine_score["score"], abs=1e-12)
     assert modified_score["matches"] == cosine_score["matches"]

--- a/tests/similarity/test_modified_cosine_hungarian.py
+++ b/tests/similarity/test_modified_cosine_hungarian.py
@@ -72,9 +72,9 @@ def test_modified_cosine_hungarian_with_mass_shift(peaks, tolerance, masses, exp
     norm_spectrum_1 = normalize_intensities(spectrum_1)
     norm_spectrum_2 = normalize_intensities(spectrum_2)
     if tolerance is None:
-        modified_cosine = ModifiedCosineHungarian()
+        modified_cosine = ModifiedCosineHungarian(remove_precursor=False, noise_cutoff=None)  # Do not remove precursor peaks for this test
     else:
-        modified_cosine = ModifiedCosineHungarian(tolerance=tolerance)
+        modified_cosine = ModifiedCosineHungarian(tolerance=tolerance, remove_precursor=False, noise_cutoff=None)
 
     score = modified_cosine.pair(norm_spectrum_1, norm_spectrum_2)
     expected_score = compute_expected_score(norm_spectrum_1, norm_spectrum_2, expected_matches)
@@ -94,7 +94,7 @@ def test_modified_cosine_hungarian_order_of_input_spectra():
 
     norm_spectrum_1 = normalize_intensities(spectrum_1)
     norm_spectrum_2 = normalize_intensities(spectrum_2)
-    modified_cosine = ModifiedCosineHungarian(tolerance=2.0)
+    modified_cosine = ModifiedCosineHungarian(tolerance=2.0, remove_precursor=False, noise_cutoff=None)
     score_1_2 = modified_cosine.pair(norm_spectrum_1, norm_spectrum_2)
     score_2_1 = modified_cosine.pair(norm_spectrum_2, norm_spectrum_1)
 
@@ -114,7 +114,7 @@ def test_modified_cosine_hungarian_precursor_mz_as_invalid_string():
 
     norm_spectrum_1 = normalize_intensities(spectrum_1)
     norm_spectrum_2 = normalize_intensities(spectrum_2)
-    modified_cosine = ModifiedCosineHungarian(tolerance=1.0)
+    modified_cosine = ModifiedCosineHungarian(tolerance=1.0, remove_precursor=False, noise_cutoff=None)
     with pytest.raises(AssertionError) as msg:
         _ = modified_cosine.pair(norm_spectrum_1, norm_spectrum_2)
 
@@ -136,7 +136,7 @@ def test_modified_cosine_hungarian_precursor_mz_as_string(caplog):
 
     norm_spectrum_1 = normalize_intensities(spectrum_1)
     norm_spectrum_2 = normalize_intensities(spectrum_2)
-    modified_cosine = ModifiedCosineHungarian(tolerance=1.0)
+    modified_cosine = ModifiedCosineHungarian(tolerance=1.0, remove_precursor=False, noise_cutoff=None)
     score = modified_cosine.pair(norm_spectrum_1, norm_spectrum_2)
 
     assert score["score"] == pytest.approx(0.0, 1e-5), "Expected different modified cosine score."
@@ -155,7 +155,7 @@ def test_modified_cosine_hungarian_reduces_to_cosine_hungarian_for_zero_shift():
                           intensities=np.array([0.9, 1.0], dtype="float"),
                           metadata={"precursor_mz": 500.0})
 
-    modified_cosine_hungarian = ModifiedCosineHungarian(tolerance=0.01)
+    modified_cosine_hungarian = ModifiedCosineHungarian(tolerance=0.01, remove_precursor=False, noise_cutoff=None)
     cosine_hungarian = CosineHungarian(tolerance=0.01)
 
     modified_score = modified_cosine_hungarian.pair(spectrum_1, spectrum_2)

--- a/tests/similarity/test_modified_cosine_hungarian_reference.py
+++ b/tests/similarity/test_modified_cosine_hungarian_reference.py
@@ -43,7 +43,10 @@ def _reference_spectra():
 
 @pytest.mark.parametrize("pair", REFERENCE_PAIRS)
 def test_modified_cosine_hungarian_reference_pairs(pair):
-    similarity = ModifiedCosineHungarian(tolerance=0.1, mz_power=0.0, intensity_power=1.0)
+    similarity = ModifiedCosineHungarian(
+        tolerance=0.1, mz_power=0.0, intensity_power=1.0,
+        remove_precursor=False, noise_cutoff=None
+        )
     spectra = _reference_spectra()
 
     left = spectra[pair["left"]]
@@ -57,7 +60,9 @@ def test_modified_cosine_hungarian_reference_pairs(pair):
 
 
 def test_modified_cosine_hungarian_reference_matrix():
-    similarity = ModifiedCosineHungarian(tolerance=0.1, mz_power=0.0, intensity_power=1.0)
+    similarity = ModifiedCosineHungarian(
+        tolerance=0.1, mz_power=0.0, intensity_power=1.0, remove_precursor=False, noise_cutoff=None
+    )
     spectra = _reference_spectra()
 
     names = ["aspirin", "cocaine", "glucose", "hydroxy_cholesterol", "phenylalanine", "salicin"]

--- a/tests/similarity/test_spectrum_similarity_functions.py
+++ b/tests/similarity/test_spectrum_similarity_functions.py
@@ -166,6 +166,20 @@ def test_filter_noise_with_zero_or_low_enough_cutoff_keeps_all_peaks(cutoff):
     np.testing.assert_array_equal(filtered_intensities, intensities)
 
 
+def test_filter_noise_empty_spectrum():
+    mz = np.array([], dtype=float)
+    intensities = np.array([], dtype=float)
+
+    filtered_mz, filtered_intensities = filter_noise(
+        mz,
+        intensities,
+        noise_cutoff=0.01,
+    )
+
+    assert filtered_mz.size == 0
+    assert filtered_intensities.size == 0
+
+
 def test_filter_peaks_above_precursor():
     mz = np.array([100.0, 198.3, 198.4, 198.5, 200.0])
     intensities = np.array([0.1, 0.2, 0.3, 0.4, 1.0])

--- a/tests/similarity/test_spectrum_similarity_functions.py
+++ b/tests/similarity/test_spectrum_similarity_functions.py
@@ -3,9 +3,13 @@ pure Python version."""
 
 import numpy as np
 import pytest
+from matchms import Spectrum
 from matchms.similarity.spectrum_similarity_functions import (
+    _preprocess_peak_array,
+    _process_spectrum_peaks,
     collect_peak_pairs,
     filter_noise,
+    filter_peaks_above_precursor,
     find_matches,
     number_matching,
     number_matching_ppm,
@@ -160,3 +164,129 @@ def test_filter_noise_with_zero_or_low_enough_cutoff_keeps_all_peaks(cutoff):
 
     np.testing.assert_array_equal(filtered_mz, mz)
     np.testing.assert_array_equal(filtered_intensities, intensities)
+
+
+def test_filter_peaks_above_precursor():
+    mz = np.array([100.0, 198.3, 198.4, 198.5, 200.0])
+    intensities = np.array([0.1, 0.2, 0.3, 0.4, 1.0])
+
+    filtered_mz, filtered_intensities = filter_peaks_above_precursor(
+        mz,
+        intensities,
+        precursor_mz=200.0,
+        offset_to_precursor=-1.6,
+    )
+
+    # Cutoff is 200.0 - 1.6 = 198.4.
+    # The peak exactly at the cutoff must be retained.
+    np.testing.assert_array_equal(
+        filtered_mz,
+        np.array([100.0, 198.3, 198.4]),
+    )
+    np.testing.assert_array_equal(
+        filtered_intensities,
+        np.array([0.1, 0.2, 0.3]),
+    )
+
+
+def test_filter_peaks_above_precursor_without_precursor_returns_unchanged():
+    mz = np.array([100.0, 200.0])
+    intensities = np.array([0.2, 1.0])
+
+    filtered_mz, filtered_intensities = filter_peaks_above_precursor(
+        mz,
+        intensities,
+        precursor_mz=None,
+        offset_to_precursor=-1.6,
+    )
+
+    np.testing.assert_array_equal(filtered_mz, mz)
+    np.testing.assert_array_equal(filtered_intensities, intensities)
+
+
+def test_preprocess_peak_array_applies_precursor_and_noise_filtering():
+    peaks = np.array([
+        [100.0, 0.01],
+        [150.0, 0.20],
+        [198.4, 1.00],
+        [199.0, 0.80],
+        [200.0, 0.90],
+    ])
+
+    processed = _preprocess_peak_array(
+        peaks,
+        precursor_mz=200.0,
+        remove_precursor=True,
+        offset_to_precursor=-1.6,
+        noise_cutoff=0.1,
+    )
+
+    # Precursor filtering first removes 199 and 200.
+    # Among the remaining peaks, 198.4 is the base peak, so 100.0
+    # is subsequently removed by the 10% relative noise cutoff.
+    expected = np.array([
+        [150.0, 0.20],
+        [198.4, 1.00],
+    ])
+
+    np.testing.assert_array_equal(processed, expected)
+
+
+def test_preprocess_peak_array_requires_precursor_when_removal_requested():
+    peaks = np.array([
+        [100.0, 0.5],
+        [200.0, 1.0],
+    ])
+
+    with pytest.raises(
+        ValueError,
+        match="Cannot remove precursor peaks when precursor_mz is None",
+    ):
+        _preprocess_peak_array(
+            peaks,
+            precursor_mz=None,
+            remove_precursor=True,
+        )
+
+
+def test_process_spectrum_peaks_uses_spectrum_precursor_mz():
+    spectrum = Spectrum(
+        mz=np.array([100.0, 198.4, 198.5, 200.0]),
+        intensities=np.array([0.2, 0.3, 0.4, 1.0]),
+        metadata={"precursor_mz": 200.0},
+    )
+
+    processed = _process_spectrum_peaks(
+        spectrum,
+        remove_precursor=True,
+        offset_to_precursor=-1.6,
+        noise_cutoff=None,
+    )
+
+    expected = np.array([
+        [100.0, 0.2],
+        [198.4, 0.3],
+    ])
+
+    np.testing.assert_array_equal(processed, expected)
+
+
+def test_process_spectrum_peaks_does_not_require_precursor_when_removal_disabled():
+    spectrum = Spectrum(
+        mz=np.array([100.0, 200.0]),
+        intensities=np.array([0.5, 1.0]),
+    )
+
+    processed = _process_spectrum_peaks(
+        spectrum,
+        remove_precursor=False,
+        noise_cutoff=None,
+    )
+
+    np.testing.assert_array_equal(
+        processed,
+        np.array([
+            [100.0, 0.5],
+            [200.0, 1.0],
+        ]),
+    )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -57,7 +57,7 @@ def test_pipeline_symmetric():
     workflow = create_workflow(
         score_computations=[
             ["precursormzmatch", {"tolerance": 120.0}],
-            ["modifiedcosinegreedy", {"tolerance": 10.0}],
+            ["modifiedcosinegreedy", {"tolerance": 10.0, "remove_precursor": False}],
         ]
     )
     pipeline = Pipeline(workflow)
@@ -80,7 +80,7 @@ def test_pipeline_symmetric_modified_cosine_hungarian():
     workflow = create_workflow(
         score_computations=[
             ["precursormzmatch", {"tolerance": 120.0}],
-            ["modifiedcosinehungarian", {"tolerance": 10.0}],
+            ["modifiedcosinehungarian", {"tolerance": 10.0, "remove_precursor": False}],
         ]
     )
     pipeline = Pipeline(workflow)
@@ -101,7 +101,7 @@ def test_pipeline_symmetric_filters():
         spectra_1_filters=[("select_by_relative_intensity", {"intensity_from": 0.05})],
         score_computations=[
             ["precursormzmatch", {"tolerance": 120.0}],
-            ["modifiedcosinegreedy", {"tolerance": 10.0}],
+            ["modifiedcosinegreedy", {"tolerance": 10.0, "remove_precursor": False}],
         ],
     )
     pipeline = Pipeline(workflow)
@@ -122,7 +122,7 @@ def test_pipeline_symmetric_masking():
         score_computations=[
             ["precursormzmatch", {"tolerance": 120.0}],
             ["mask", {"field": "score", "value": True, "operation": "=="}],
-            ["modifiedcosinegreedy", {"tolerance": 10.0}],
+            ["modifiedcosinegreedy", {"tolerance": 10.0, "remove_precursor": False}],
         ]
     )
     pipeline = Pipeline(workflow)
@@ -145,7 +145,7 @@ def test_pipeline_symmetric_custom_score():
     workflow = create_workflow(
         score_computations=[
             ["precursormzmatch", {"tolerance": 120.0}],
-            [ModifiedCosineGreedy, {"tolerance": 10.0}],
+            [ModifiedCosineGreedy, {"tolerance": 10.0, "remove_precursor": False}],
         ]
     )
     pipeline = Pipeline(workflow)
@@ -168,7 +168,7 @@ def test_pipeline_non_symmetric():
     workflow = create_workflow(
         score_computations=[
             ["precursormzmatch", {"tolerance": 120.0}],
-            ["modifiedcosinegreedy", {"tolerance": 10.0}],
+            ["modifiedcosinegreedy", {"tolerance": 10.0, "remove_precursor": False}],
         ]
     )
     pipeline = Pipeline(workflow)
@@ -216,7 +216,7 @@ def test_pipeline_to_and_from_yaml(tmp_path):
         config_file,
         score_computations=[
             ["precursormzmatch", {"tolerance": 120.0}],
-            ["modifiedcosinegreedy", {"tolerance": 10.0}],
+            ["modifiedcosinegreedy", {"tolerance": 10.0, "remove_precursor": False}],
         ],
     )
     assert os.path.exists(config_file)
@@ -228,7 +228,6 @@ def test_pipeline_to_and_from_yaml(tmp_path):
     workflow = load_workflow_from_yaml_file(config_file)
     pipeline = Pipeline(workflow)
     pipeline.run(spectra_file_msp)
-
     assert np.allclose(_score_array(pipeline.scores), scores_run1)
 
 
@@ -253,7 +252,7 @@ def test_pipeline_relative_intensity_filter():
         spectra_2_filters=[("select_by_relative_intensity", {"intensity_from": 0.05})],
         score_computations=[
             ["precursormzmatch", {"tolerance": 50}],
-            ["modifiedcosinegreedy", {"tolerance": 10.0}],
+            ["modifiedcosinegreedy", {"tolerance": 10.0, "remove_precursor": False}],
         ],
     )
     pipeline = Pipeline(workflow)
@@ -273,7 +272,9 @@ def test_pipeline_changing_workflow():
 
     pipeline.spectra_1_filters = [("select_by_relative_intensity", {"intensity_from": 0.05})]
     pipeline.spectra_2_filters = [("select_by_relative_intensity", {"intensity_from": 0.05})]
-    pipeline.score_computations = [["modifiedcosinegreedy", {"tolerance": 10.0}]]
+    pipeline.score_computations = [[
+        "modifiedcosinegreedy", {"tolerance": 10.0, "remove_precursor": False}
+        ]]
 
     pipeline.run(spectra_file_msp, spectra_file_msp)
 

--- a/tests/test_pipeline.yaml
+++ b/tests/test_pipeline.yaml
@@ -28,3 +28,4 @@ score_computations:
   - tolerance: 120.0
 - - modifiedcosinegreedy
   - tolerance: 10.0
+    remove_precursor: False


### PR DESCRIPTION
All cosine-like and entropy-like similarity scores now have new parameters with new defaults:
- `noise_cutoff = 0.01` --> will ignore peaks with relative intensity < 0.01
- `remove_precursor = True` --> will remove precursor (Fiehn style with the default parameter `cutoff_to_precursor = -1.6`)

The commonly used internal helper functions are in `spectrum_similarity_functions.py`.