### PR TITLE
Use SpectraCollection for faster score computation (1st case: FlashSimilarity)

### DIFF
--- a/matchms/similarity/base_similarity.py
+++ b/matchms/similarity/base_similarity.py
@@ -170,6 +170,19 @@ class BaseSimilarity(ABC):
             return spectra_1, True
         return spectra_2, False
 
+    @staticmethod
+    def _as_spectra_collection(
+        spectra,
+        **kwargs,
+        ):
+        """Return spectra as a SpectraCollection."""
+        from matchms.spectra_collection import SpectraCollection
+
+        if isinstance(spectra, SpectraCollection):
+            return spectra
+
+        return SpectraCollection(spectra, **kwargs)
+
     def _available_score_fields(self) -> tuple[str, ...]:
         """Return the available score fields and validate consistency."""
         dtype_names = np.dtype(self.score_datatype).names

--- a/matchms/similarity/flash_similarity.py
+++ b/matchms/similarity/flash_similarity.py
@@ -117,6 +117,50 @@ class _BaseFlashSimilarity(BaseSimilarity):
 
         return prepared_1, prepared_2, False
 
+    def _optimize_matrix_orientation(
+        self,
+        refs: _PreparedSpectra,
+        queries: _PreparedSpectra,
+        is_symmetric: bool,
+    ) -> tuple[_PreparedSpectra, _PreparedSpectra, bool]:
+        """Orient an asymmetric comparison for efficient Flash searching.
+
+        Flash scoring is computationally asymmetric: reference spectra are streamed
+        one row at a time, while query spectra are indexed once as the library.
+        For commutative similarities it is therefore usually faster to stream the
+        smaller collection and build the library from the larger collection.
+
+        If the inputs are swapped internally, the resulting score matrix must be
+        transposed before returning it so that the public result still has shape
+        ``(len(spectra_1), len(spectra_2))``.
+
+        Parameters
+        ----------
+        refs
+            Prepared first input collection.
+        queries
+            Prepared second input collection.
+        is_symmetric
+            Whether this is a self-comparison originating from ``spectra_2=None``.
+
+        Returns
+        -------
+        refs
+            Prepared collection to stream as reference rows.
+        queries
+            Prepared collection to use as the indexed library.
+        transpose_output
+            Whether the computed matrix must be transposed before returning.
+        """
+        if (
+            is_symmetric
+            or not self.is_commutative
+            or refs.n_specs <= queries.n_specs
+        ):
+            return refs, queries, False
+
+        return queries, refs, True
+
     def _build_library(self, prepared: _PreparedSpectra):
         return _build_library_index_from_prepared(
             prepared,
@@ -369,9 +413,20 @@ class FlashEntropy(_BaseFlashSimilarity):
                 "FlashEntropy.matrix() supports only score_fields=('score',)."
             )
 
-        refs, queries, is_symmetric = self._prepare_matrix_inputs(spectra_1, spectra_2)
+        refs, queries, is_symmetric = self._prepare_matrix_inputs(
+            spectra_1,
+            spectra_2,
+        )
         if is_symmetric and refs.n_specs != queries.n_specs:
-            raise ValueError("Self-comparison requires same number of rows and columns.")
+            raise ValueError(
+                "Self-comparison requires same number of rows and columns."
+            )
+
+        refs, queries, transpose_output = self._optimize_matrix_orientation(
+            refs,
+            queries,
+            is_symmetric,
+        )
 
         lib = self._build_library(queries)
         results = self._run_row_workers(
@@ -383,11 +438,24 @@ class FlashEntropy(_BaseFlashSimilarity):
             descriptor=self._descriptor_name,
         )
 
-        out_score = np.zeros((refs.n_specs, queries.n_specs), dtype=self.dtype)
+        out_score = np.zeros(
+            (refs.n_specs, queries.n_specs),
+            dtype=self.dtype,
+        )
         for row_idx, row_score in results:
             out_score[row_idx, :] = row_score
 
-        return Scores({"score": out_score.astype(self.score_datatype, copy=False)})
+        if transpose_output:
+            out_score = out_score.T
+
+        return Scores(
+            {
+                "score": out_score.astype(
+                    self.score_datatype,
+                    copy=False,
+                )
+            }
+        )
 
 
 class CosineFlash(_BaseFlashSimilarity):
@@ -519,9 +587,20 @@ class CosineFlash(_BaseFlashSimilarity):
         """
         selected_fields = self._resolve_score_fields(score_fields)
 
-        refs, queries, is_symmetric = self._prepare_matrix_inputs(spectra_1, spectra_2)
+        refs, queries, is_symmetric = self._prepare_matrix_inputs(
+            spectra_1,
+            spectra_2,
+        )
         if is_symmetric and refs.n_specs != queries.n_specs:
-            raise ValueError("Self-comparison requires same number of rows and columns.")
+            raise ValueError(
+                "Self-comparison requires same number of rows and columns."
+            )
+
+        refs, queries, transpose_output = self._optimize_matrix_orientation(
+            refs,
+            queries,
+            is_symmetric,
+        )
 
         lib = self._build_library(queries)
         results = self._run_row_workers(
@@ -533,18 +612,34 @@ class CosineFlash(_BaseFlashSimilarity):
             descriptor=self._descriptor_name,
         )
 
-        out_score = np.zeros((refs.n_specs, queries.n_specs), dtype=self.dtype)
-        out_matches = np.zeros((refs.n_specs, queries.n_specs), dtype=np.int32)
+        out_score = np.zeros(
+            (refs.n_specs, queries.n_specs),
+            dtype=self.dtype,
+        )
+        out_matches = np.zeros(
+            (refs.n_specs, queries.n_specs),
+            dtype=np.int32,
+        )
 
         for row_idx, row_score, row_matches in results:
             out_score[row_idx, :] = row_score
             out_matches[row_idx, :] = row_matches
 
+        if transpose_output:
+            out_score = out_score.T
+            out_matches = out_matches.T
+
         result = {}
+
         if "score" in selected_fields:
-            result["score"] = out_score.astype(self.dtype, copy=False)
+            result["score"] = out_score.astype(
+                self.dtype,
+                copy=False,
+            )
+
         if "matches" in selected_fields:
             result["matches"] = out_matches
+
         return Scores(result)
 
 

--- a/matchms/similarity/flash_similarity_spectrum_list.py
+++ b/matchms/similarity/flash_similarity_spectrum_list.py
@@ -1,7 +1,6 @@
-"""SpectraCollection-native Flash similarity implementations.
+"""Flash similarity implementations based in lists of matchms Spectrum objects
 """
 
-from __future__ import annotations
 import logging
 import multiprocessing as mp
 import platform
@@ -19,24 +18,20 @@ from .default_parameters import (
     DEFAULT_NOISE_CUTOFF,
     DEFAULT_OFFSET_TO_PRECURSOR,
 )
-from .flash_utils import (
-    _build_library_index_from_prepared,
-    _prepare_collection,
-    _PreparedSpectra,
-)
+from .flash_utils_spectrum_list import _build_library_index, _clean_and_weight
 
 
 logger = logging.getLogger("matchms")
 
 
-class _BaseFlashSimilarity(BaseSimilarity):
-    """Shared base class for SpectraCollection-native Flash similarities."""
+class _BaseFlashSimilaritySL(BaseSimilarity):
+    """Shared base class for Flash-based similarities."""
 
     is_commutative = True
 
     def __init__(
         self,
-        matching_mode: str = "fragment",
+        matching_mode: str = "fragment",           # 'fragment' | 'neutral_loss' | 'hybrid'
         tolerance: float = DEFAULT_MZ_TOLERANCE,
         use_ppm: bool = False,
         intensity_power: float = DEFAULT_INTENSITY_POWER,
@@ -50,9 +45,7 @@ class _BaseFlashSimilarity(BaseSimilarity):
         dtype: np.dtype = DEFAULT_DTYPE,
     ):
         if matching_mode not in ("fragment", "neutral_loss", "hybrid"):
-            raise ValueError(
-                "matching_mode must be 'fragment', 'neutral_loss', or 'hybrid'"
-            )
+            raise ValueError("matching_mode must be 'fragment', 'neutral_loss', or 'hybrid'")
 
         self.matching_mode = matching_mode
         self.tolerance = tolerance
@@ -83,10 +76,12 @@ class _BaseFlashSimilarity(BaseSimilarity):
     def _descriptor_name(self) -> str:
         raise NotImplementedError
 
-    def _prepare_collection(self, collection) -> _PreparedSpectra:
-        """Prepare one complete SpectraCollection for Flash scoring."""
-        return _prepare_collection(
-            collection,
+    def _prepare(self, spectrum: SpectrumType) -> tuple[np.ndarray, float | None]:
+        peaks = spectrum.peaks.to_numpy
+        pmz = spectrum.metadata.get("precursor_mz", None)
+        cleaned = _clean_and_weight(
+            peaks,
+            pmz,
             intensity_power=self.intensity_power,
             remove_precursor=self.remove_precursor,
             offset_to_precursor=self.offset_to_precursor,
@@ -94,34 +89,40 @@ class _BaseFlashSimilarity(BaseSimilarity):
             normalize_to_half=self.normalize_to_half,
             merge_within_da=self.merge_within,
             weighing_type=self._weighing_type,
-            compute_l2_norm=self._compute_l2,
             dtype=self.dtype,
         )
+        return cleaned, (None if pmz is None else float(pmz))
 
-    def _prepare_matrix_inputs(self, spectra_1, spectra_2):
-        """Convert matrix inputs to collections and preprocess each collection once."""
-        collection_1 = self._as_spectra_collection(spectra_1)
+    def _build_library(self, spectra_2: Sequence[SpectrumType]):
+        lib_proc = []
+        lib_pmz = []
 
-        if spectra_2 is None:
-            prepared_1 = self._prepare_collection(collection_1)
-            return prepared_1, prepared_1, True
+        for spectrum_2 in spectra_2:
+            peaks = spectrum_2.peaks.to_numpy
+            pmz = spectrum_2.metadata.get("precursor_mz", None)
+            cleaned = _clean_and_weight(
+                peaks,
+                pmz,
+                intensity_power=self.intensity_power,
+                remove_precursor=self.remove_precursor,
+                offset_to_precursor=self.offset_to_precursor,
+                noise_cutoff=self.noise_cutoff,
+                normalize_to_half=self.normalize_to_half,
+                merge_within_da=self.merge_within,
+                weighing_type=self._weighing_type,
+                dtype=self.dtype,
+            )
+            lib_proc.append(cleaned)
+            lib_pmz.append(None if pmz is None else float(pmz))
 
-        collection_2 = self._as_spectra_collection(spectra_2)
-        prepared_1 = self._prepare_collection(collection_1)
+        compute_nl = self.matching_mode in ("neutral_loss", "hybrid")
 
-        # Reuse preprocessing when the exact same collection is passed explicitly.
-        if collection_2 is collection_1:
-            prepared_2 = prepared_1
-        else:
-            prepared_2 = self._prepare_collection(collection_2)
-
-        return prepared_1, prepared_2, False
-
-    def _build_library(self, prepared: _PreparedSpectra):
-        return _build_library_index_from_prepared(
-            prepared,
-            compute_neutral_loss=self.matching_mode in ("neutral_loss", "hybrid"),
+        return _build_library_index(
+            lib_proc,
+            lib_pmz,
+            compute_neutral_loss=compute_nl,
             compute_l2_norm=self._compute_l2,
+            dtype=self.dtype,
         )
 
     def _make_worker_cfg(self) -> dict:
@@ -129,7 +130,7 @@ class _BaseFlashSimilarity(BaseSimilarity):
             "tol": float(self.tolerance),
             "use_ppm": bool(self.use_ppm),
             "matching_mode": self.matching_mode,
-            "compute_nl": self.matching_mode in ("neutral_loss", "hybrid"),
+            "compute_nl": (self.matching_mode in ("neutral_loss", "hybrid")),
             "iden_tol": (
                 None
                 if self.identity_precursor_tolerance is None
@@ -138,43 +139,51 @@ class _BaseFlashSimilarity(BaseSimilarity):
             "iden_use_ppm": bool(self.identity_use_ppm),
         }
 
+    def _prepare_row_inputs(self, spectra_1: Sequence[SpectrumType]):
+        row_inputs = []
+        for i, spectrum_1 in enumerate(spectra_1):
+            peaks_1, pmz_1 = self._prepare(spectrum_1)
+            row_inputs.append((i, peaks_1, pmz_1))
+        return row_inputs
+
     def _run_row_workers(
         self,
-        refs: _PreparedSpectra,
+        row_inputs,
         lib,
         cfg,
         progress_bar: bool,
         n_jobs: int,
         descriptor: str,
     ):
-        """Run row workers using integer row ids instead of pickled peak arrays."""
-        _set_globals(refs, lib, cfg)
+        _set_globals(lib, cfg)
         worker = self._worker
-        row_indices = range(refs.n_specs)
+        n_rows = len(row_inputs)
+
         results = []
 
         if n_jobs in (None, 1, 0):
-            for row_idx in tqdm(
-                row_indices,
-                total=refs.n_specs,
+            for item in tqdm(
+                row_inputs,
+                total=n_rows,
                 desc=descriptor + " (matrix)",
                 disable=not progress_bar,
             ):
-                results.append(worker(row_idx))
+                results.append(worker(item))
             return results
 
+        # Windows fallback
         if platform.system() == "Windows":
             print(
-                f"{self.__class__.__name__}.matrix: n_jobs != 1 is not yet "
-                "implemented on Windows; falling back to n_jobs=1."
+                f"{self.__class__.__name__}.matrix: n_jobs != 1 is not yet implemented on Windows; "
+                "falling back to n_jobs=1."
             )
-            for row_idx in tqdm(
-                row_indices,
-                total=refs.n_specs,
+            for item in tqdm(
+                row_inputs,
+                total=n_rows,
                 desc=descriptor + " (matrix)",
                 disable=not progress_bar,
             ):
-                results.append(worker(row_idx))
+                results.append(worker(item))
             return results
 
         n_cpus = mp.cpu_count()
@@ -183,27 +192,27 @@ class _BaseFlashSimilarity(BaseSimilarity):
         n_jobs = max(1, min(n_jobs, n_cpus))
 
         start_methods = mp.get_all_start_methods()
-        use_fork = "fork" in start_methods and platform.system() != "Windows"
+        use_fork = ("fork" in start_methods) and (platform.system() != "Windows")
 
         if not use_fork:
             print(
-                f"{self.__class__.__name__}.matrix: parallel execution requires "
-                "'fork'; falling back to n_jobs=1."
+                f"{self.__class__.__name__}.matrix: parallel execution requires 'fork'; "
+                "falling back to n_jobs=1."
             )
-            for row_idx in tqdm(
-                row_indices,
-                total=refs.n_specs,
+            for item in tqdm(
+                row_inputs,
+                total=n_rows,
                 desc=descriptor + " (matrix)",
                 disable=not progress_bar,
             ):
-                results.append(worker(row_idx))
+                results.append(worker(item))
             return results
 
         ctx = mp.get_context("fork")
         with ctx.Pool(processes=n_jobs) as pool:
             for result in tqdm(
-                pool.imap(worker, row_indices, chunksize=8),
-                total=refs.n_specs,
+                pool.imap(worker, row_inputs, chunksize=8),
+                total=n_rows,
                 desc=descriptor + f" (parallel x{n_jobs})",
                 disable=not progress_bar,
             ):
@@ -212,7 +221,7 @@ class _BaseFlashSimilarity(BaseSimilarity):
         return results
 
 
-class FlashEntropy(_BaseFlashSimilarity):
+class FlashEntropy(_BaseFlashSimilaritySL):
     """
     Flash entropy similarity (Li & Fiehn, 2023) with a fast .matrix() that
     builds a library-wide index over 'queries' and streams all 'references'
@@ -323,23 +332,34 @@ class FlashEntropy(_BaseFlashSimilarity):
         Careful: This is not the fast intended use; better .matrix() instead.
         """
         logger.warning("This is not the fast intended use; better use .matrix() instead.")
-        scores = self.matrix(
-            [spectrum_1],
-            [spectrum_2],
-            score_fields=("score",),
-            progress_bar=False,
-            n_jobs=0,
-        )
-        return np.asarray(scores.to_array("score")[0, 0], dtype=self.dtype)
 
+        # Preprocess both spectra
+        peaks_1, pmz_1 = self._prepare(spectrum_1)
+        peaks_2, pmz_2 = self._prepare(spectrum_2)
+        if peaks_1.size == 0 or peaks_2.size == 0:
+            return np.asarray(0.0, dtype=self.dtype)
+
+        compute_nl = self.matching_mode in ("neutral_loss", "hybrid")
+        lib = _build_library_index(
+            [peaks_2],
+            [pmz_2],
+            compute_neutral_loss=compute_nl,
+            compute_l2_norm=False,
+            dtype=self.dtype,
+        )
+        _set_globals(lib, self._make_worker_cfg())
+        _, row = _row_task_entropy((0, peaks_1, pmz_1))
+        return np.asarray(row[0], dtype=self.dtype)
+
+    # FAST + PARALLEL score matrix computation
     def matrix(
-        self,
-        spectra_1: Sequence[SpectrumType],
-        spectra_2: Sequence[SpectrumType] | None = None,
-        score_fields: Sequence[str] | None = None,
-        progress_bar: bool = True,
-        n_jobs: int = -1,
-    ) -> Scores:
+            self,
+            spectra_1: Sequence[SpectrumType],
+            spectra_2: Sequence[SpectrumType] | None = None,
+            score_fields: Sequence[str] | None = None,
+            progress_bar: bool = True,
+            n_jobs: int = -1,
+        ):
         """
         Calculate matrix of Flash Entropy scores.
 
@@ -369,13 +389,17 @@ class FlashEntropy(_BaseFlashSimilarity):
                 "FlashEntropy.matrix() supports only score_fields=('score',)."
             )
 
-        refs, queries, is_symmetric = self._prepare_matrix_inputs(spectra_1, spectra_2)
-        if is_symmetric and refs.n_specs != queries.n_specs:
+        spectra_2, is_symmetric = self._prepare_inputs(spectra_1, spectra_2)
+        n_rows = len(spectra_1)
+        n_cols = len(spectra_2)
+
+        if is_symmetric and n_rows != n_cols:
             raise ValueError("Self-comparison requires same number of rows and columns.")
 
-        lib = self._build_library(queries)
+        lib = self._build_library(spectra_2)
+        row_inputs = self._prepare_row_inputs(spectra_1)
         results = self._run_row_workers(
-            refs=refs,
+            row_inputs=row_inputs,
             lib=lib,
             cfg=self._make_worker_cfg(),
             progress_bar=progress_bar,
@@ -383,14 +407,14 @@ class FlashEntropy(_BaseFlashSimilarity):
             descriptor=self._descriptor_name,
         )
 
-        out_score = np.zeros((refs.n_specs, queries.n_specs), dtype=self.dtype)
+        out_score = np.zeros((n_rows, n_cols), dtype=self.dtype)
         for row_idx, row_score in results:
             out_score[row_idx, :] = row_score
 
         return Scores({"score": out_score.astype(self.score_datatype, copy=False)})
 
 
-class CosineFlash(_BaseFlashSimilarity):
+class CosineFlash(_BaseFlashSimilaritySL):
     """
     Flash Cosine similarity following the original Flash Entropy (Li & Fiehn, 2023)
     with a fast .matrix() that builds a library-wide index over 'queries' and streams 
@@ -469,22 +493,24 @@ class CosineFlash(_BaseFlashSimilarity):
         return f"Flash cosine ({self.matching_mode})"
 
     def pair(self, spectrum_1: SpectrumType, spectrum_2: SpectrumType) -> np.ndarray:
-        """Compute one score via the same collection-native matrix path."""
-        logger.warning("CosineFlash.pair() is not the fast intended use; use .matrix().")
-        scores = self.matrix(
-            [spectrum_1],
-            [spectrum_2],
-            score_fields=("score", "matches"),
-            progress_bar=False,
-            n_jobs=0,
+        logger.warning("This is not the fast intended use; better use .matrix() instead.")
+
+        peaks_1, pmz_1 = self._prepare(spectrum_1)
+        peaks_2, pmz_2 = self._prepare(spectrum_2)
+        if peaks_1.size == 0 or peaks_2.size == 0:
+            return np.asarray((0.0, 0), dtype=self.score_datatype)
+
+        compute_nl = self.matching_mode in ("neutral_loss", "hybrid")
+        lib = _build_library_index(
+            [peaks_2],
+            [pmz_2],
+            compute_neutral_loss=compute_nl,
+            compute_l2_norm=True,
+            dtype=self.dtype,
         )
-        return np.asarray(
-            (
-                scores.to_array("score")[0, 0],
-                scores.to_array("matches")[0, 0],
-            ),
-            dtype=self.score_datatype,
-        )
+        _set_globals(lib, self._make_worker_cfg())
+        _, row_score, row_matches = _row_task_cosine((0, peaks_1, pmz_1))
+        return np.asarray((row_score[0], row_matches[0]), dtype=self.score_datatype)
 
     def matrix(
         self,
@@ -493,7 +519,7 @@ class CosineFlash(_BaseFlashSimilarity):
         score_fields: Sequence[str] | None = None,
         progress_bar: bool = True,
         n_jobs: int = -1,
-    ) -> Scores:
+    ):
         """
         Calculate matrix of Flash Cosine scores.
 
@@ -519,13 +545,17 @@ class CosineFlash(_BaseFlashSimilarity):
         """
         selected_fields = self._resolve_score_fields(score_fields)
 
-        refs, queries, is_symmetric = self._prepare_matrix_inputs(spectra_1, spectra_2)
-        if is_symmetric and refs.n_specs != queries.n_specs:
+        spectra_2, is_symmetric = self._prepare_inputs(spectra_1, spectra_2)
+        n_rows = len(spectra_1)
+        n_cols = len(spectra_2)
+
+        if is_symmetric and n_rows != n_cols:
             raise ValueError("Self-comparison requires same number of rows and columns.")
 
-        lib = self._build_library(queries)
+        lib = self._build_library(spectra_2)
+        row_inputs = self._prepare_row_inputs(spectra_1)
         results = self._run_row_workers(
-            refs=refs,
+            row_inputs=row_inputs,
             lib=lib,
             cfg=self._make_worker_cfg(),
             progress_bar=progress_bar,
@@ -533,8 +563,8 @@ class CosineFlash(_BaseFlashSimilarity):
             descriptor=self._descriptor_name,
         )
 
-        out_score = np.zeros((refs.n_specs, queries.n_specs), dtype=self.dtype)
-        out_matches = np.zeros((refs.n_specs, queries.n_specs), dtype=np.int32)
+        out_score = np.zeros((n_rows, n_cols), dtype=self.dtype)
+        out_matches = np.zeros((n_rows, n_cols), dtype=np.int32)
 
         for row_idx, row_score, row_matches in results:
             out_score[row_idx, :] = row_score
@@ -545,22 +575,28 @@ class CosineFlash(_BaseFlashSimilarity):
             result["score"] = out_score.astype(self.dtype, copy=False)
         if "matches" in selected_fields:
             result["matches"] = out_matches
+
         return Scores(result)
 
 
 # ===================== worker plumbing =====================
 
-_G_REFS = None
+# Globals visible to workers
 _G_LIB = None
 _G_CFG = None
 
+def _set_globals(lib_obj, cfg):
+    """
+    Install the shared library index and constant config in module-level globals.
 
-def _set_globals(refs_obj, lib_obj, cfg):
-    """Install packed references, library index, and worker configuration."""
-    global _G_REFS, _G_LIB, _G_CFG
-    _G_REFS = refs_obj
+    Worker functions read from these globals to avoid re-pickling large arrays
+    for every work item (especially efficient with fork on Unix).
+    """
+    global _G_LIB, _G_CFG
     _G_LIB = lib_obj
     _G_CFG = cfg
+
+# ====================== Numba-accelerated helpers ====================
 
 @njit(cache=True, nogil=True)
 def _search_spec_in_fragment_window(lib_mz: np.ndarray, mz: float, tol: float, use_ppm: bool):
@@ -983,27 +1019,19 @@ def _score_entropy_candidate_cols_numba(
         scores[col] = score
 
 
+def _row_task_entropy(args):
+    """Compute one FlashEntropy matrix row."""
+    row_idx, ref_peaks, ref_pmz = args
 
-
-def _row_task_entropy(row_idx):
-    """Compute one FlashEntropy row from the shared packed references."""
-    row_idx = int(row_idx)
-    refs = _G_REFS
-    lib = _G_LIB
     cfg = _G_CFG
+    lib = _G_LIB
     scores = np.zeros(lib.n_specs, dtype=lib.dtype)
 
-    start = int(refs.spec_offsets[row_idx])
-    end = int(refs.spec_offsets[row_idx + 1])
-    if start >= end:
+    if ref_peaks.size == 0:
         return row_idx, scores
 
-    ref_mz = refs.spec_mz[start:end]
-    ref_int = refs.spec_int[start:end]
-    ref_pmz_value = float(refs.precursor_mz[row_idx])
-    has_ref_pmz = np.isfinite(ref_pmz_value)
-
     matching_mode = cfg["matching_mode"]
+
     if matching_mode == "fragment":
         matching_mode_code = _ENTROPY_MODE_FRAGMENT
     elif matching_mode == "neutral_loss":
@@ -1011,11 +1039,18 @@ def _row_task_entropy(row_idx):
     else:
         matching_mode_code = _ENTROPY_MODE_HYBRID
 
+    has_ref_pmz = ref_pmz is not None
+    ref_pmz_value = float(ref_pmz) if has_ref_pmz else np.nan
+
     if matching_mode_code == _ENTROPY_MODE_FRAGMENT:
         lib_nl_mz = np.empty(0, dtype=lib.dtype)
         lib_nl_spec_idx = np.empty(0, dtype=np.int32)
     else:
-        lib_nl_mz = lib.nl_mz if lib.nl_mz is not None else np.empty(0, dtype=lib.dtype)
+        lib_nl_mz = (
+            lib.nl_mz
+            if lib.nl_mz is not None
+            else np.empty(0, dtype=lib.dtype)
+        )
         lib_nl_spec_idx = (
             lib.nl_spec_idx
             if lib.nl_spec_idx is not None
@@ -1023,8 +1058,8 @@ def _row_task_entropy(row_idx):
         )
 
     candidate_cols = _gather_entropy_candidate_cols_numba(
-        ref_mz,
-        ref_int,
+        ref_peaks[:, 0],
+        ref_peaks[:, 1],
         ref_pmz_value,
         has_ref_pmz,
         lib.peaks_mz,
@@ -1039,8 +1074,8 @@ def _row_task_entropy(row_idx):
 
     _score_entropy_candidate_cols_numba(
         scores,
-        ref_mz,
-        ref_int,
+        ref_peaks[:, 0],
+        ref_peaks[:, 1],
         ref_pmz_value,
         has_ref_pmz,
         candidate_cols,
@@ -1053,22 +1088,31 @@ def _row_task_entropy(row_idx):
         matching_mode_code,
     )
 
-    if cfg["iden_tol"] is not None and has_ref_pmz:
+    # Optional identity-search precursor gate.
+    if cfg["iden_tol"] is not None and ref_pmz is not None:
         if cfg["iden_use_ppm"]:
-            allow = np.abs(lib.precursor_mz - ref_pmz_value) <= (
-                cfg["iden_tol"]
-                * 1e-6
-                * 0.5
-                * (lib.precursor_mz + ref_pmz_value)
+            allow = (
+                np.abs(lib.precursor_mz - ref_pmz)
+                <= (
+                    cfg["iden_tol"]
+                    * 1e-6
+                    * 0.5
+                    * (lib.precursor_mz + ref_pmz)
+                )
             )
         else:
-            allow = np.abs(lib.precursor_mz - ref_pmz_value) <= cfg["iden_tol"]
+            allow = (
+                np.abs(lib.precursor_mz - ref_pmz)
+                <= cfg["iden_tol"]
+            )
 
         allow &= np.isfinite(lib.precursor_mz)
         scores[~allow] = 0.0
 
     return row_idx, scores
 
+
+# ===================== Cosine related helpers =====================
 @njit(cache=True, nogil=True)
 def _precursor_shift_is_effectively_zero_nb(
     ref_pmz: float,
@@ -1331,32 +1375,119 @@ def _greedy_scores_and_matches_all_cols_nb(
     return out_score, out_matches
 
 
+@njit(cache=True, nogil=True)
+def _greedy_scores_and_matches_all_cols_nb(
+    n_cols: int,
+    n_q: int,
+    col_offsets: np.ndarray,
+    ref_idx: np.ndarray,
+    lib_idx: np.ndarray,
+    score: np.ndarray,
+    is_frag: np.ndarray,
+    lib_spec_l2: np.ndarray,
+    q_l2: float,
+):
+    out_score = np.zeros(n_cols, dtype=np.float64)
+    out_matches = np.zeros(n_cols, dtype=np.int32)
+    used_q = np.empty(n_q, dtype=np.uint8)
+
+    eps = 1e-12
+
+    for col in range(n_cols):
+        start = int(col_offsets[col])
+        end = int(col_offsets[col + 1])
+        size = end - start
+        if size <= 0:
+            continue
+
+        s_ref = ref_idx[start:end]
+        s_lib = lib_idx[start:end]
+        s_score = score[start:end]
+        s_frag = is_frag[start:end]
+
+        key = np.empty(size, dtype=np.float64)
+        for t in range(size):
+            key[t] = s_score[t] + (eps if s_frag[t] == 1 else 0.0)
+        order = np.argsort(-key)
+
+        for qi in range(n_q):
+            used_q[qi] = 0
+
+        used_lib_j = np.empty(size, dtype=np.int32)
+        used_lib_n = 0
+
+        dot = 0.0
+        n_match = 0
+
+        for r in range(size):
+            idx = int(order[r])
+            i = int(s_ref[idx])
+            j = int(s_lib[idx])
+
+            if used_q[i] == 1:
+                continue
+
+            seen = False
+            for u in range(used_lib_n):
+                if used_lib_j[u] == j:
+                    seen = True
+                    break
+            if seen:
+                continue
+
+            used_q[i] = 1
+            used_lib_j[used_lib_n] = j
+            used_lib_n += 1
+            dot += float(s_score[idx])
+            n_match += 1
+
+        denom = q_l2 * float(lib_spec_l2[col])
+        if denom > 0.0 and dot > 0.0:
+            out_score[col] = dot / denom
+        out_matches[col] = n_match
+
+    return out_score, out_matches
 
 
-def _row_task_cosine(row_idx):
-    """Compute one CosineFlash row from the shared packed references."""
-    row_idx = int(row_idx)
-    refs = _G_REFS
+# ==================== Row worker (cosine) ====================
+
+def _row_task_cosine(args):
+    """
+    Compute one row (reference spectrum vs all library spectra) of
+    (modified) cosine scores using a fully Numba-accelerated pipeline.
+
+    Steps (per row / reference spectrum)
+    ------------------------------------
+    1. Build candidate (i,j) pairs against the global, sorted library index:
+         - fragment matches around each reference m/z
+         - neutral-loss matches around (precursor_ref - m/z), if enabled
+    2. Group candidates by target library spectrum (column) in CSR-like form
+       using prefix sums (`col_offsets`).
+    3. For each column, greedily select a maximum-weight, non-overlapping
+       subset of pairs (no query or library peak may be used twice),
+       sorting by score (descending) with a tie-break to prefer fragments.
+    4. Normalize by L2 norms to produce cosine / modified cosine.
+
+    Parameters
+    ----------
+    args : tuple
+        (row_index, peaks_array, precursor_mz_or_None)
+    """
+    row_idx, ref_peaks, ref_pmz = args
     lib = _G_LIB
     cfg = _G_CFG
 
-    start = int(refs.spec_offsets[row_idx])
-    end = int(refs.spec_offsets[row_idx + 1])
-    if start >= end:
+    if ref_peaks.size == 0:
         return (
             row_idx,
             np.zeros(lib.n_specs, dtype=lib.dtype),
             np.zeros(lib.n_specs, dtype=np.int32),
         )
 
-    ref_mz = refs.spec_mz[start:end]
-    ref_int = refs.spec_int[start:end]
+    ref_mz = ref_peaks[:, 0]
+    ref_int = ref_peaks[:, 1]
 
-    if refs.spec_l2 is not None:
-        q_l2 = float(refs.spec_l2[row_idx])
-    else:
-        q_l2 = float(np.sqrt(np.sum(ref_int * ref_int, dtype=np.float64)))
-
+    q_l2 = float(np.sqrt(np.sum(ref_int * ref_int, dtype=np.float64)))
     if q_l2 == 0.0:
         return (
             row_idx,
@@ -1365,60 +1496,31 @@ def _row_task_cosine(row_idx):
         )
 
     match_mode = cfg["matching_mode"]
-    do_frag = match_mode in ("fragment", "hybrid")
-    do_nl = match_mode in ("neutral_loss", "hybrid")
+    do_frag = (match_mode == "fragment") or (match_mode == "hybrid")
+    do_nl = (match_mode == "neutral_loss") or (match_mode == "hybrid")
 
-    ref_pmz = float(refs.precursor_mz[row_idx])
-    has_pmz = np.isfinite(ref_pmz)
-    if not has_pmz:
-        ref_pmz = 0.0
+    has_pmz = ref_pmz is not None
+    ref_pmz = float(ref_pmz) if has_pmz else 0.0
 
     tol = float(cfg["tol"])
     use_ppm = bool(cfg["use_ppm"])
     n_cols = int(lib.n_specs)
 
-    empty_mz = np.empty(0, dtype=lib.dtype)
-    empty_idx = np.empty(0, dtype=np.int32)
-    empty_prod = np.empty(0, dtype=np.int64)
-
-    lib_nl_mz = (
-        lib.nl_mz
-        if cfg["compute_nl"] and lib.nl_mz is not None
-        else empty_mz
-    )
-    lib_nl_spec_idx = (
-        lib.nl_spec_idx
-        if cfg["compute_nl"] and lib.nl_spec_idx is not None
-        else empty_idx
-    )
-    lib_nl_product_idx = (
-        lib.nl_product_idx
-        if cfg["compute_nl"] and lib.nl_product_idx is not None
-        else empty_prod
-    )
-
     counts_by_col = _count_candidates_per_col_nb(
-        ref_mz,
-        ref_int,
-        has_pmz,
-        ref_pmz,
+        ref_mz, ref_int, has_pmz, ref_pmz,
         lib.peaks_mz,
         lib.peaks_spec_idx.astype(np.int32, copy=False),
-        lib_nl_mz,
-        lib_nl_spec_idx.astype(np.int32, copy=False),
-        lib_nl_product_idx,
+        (lib.nl_mz if (cfg["compute_nl"] and lib.nl_mz is not None) else np.empty(0, np.float64)),
+        (lib.nl_spec_idx if (cfg["compute_nl"] and lib.nl_spec_idx is not None) else np.empty(0, np.int32)),
+        (lib.nl_product_idx if (cfg["compute_nl"] and lib.nl_product_idx is not None) else np.empty(0, np.int32)),
         lib.precursor_mz.astype(np.float64, copy=False),
-        tol,
-        use_ppm,
-        do_frag,
-        do_nl and cfg["compute_nl"],
-        n_cols,
+        tol, use_ppm, do_frag, (do_nl and cfg["compute_nl"]), n_cols,
     )
 
     col_offsets = np.empty(n_cols + 1, dtype=np.int64)
     col_offsets[0] = 0
-    for col in range(n_cols):
-        col_offsets[col + 1] = col_offsets[col] + counts_by_col[col]
+    for c in range(n_cols):
+        col_offsets[c + 1] = col_offsets[c] + counts_by_col[c]
 
     n_total = int(col_offsets[-1])
     if n_total == 0:
@@ -1426,40 +1528,30 @@ def _row_task_cosine(row_idx):
         out_matches = np.zeros(n_cols, dtype=np.int32)
     else:
         ref_idx, lib_idx, score, is_frag = _fill_candidates_per_col_nb(
-            ref_mz,
-            ref_int,
-            has_pmz,
-            ref_pmz,
+            ref_mz, ref_int,
+            has_pmz, ref_pmz,
             lib.peaks_mz,
             lib.peaks_int,
             lib.peaks_spec_idx.astype(np.int32, copy=False),
-            lib_nl_mz,
-            lib_nl_spec_idx.astype(np.int32, copy=False),
-            lib_nl_product_idx,
+            (lib.nl_mz if (cfg["compute_nl"] and lib.nl_mz is not None) else np.empty(0, np.float64)),
+            (lib.nl_spec_idx if (cfg["compute_nl"] and lib.nl_spec_idx is not None) else np.empty(0, np.int32)),
+            (lib.nl_product_idx if (cfg["compute_nl"] and lib.nl_product_idx is not None) else np.empty(0, np.int32)),
             lib.precursor_mz.astype(np.float64, copy=False),
-            tol,
-            use_ppm,
-            do_frag,
-            do_nl and cfg["compute_nl"],
-            col_offsets,
-            counts_by_col,
+            tol, use_ppm, do_frag, (do_nl and cfg["compute_nl"]),
+            col_offsets, counts_by_col,
         )
 
         out_score64, out_matches = _greedy_scores_and_matches_all_cols_nb(
-            n_cols,
-            ref_mz.shape[0],
+            n_cols, ref_mz.shape[0],
             col_offsets,
-            ref_idx,
-            lib_idx,
-            score,
-            is_frag,
+            ref_idx, lib_idx, score, is_frag,
             lib.spec_l2.astype(np.float64, copy=False),
             q_l2,
         )
         out_score = out_score64.astype(lib.dtype, copy=False)
 
     iden_tol = cfg["iden_tol"]
-    if iden_tol is not None and has_pmz:
+    if (iden_tol is not None) and has_pmz:
         if cfg["iden_use_ppm"]:
             allow = np.abs(lib.precursor_mz - ref_pmz) <= (
                 iden_tol * 1e-6 * 0.5 * (lib.precursor_mz + ref_pmz)

--- a/matchms/similarity/flash_utils.py
+++ b/matchms/similarity/flash_utils.py
@@ -1,21 +1,56 @@
+"""SpectraCollection-native helpers for Flash-based similarities.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
 import numpy as np
-from .spectrum_similarity_functions import filter_noise, filter_peaks_above_precursor
+from numba import njit
 
 
-# ===================== library index =====================
+@dataclass
+class _PreparedSpectra:
+    """Packed, spectrum-major representation after Flash preprocessing.
+
+    Parameters
+    ----------
+    n_specs
+        Number of spectra.
+    spec_offsets
+        CSR-like offsets into ``spec_mz`` and ``spec_int``. Spectrum ``i`` uses
+        ``[spec_offsets[i]:spec_offsets[i + 1])``.
+    spec_mz
+        Preprocessed fragment m/z values concatenated spectrum by spectrum.
+    spec_int
+        Preprocessed fragment intensities aligned with ``spec_mz``.
+    precursor_mz
+        Precursor m/z per spectrum. Missing values are represented by ``NaN``.
+    spec_l2
+        Optional L2 norm per spectrum, used by cosine scoring.
+    dtype
+        Floating-point dtype of the packed arrays.
+    """
+
+    n_specs: int
+    spec_offsets: np.ndarray
+    spec_mz: np.ndarray
+    spec_int: np.ndarray
+    precursor_mz: np.ndarray
+    spec_l2: np.ndarray | None
+    dtype: np.dtype
+
 
 class _LibraryIndex:
-    """
-    Compact container for library views used by Numba row workers.
+    """Compact library views used by the Flash row workers.
 
-    The index stores the same peak information in two layouts:
+    The index stores the preprocessed library in two complementary layouts:
 
-    1) Global m/z-sorted view (used for candidate window searches):
-       - ``peaks_mz``, ``peaks_int``, ``peaks_spec_idx``.
-    2) Spectrum-major contiguous view (used for pairwise one-to-one scans):
-       - ``spec_offsets``, ``spec_mz``, ``spec_int``.
+    - spectrum-major arrays (``spec_offsets``, ``spec_mz``, ``spec_int``), used
+      for exact one-to-one pair scans;
+    - globally m/z-sorted arrays (``peaks_mz``, ``peaks_int``,
+      ``peaks_spec_idx``), used for fast candidate discovery.
 
-    All arrays are treated as read-only in worker processes.
+    Optional neutral-loss arrays are built for ``neutral_loss`` and ``hybrid``
+    matching modes.
 
     Attributes
     ----------
@@ -66,317 +101,485 @@ class _LibraryIndex:
         self.spec_int = None
         self.spec_l2 = None
         self.precursor_mz = None
-        self.dtype = dtype
+        self.dtype = np.dtype(dtype)
 
-def _build_library_index(processed_peaks_list: list[np.ndarray],
-                         precursor_mz_list: list[float | None],
-                         compute_neutral_loss: bool = False,
-                         compute_l2_norm: bool = False,
-                         dtype: np.dtype = np.float32) -> _LibraryIndex:
-    """
-    Build shared library views over all query spectra peaks.
 
-    Output layout
-    -------------
-    The returned :class:`_LibraryIndex` stores two complementary product-peak views:
+def _extract_precursor_mz(collection, dtype: np.dtype) -> np.ndarray:
+    """Return precursor m/z metadata as a dense floating-point array."""
+    n_specs = len(collection)
+    precursor_mz = np.full(n_specs, np.nan, dtype=dtype)
 
-    - Global m/z-sorted arrays (``peaks_mz``, ``peaks_int``, ``peaks_spec_idx``)
-      for fast tolerance-window candidate lookup.
-    - Spectrum-major contiguous arrays (``spec_offsets``, ``spec_mz``, ``spec_int``)
-      for one-to-one per-spectrum matching.
+    metadata = collection.metadata
+    if "precursor_mz" not in metadata.columns:
+        return precursor_mz
 
-    If ``compute_neutral_loss`` is True, neutral-loss arrays are created from
-    ``precursor_mz - product_mz`` for spectra with known precursors and sorted by NL m/z.
-    ``nl_product_idx`` maps each NL entry back to its global product-peak position.
+    series = metadata["precursor_mz"]
+    try:
+        values = series.to_numpy(dtype=float, na_value=np.nan)
+    except (TypeError, ValueError):
+        values = np.empty(n_specs, dtype=np.float64)
+        for i, value in enumerate(series):
+            try:
+                values[i] = float(value)
+            except (TypeError, ValueError):
+                values[i] = np.nan
 
-    Parameters
-    ----------
-    processed_peaks_list : list of ndarray
-        Each entry is a 2D array of shape (n_peaks, 2) with columns [mz, intensity].
-        May be empty (shape (0, 2)) if all peaks were filtered away.
-    precursor_mz_list : list of float or None
-        Precursor m/z for each spectrum (if known).
-    compute_neutral_loss : bool
-        If True, build neutral-loss arrays used by hybrid entropy and modified cosine.
-    compute_l2_norm : bool
-        If True, precompute the L2 norm of each spectrum's intensities (for cosine or modified cosine).
-    dtype : np.dtype
-        Float dtype for all arrays. Default is np.float32.
+    precursor_mz[:] = np.asarray(values, dtype=dtype)
+    return precursor_mz
 
-    Returns
-    -------
-    _LibraryIndex
-        Compact structure used by row workers to accumulate scores quickly.
-        Empty inputs still return fully initialized arrays (often size 0), with
-        ``spec_offsets`` always shaped ``(n_specs + 1,)``.
-    """
-    idx = _LibraryIndex(dtype)
-    idx.n_specs = len(processed_peaks_list)
 
-    # Precursor array
-    prec = np.full(idx.n_specs, np.nan, dtype=dtype)
-    for k, pmz in enumerate(precursor_mz_list):
-        if pmz is not None:
-            prec[k] = pmz
-    idx.precursor_mz = prec
+def _row_ids_from_offsets(offsets: np.ndarray, dtype=np.int32) -> np.ndarray:
+    """Expand CSR-like row offsets to one row id per stored peak."""
+    counts = np.diff(offsets)
+    if int(offsets[-1]) > (2**31 - 1):
+        dtype = np.int64
+    return np.repeat(np.arange(counts.size, dtype=dtype), counts)
 
-    # Preallocate l2 norm array if needed (for cosine or modified cosine)
-    if compute_l2_norm:
-        spec_l2 = np.zeros(idx.n_specs, dtype=dtype)
 
-    # Concatenate all peaks
-    counts = np.array([p.shape[0] for p in processed_peaks_list], dtype=np.int64)
-    idx.spec_offsets = np.zeros(idx.n_specs + 1, dtype=np.int64)
-    if idx.n_specs > 0:
-        idx.spec_offsets[1:] = np.cumsum(counts, dtype=np.int64)
-    n_peaks = int(idx.spec_offsets[-1])
-    if n_peaks > (2**31 - 1):
-        int_dtype = np.int64
-        print(f"Too many total peaks ({n_peaks}) to build index using 32-bit integers (now using 64-bit integers).")
-    else:
-        int_dtype = np.int32 
+def _rebuild_offsets(spec_idx: np.ndarray, n_specs: int) -> np.ndarray:
+    """Build spectrum-major offsets from ordered spectrum ids."""
+    counts = np.bincount(spec_idx, minlength=n_specs).astype(np.int64, copy=False)
+    offsets = np.empty(n_specs + 1, dtype=np.int64)
+    offsets[0] = 0
+    offsets[1:] = np.cumsum(counts, dtype=np.int64)
+    return offsets
 
-    # Return empty arrays if no peaks
-    if n_peaks == 0:
-        idx.peaks_mz = np.zeros(0, dtype=dtype)
-        idx.peaks_int = np.zeros(0, dtype=dtype)
-        idx.peaks_spec_idx = np.zeros(0, dtype=int_dtype)
-        idx.spec_mz = np.zeros(0, dtype=dtype)
-        idx.spec_int = np.zeros(0, dtype=dtype)
-        if compute_neutral_loss:
-            idx.nl_mz = np.zeros(0, dtype=dtype)
-            idx.nl_int = np.zeros(0, dtype=dtype)
-            idx.nl_spec_idx = np.zeros(0, dtype=int_dtype)
-            idx.nl_product_idx = np.zeros(0, dtype=int_dtype)
-        if compute_l2_norm:
-            idx.spec_l2 = spec_l2
-        return idx
 
-    mz_flat = np.empty(n_peaks, dtype=dtype)
-    int_flat = np.empty(n_peaks, dtype=dtype)
-    spec_flat = np.empty(n_peaks, dtype=int_dtype)
+def _entropy_weight_packed(
+    intensities: np.ndarray,
+    spec_idx: np.ndarray,
+    n_specs: int,
+    dtype: np.dtype,
+) -> np.ndarray:
+    """Apply Li/Fiehn entropy weighting independently to all packed spectra."""
+    if intensities.size == 0:
+        return intensities.astype(dtype, copy=False)
+
+    totals = np.bincount(
+        spec_idx,
+        weights=intensities.astype(np.float64, copy=False),
+        minlength=n_specs,
+    )
+
+    per_peak_totals = totals[spec_idx]
+    p = np.zeros(intensities.shape[0], dtype=dtype)
+    valid_total = per_peak_totals > 0.0
+    p[valid_total] = (
+        intensities[valid_total] / per_peak_totals[valid_total]
+    ).astype(dtype, copy=False)
+
+    entropy_terms = np.zeros(p.shape[0], dtype=np.float64)
+    positive = p > 0.0
+    entropy_terms[positive] = -(
+        p[positive].astype(np.float64, copy=False)
+        * np.log(p[positive]).astype(np.float64, copy=False)
+    )
+    entropy = np.bincount(
+        spec_idx,
+        weights=entropy_terms,
+        minlength=n_specs,
+    )
+
+    weight = np.where(entropy >= 3.0, 1.0, 0.25 + 0.25 * entropy)
+    return np.power(intensities, weight[spec_idx]).astype(dtype, copy=False)
+
+
+@njit(cache=True, nogil=True)
+def _merge_packed_rows_numba(
+    mz: np.ndarray,
+    intensities: np.ndarray,
+    offsets: np.ndarray,
+    max_delta_da: float,
+):
+    """Merge nearby peaks row-wise using the current Flash centroid rule."""
+    n_specs = offsets.shape[0] - 1
+    out_mz = np.empty_like(mz)
+    out_int = np.empty_like(intensities)
+    out_offsets = np.empty(n_specs + 1, dtype=np.int64)
+    out_offsets[0] = 0
 
     write = 0
-    for spec_id, peaks in enumerate(processed_peaks_list):
-        n = peaks.shape[0]
-        if n == 0:
+    for row in range(n_specs):
+        start = int(offsets[row])
+        end = int(offsets[row + 1])
+
+        if start >= end:
+            out_offsets[row + 1] = write
             continue
-        mz_flat[write:write+n] = peaks[:, 0]
-        int_flat[write:write+n] = peaks[:, 1]
-        spec_flat[write:write+n] = spec_id
-        if compute_l2_norm:
-            spec_l2[spec_id] = np.sqrt(np.sum((peaks[:, 1]).astype(np.float64)**2, dtype=np.float64)).astype(dtype)
-        write += n
 
-    idx.spec_mz = mz_flat.copy()
-    idx.spec_int = int_flat.copy()
+        current_mz = mz[start]
+        current_int = intensities[start]
 
-    # Sort by m/z
-    order = np.argsort(mz_flat)
-    idx.peaks_mz = mz_flat[order]
-    idx.peaks_int = int_flat[order]
+        for k in range(start + 1, end):
+            if (mz[k] - current_mz) <= max_delta_da:
+                total = current_int + intensities[k]
+                if total > 0.0:
+                    current_mz = (
+                        current_mz * current_int + mz[k] * intensities[k]
+                    ) / total
+                    current_int = total
+                else:
+                    current_mz = mz[k]
+                    current_int = 0.0
+            else:
+                out_mz[write] = current_mz
+                out_int[write] = current_int
+                write += 1
+                current_mz = mz[k]
+                current_int = intensities[k]
+
+        out_mz[write] = current_mz
+        out_int[write] = current_int
+        write += 1
+        out_offsets[row + 1] = write
+
+    return out_mz[:write], out_int[:write], out_offsets
+
+
+def _compute_l2_by_row(
+    intensities: np.ndarray,
+    offsets: np.ndarray,
+    dtype: np.dtype,
+) -> np.ndarray:
+    """Return one L2 norm per packed spectrum."""
+    n_specs = offsets.shape[0] - 1
+    out = np.zeros(n_specs, dtype=dtype)
+
+    for i in range(n_specs):
+        start = offsets[i]
+        end = offsets[i + 1]
+
+        row = intensities[start:end]
+
+        out[i] = np.sqrt(
+            np.sum(
+                row * row,
+                dtype=np.float64,
+            )
+        )
+
+    return out
+
+
+def _prepare_collection(
+    collection,
+    *,
+    intensity_power: float = 1.0,
+    remove_precursor: bool = True,
+    offset_to_precursor: float = -1.6,
+    noise_cutoff: float | None = 0.01,
+    normalize_to_half: bool = False,
+    merge_within_da: float = 0.0,
+    weighing_type: str = "cosine",
+    compute_l2_norm: bool = False,
+    dtype: np.dtype = np.float64,
+) -> _PreparedSpectra:
+    """Prepare an entire SpectraCollection directly from its CSR fragment store.
+
+    The preprocessing order intentionally mirrors ``flash_utils._clean_and_weight``:
+
+    1. remove peaks above ``precursor_mz + offset_to_precursor``;
+    2. remove peaks below the row-wise relative noise cutoff;
+    3. apply entropy weighting or cosine intensity power;
+    4. optionally merge nearby peaks by intensity-weighted centroid;
+    5. optionally normalize each spectrum to total intensity 0.5.
+
+    No ``Spectrum`` objects are reconstructed.
+    """
+    dtype = np.dtype(dtype)
+    if weighing_type not in ("cosine", "entropy"):
+        raise ValueError(f"Score type '{weighing_type}' not recognized.")
+
+    fragments = collection.fragments
+    if not hasattr(fragments, "array") or not hasattr(fragments, "bin_to_mz"):
+        raise TypeError(
+            "SpectraCollection-native Flash scoring currently requires a fragment "
+            "backend exposing 'array' and 'bin_to_mz' (CSRFragmentCollection)."
+        )
+
+    csr = fragments.array
+    if not csr.has_sorted_indices:
+        csr = csr.sorted_indices()
+
+    n_specs = len(collection)
+    precursor_mz = _extract_precursor_mz(collection, dtype)
+
+    if csr.nnz == 0:
+        offsets = np.zeros(n_specs + 1, dtype=np.int64)
+        empty = np.zeros(0, dtype=dtype)
+        spec_l2 = np.zeros(n_specs, dtype=dtype) if compute_l2_norm else None
+        return _PreparedSpectra(
+            n_specs=n_specs,
+            spec_offsets=offsets,
+            spec_mz=empty,
+            spec_int=empty.copy(),
+            precursor_mz=precursor_mz,
+            spec_l2=spec_l2,
+            dtype=dtype,
+        )
+
+    raw_offsets = np.asarray(csr.indptr, dtype=np.int64)
+    spec_idx = _row_ids_from_offsets(raw_offsets)
+    mz = np.asarray(fragments.bin_to_mz(csr.indices), dtype=dtype)
+    intensities = np.asarray(csr.data, dtype=dtype)
+
+    keep = np.ones(mz.shape[0], dtype=bool)
+
+    # 1) Precursor-region removal. Missing precursor values leave the row unchanged.
+    if remove_precursor:
+        peak_pmz = precursor_mz[spec_idx]
+        have_pmz = np.isfinite(peak_pmz)
+        keep &= (~have_pmz) | (mz <= peak_pmz + offset_to_precursor)
+
+    if not np.all(keep):
+        mz = mz[keep]
+        intensities = intensities[keep]
+        spec_idx = spec_idx[keep]
+
+    if mz.size == 0:
+        offsets = np.zeros(n_specs + 1, dtype=np.int64)
+        spec_l2 = np.zeros(n_specs, dtype=dtype) if compute_l2_norm else None
+        return _PreparedSpectra(
+            n_specs=n_specs,
+            spec_offsets=offsets,
+            spec_mz=np.zeros(0, dtype=dtype),
+            spec_int=np.zeros(0, dtype=dtype),
+            precursor_mz=precursor_mz,
+            spec_l2=spec_l2,
+            dtype=dtype,
+        )
+
+    # 2) Relative noise filtering, after precursor removal
+    if noise_cutoff and noise_cutoff > 0.0:
+        row_max = np.zeros(n_specs, dtype=dtype)
+        np.maximum.at(row_max, spec_idx, intensities)
+        keep = intensities >= row_max[spec_idx] * float(noise_cutoff)
+        mz = mz[keep]
+        intensities = intensities[keep]
+        spec_idx = spec_idx[keep]
+
+    if mz.size == 0:
+        offsets = np.zeros(n_specs + 1, dtype=np.int64)
+        spec_l2 = np.zeros(n_specs, dtype=dtype) if compute_l2_norm else None
+        return _PreparedSpectra(
+            n_specs=n_specs,
+            spec_offsets=offsets,
+            spec_mz=np.zeros(0, dtype=dtype),
+            spec_int=np.zeros(0, dtype=dtype),
+            precursor_mz=precursor_mz,
+            spec_l2=spec_l2,
+            dtype=dtype,
+        )
+
+    # 3) Score-specific intensity weighting.
+    if weighing_type == "entropy":
+        intensities = _entropy_weight_packed(
+            intensities,
+            spec_idx,
+            n_specs,
+            dtype,
+        )
+    elif intensity_power != 1.0:
+        intensities = np.power(intensities, intensity_power).astype(dtype, copy=False)
+
+    offsets = _rebuild_offsets(spec_idx, n_specs)
+
+    # 4) Optional row-local peak merging. This is the only inherently segmented
+    # preprocessing step; it still works directly on packed arrays without Spectrum objects.
+    if merge_within_da and merge_within_da > 0.0 and mz.size > 1:
+        mz, intensities, offsets = _merge_packed_rows_numba(
+            mz,
+            intensities,
+            offsets,
+            float(merge_within_da),
+        )
+
+    # 5) Optional row-wise normalization to total intensity 0.5.
+    if normalize_to_half and intensities.size > 0:
+        spec_idx = _row_ids_from_offsets(offsets)
+        row_sum = np.bincount(
+            spec_idx,
+            weights=intensities.astype(np.float64, copy=False),
+            minlength=n_specs,
+        )
+        scale = np.zeros(n_specs, dtype=np.float64)
+        nonzero = row_sum > 0.0
+        scale[nonzero] = 0.5 / row_sum[nonzero]
+        intensities = (
+            intensities * scale[spec_idx]
+        ).astype(dtype, copy=False)
+
+    spec_l2 = (
+        _compute_l2_by_row(intensities, offsets, dtype)
+        if compute_l2_norm
+        else None
+    )
+
+    return _PreparedSpectra(
+        n_specs=n_specs,
+        spec_offsets=np.asarray(offsets, dtype=np.int64),
+        spec_mz=np.asarray(mz, dtype=dtype),
+        spec_int=np.asarray(intensities, dtype=dtype),
+        precursor_mz=precursor_mz,
+        spec_l2=spec_l2,
+        dtype=dtype,
+    )
+
+
+def _build_library_index_from_prepared(
+    prepared: _PreparedSpectra,
+    *,
+    compute_neutral_loss: bool = False,
+    compute_l2_norm: bool = False,
+) -> _LibraryIndex:
+    """Build the Flash search index directly from packed prepared spectra."""
+    idx = _LibraryIndex(prepared.dtype)
+    idx.n_specs = prepared.n_specs
+    idx.precursor_mz = prepared.precursor_mz
+    idx.spec_offsets = prepared.spec_offsets
+    idx.spec_mz = prepared.spec_mz
+    idx.spec_int = prepared.spec_int
+
+    n_peaks = prepared.spec_mz.shape[0]
+    int_dtype = np.int64 if n_peaks > (2**31 - 1) else np.int32
+
+    if compute_l2_norm:
+        if prepared.spec_l2 is None:
+            idx.spec_l2 = _compute_l2_by_row(
+                prepared.spec_int,
+                prepared.spec_offsets,
+                prepared.dtype,
+            )
+        else:
+            idx.spec_l2 = prepared.spec_l2
+
+    if n_peaks == 0:
+        idx.peaks_mz = np.zeros(0, dtype=prepared.dtype)
+        idx.peaks_int = np.zeros(0, dtype=prepared.dtype)
+        idx.peaks_spec_idx = np.zeros(0, dtype=int_dtype)
+        if compute_neutral_loss:
+            idx.nl_mz = np.zeros(0, dtype=prepared.dtype)
+            idx.nl_int = np.zeros(0, dtype=prepared.dtype)
+            idx.nl_spec_idx = np.zeros(0, dtype=int_dtype)
+            idx.nl_product_idx = np.zeros(0, dtype=np.int64)
+        return idx
+
+    spec_flat = _row_ids_from_offsets(prepared.spec_offsets, dtype=int_dtype)
+
+    # Global m/z-sorted product view for search windows.
+    order = np.argsort(prepared.spec_mz)
+    idx.peaks_mz = prepared.spec_mz[order]
+    idx.peaks_int = prepared.spec_int[order]
     idx.peaks_spec_idx = spec_flat[order]
+
+    # Map spectrum-major peak positions to positions in the globally sorted arrays.
     product_pos = np.empty(n_peaks, dtype=np.int64)
     product_pos[order] = np.arange(n_peaks, dtype=np.int64)
 
-    # Neutral-loss view (if requested)
     if compute_neutral_loss:
-        pmz_per_peak = idx.precursor_mz[spec_flat]
-        have_pmz = ~np.isnan(pmz_per_peak)  # catch cases without precursor m/z
+        pmz_per_peak = prepared.precursor_mz[spec_flat]
+        have_pmz = np.isfinite(pmz_per_peak)
         src_idx = np.nonzero(have_pmz)[0]
+
         if src_idx.size == 0:
-            idx.nl_mz = np.zeros(0, dtype=dtype)
-            idx.nl_int = np.zeros(0, dtype=dtype)
+            idx.nl_mz = np.zeros(0, dtype=prepared.dtype)
+            idx.nl_int = np.zeros(0, dtype=prepared.dtype)
             idx.nl_spec_idx = np.zeros(0, dtype=int_dtype)
-            idx.nl_product_idx = np.zeros(0, dtype=int_dtype)
+            idx.nl_product_idx = np.zeros(0, dtype=np.int64)
         else:
-            nl_mz = (pmz_per_peak[src_idx] - mz_flat[src_idx]).astype(dtype, copy=False)
-            nl_int = int_flat[src_idx]
+            nl_mz = (
+                pmz_per_peak[src_idx] - prepared.spec_mz[src_idx]
+            ).astype(prepared.dtype, copy=False)
+            nl_int = prepared.spec_int[src_idx]
             nl_spec = spec_flat[src_idx]
             nl_prod = product_pos[src_idx]
 
-            # Sort neutral-losses by m/z
             order_nl = np.argsort(nl_mz)
             idx.nl_mz = nl_mz[order_nl]
             idx.nl_int = nl_int[order_nl]
             idx.nl_spec_idx = nl_spec[order_nl]
             idx.nl_product_idx = nl_prod[order_nl]
 
-    if compute_l2_norm:
-        idx.spec_l2 = spec_l2
-
     return idx
 
 
-# ===================== preprocessing =====================
+# -----------------------------------------------------------------------------
+# Spectrum-oriented helpers retained for pair-level compatibility and direct
+# comparison with the old spectrum based implementation.
+# -----------------------------------------------------------------------------
 
 def _entropy_weight(intensities: np.ndarray, dtype: np.dtype) -> np.ndarray:
-    """
-    Apply entropy-based weighting to intensities as described by Li & Fiehn (2023).
-    """
-    total = float(intensities.sum(dtype=np.float64))  # sum in high precision for stability
+    """Apply entropy-based weighting to one intensity array."""
+    total = float(intensities.sum(dtype=np.float64))
     if total <= 0.0:
         return intensities.astype(dtype, copy=False)
+
     p = intensities / total
     with np.errstate(divide="ignore", invalid="ignore"):
         logp = np.zeros_like(p, dtype=dtype)
         mask = p > 0
-        # Keep the weighting rule aligned with ms_entropy (natural log entropy).
         logp[mask] = np.log(p[mask]).astype(dtype, copy=False)
 
-    # Compute spectral entropy S
-    S = float((-p * logp).sum(dtype=np.float64))
-
-    # Compute weight w (used for scaling)
-    w = 1.0 if S >= 3.0 else (0.25 + 0.25 * S)
-    return np.power(intensities, w).astype(dtype, copy=False)
+    entropy = float((-p * logp).sum(dtype=np.float64))
+    weight = 1.0 if entropy >= 3.0 else (0.25 + 0.25 * entropy)
+    return np.power(intensities, weight).astype(dtype, copy=False)
 
 
 def _clean_and_weight(
-        peaks: np.ndarray,
-        precursor_mz: float | None,
-        remove_precursor: bool,
-        offset_to_precursor: float,
-        noise_cutoff: float,
-        normalize_to_half: bool,
-        merge_within_da: float,
-        weighing_type: str,
-        intensity_power: float = 1.0,
-        dtype: np.dtype = np.float64
-        ) -> np.ndarray:
-    """
-    Apply the Flash preprocessing rules to a (mz, intensity) peak list.
-
-    Steps:
-      1) (Optional) Remove all peaks above (precursor_mz + offset_to_precursor).
-      2) (Optional) Remove noise: keep peaks with intensity >= noise_cutoff * max(intensity).
-      3) (Optional) Entropy-weight intensities (Li & Fiehn): raise intensities by a power derived 
-         from spectrum entropy.
-      4) (Optional) Merge peaks within a small m/z window by intensity-weighted centroid.
-      5) (Optional) normalize intensities to sum to 0.5 (recommended in the paper).
-
-    Parameters
-    ----------
-    peaks : ndarray of shape (N, 2)
-        Column 0 = m/z, column 1 = intensity.
-    precursor_mz : float or None
-        Precursor m/z for the spectrum (if known).
-    remove_precursor : bool
-        If True, remove the precursor and near-precursor peaks.
-    offset_to_precursor : float
-        Size (Da) to cut below the precursor (remove m/z > precursor_mz + offset_to_precursor).
-    noise_cutoff : float
-        Fraction of max intensity to keep (0.01 means keep peaks >= 1% of max).
-    normalize_to_half : bool
-        If True, scale intensities so their sum is 0.5.
-    merge_within_da : float
-        If > 0, merge peaks that are within this m/z distance.
-    weighing_type : str
-        One of "cosine" or "entropy". Fragment intensities will be weighted accordingly.
-        for "cosine", weighing is only changed if intensity_power != 1.0.
-    intensity_power : float
-        The power to raise intensity to in the cosine function. The default is 1.
-    dtype : np.dtype
-        Float dtype for outputs. Default is np.float64. TODO: should not be handled by this function?
-
-    Returns
-    -------
-    ndarray
-        Cleaned array with columns [mz, intensity], dtype=dtype, sorted by m/z.
-        May be empty with shape (0, 2) if everything is filtered away.
-    """
+    peaks: np.ndarray,
+    precursor_mz: float | None,
+    remove_precursor: bool,
+    offset_to_precursor: float,
+    noise_cutoff: float,
+    normalize_to_half: bool,
+    merge_within_da: float,
+    weighing_type: str,
+    intensity_power: float = 1.0,
+    dtype: np.dtype = np.float64,
+) -> np.ndarray:
+    """Apply the existing Flash preprocessing rules to a single peak array."""
+    dtype = np.dtype(dtype)
     if peaks.size == 0:
         return np.empty((0, 2), dtype=dtype)
 
-    mz = _as_dtype(peaks[:, 0], dtype)
-    intensities = _as_dtype(peaks[:, 1], dtype)
+    mz = np.asarray(peaks[:, 0], dtype=dtype)
+    intensities = np.asarray(peaks[:, 1], dtype=dtype)
 
-    # (optional) remove precursor and nearby peaks
-    if remove_precursor and (precursor_mz is not None):
-        mz, intensities = filter_peaks_above_precursor(
-            mz,
-            intensities,
-            precursor_mz,
-            offset_to_precursor,
-        )
+    if remove_precursor and precursor_mz is not None:
+        keep = mz <= float(precursor_mz) + float(offset_to_precursor)
+        mz = mz[keep]
+        intensities = intensities[keep]
         if mz.size == 0:
             return np.empty((0, 2), dtype=dtype)
 
-    # (optional) remove noise peaks below a fraction of max intensity
     if noise_cutoff and noise_cutoff > 0.0:
-        mz, intensities = filter_noise(mz, intensities, noise_cutoff)
+        threshold = intensities.max() * float(noise_cutoff)
+        keep = intensities >= threshold
+        mz = mz[keep]
+        intensities = intensities[keep]
         if mz.size == 0:
             return np.empty((0, 2), dtype=dtype)
 
-    # (optional) entropy-weight intensities (for flash entropy score)
     if weighing_type == "entropy":
         intensities = _entropy_weight(intensities, dtype)
     elif weighing_type == "cosine":
         if intensity_power != 1.0:
-            # Apply power-based weighing to intensities (for cosine or modified cosine)
-            intensities = np.power(intensities, intensity_power)
+            intensities = np.power(intensities, intensity_power).astype(dtype, copy=False)
     else:
         raise ValueError(f"Score type '{weighing_type}' not recognized.")
 
-    # (optional) merge nearby peaks by intensity-weighted centroid
     if merge_within_da and merge_within_da > 0.0 and mz.size > 1:
-        peaks = _merge_within(np.column_stack((mz, intensities)), merge_within_da)
-        mz, intensities = peaks[:, 0], peaks[:, 1]
+        offsets = np.array([0, mz.size], dtype=np.int64)
+        mz, intensities, _ = _merge_packed_rows_numba(
+            mz,
+            intensities,
+            offsets,
+            float(merge_within_da),
+        )
 
-    # (optional) normalize intensities to sum to 0.5
     if normalize_to_half:
-        sum_intensities = intensities.sum(dtype=np.float64)
-        if sum_intensities > 0.0:
-            intensities = (intensities * (0.5 / sum_intensities)).astype(dtype, copy=False)
+        total = intensities.sum(dtype=np.float64)
+        if total > 0.0:
+            intensities = (intensities * (0.5 / total)).astype(dtype, copy=False)
 
     return np.column_stack((mz, intensities))
-
-
-# ===================== smaller helper functions =====================
-
-def _as_dtype(a: np.ndarray, dtype: np.dtype) -> np.ndarray:
-    if a.dtype == dtype:
-        return a.astype(dtype, copy=False) 
-    return a.astype(dtype, copy=True)
-
-
-def _merge_within(
-        peaks: np.ndarray,
-        max_delta_da: float) -> np.ndarray:
-    """
-    Merges peaks within `max_delta_da` of each other by intensity-weighted averaging.
-    
-    Parameters
-    ---------- 
-    peaks : np.ndarray
-        2D array of shape (n_peaks, 2) with m/z values in first column and intensities in second column.
-    max_delta_da : float
-        Maximum difference in m/z values to consider peaks as the same (in Dalton).
-    """
-    if peaks.shape[0] <= 1 or max_delta_da <= 0.0:
-        return peaks
-    mz = peaks[:, 0]
-    intensities = peaks[:, 1]
-    new_mz = []
-    new_int = []
-    current_mz = mz[0]
-    current_int = intensities[0]
-    for k in range(1, mz.shape[0]):
-        if (mz[k] - current_mz) <= max_delta_da:
-            total = current_int + intensities[k]
-            if total > 0:
-                current_mz = (current_mz * current_int + mz[k] * intensities[k]) / total
-                current_int = total
-            else:
-                current_mz = mz[k]
-                current_int = 0.0
-        else:
-            new_mz.append(current_mz)
-            new_int.append(current_int)
-            current_mz = mz[k]
-            current_int = intensities[k]
-    new_mz.append(current_mz)
-    new_int.append(current_int)
-    out = np.column_stack((np.array(new_mz, dtype=mz.dtype),
-                           np.array(new_int, dtype=intensities.dtype)))
-    return out

--- a/matchms/similarity/flash_utils_spectrum_list.py
+++ b/matchms/similarity/flash_utils_spectrum_list.py
@@ -1,0 +1,382 @@
+import numpy as np
+from .spectrum_similarity_functions import filter_noise, filter_peaks_above_precursor
+
+
+# ===================== library index =====================
+
+class _LibraryIndex:
+    """
+    Compact container for library views used by Numba row workers.
+
+    The index stores the same peak information in two layouts:
+
+    1) Global m/z-sorted view (used for candidate window searches):
+       - ``peaks_mz``, ``peaks_int``, ``peaks_spec_idx``.
+    2) Spectrum-major contiguous view (used for pairwise one-to-one scans):
+       - ``spec_offsets``, ``spec_mz``, ``spec_int``.
+
+    All arrays are treated as read-only in worker processes.
+
+    Attributes
+    ----------
+    n_specs : int
+        Number of spectra in the library.
+    peaks_mz : np.ndarray[dtype]
+        Product (fragment) m/z values for all spectra, globally sorted ascending.
+    peaks_int : np.ndarray[dtype]
+        Intensities aligned 1:1 with ``peaks_mz``.
+    peaks_spec_idx : np.ndarray[int32 or int64]
+        Source spectrum id for each entry in ``peaks_mz``.
+    spec_offsets : np.ndarray[int64]
+        Prefix offsets into spectrum-major arrays. Slice for spectrum ``i`` is
+        ``[spec_offsets[i]:spec_offsets[i + 1])``.
+        Invariants: ``len(spec_offsets) == n_specs + 1``, ``spec_offsets[0] == 0``,
+        ``spec_offsets[-1] == total number of peaks``.
+    spec_mz : np.ndarray[dtype]
+        Product m/z values concatenated spectrum-by-spectrum (not globally sorted).
+    spec_int : np.ndarray[dtype]
+        Intensities aligned 1:1 with ``spec_mz``.
+    nl_mz : np.ndarray[dtype] or None
+        Neutral-loss m/z values, globally sorted ascending (only when requested).
+    nl_int : np.ndarray[dtype] or None
+        Intensities aligned 1:1 with ``nl_mz``.
+    nl_spec_idx : np.ndarray[int32 or int64] or None
+        Source spectrum id for each entry in ``nl_mz``.
+    nl_product_idx : np.ndarray[int64] or None
+        For each NL entry, index back into global product arrays
+        (``peaks_mz`` / ``peaks_int``). Used for hybrid de-duplication rules.
+    spec_l2 : np.ndarray[dtype] or None
+        Optional per-spectrum L2 norm of product intensities (cosine paths).
+    precursor_mz : np.ndarray[dtype]
+        Precursor m/z per spectrum. Unknown values are stored as ``NaN``.
+    dtype : np.dtype
+        Floating-point dtype used for all float arrays.
+    """
+    def __init__(self, dtype: np.dtype = np.float32):
+        self.n_specs = 0
+        self.peaks_mz = None
+        self.peaks_int = None
+        self.peaks_spec_idx = None
+        self.nl_mz = None
+        self.nl_int = None
+        self.nl_spec_idx = None
+        self.nl_product_idx = None
+        self.spec_offsets = None
+        self.spec_mz = None
+        self.spec_int = None
+        self.spec_l2 = None
+        self.precursor_mz = None
+        self.dtype = dtype
+
+def _build_library_index(processed_peaks_list: list[np.ndarray],
+                         precursor_mz_list: list[float | None],
+                         compute_neutral_loss: bool = False,
+                         compute_l2_norm: bool = False,
+                         dtype: np.dtype = np.float32) -> _LibraryIndex:
+    """
+    Build shared library views over all query spectra peaks.
+
+    Output layout
+    -------------
+    The returned :class:`_LibraryIndex` stores two complementary product-peak views:
+
+    - Global m/z-sorted arrays (``peaks_mz``, ``peaks_int``, ``peaks_spec_idx``)
+      for fast tolerance-window candidate lookup.
+    - Spectrum-major contiguous arrays (``spec_offsets``, ``spec_mz``, ``spec_int``)
+      for one-to-one per-spectrum matching.
+
+    If ``compute_neutral_loss`` is True, neutral-loss arrays are created from
+    ``precursor_mz - product_mz`` for spectra with known precursors and sorted by NL m/z.
+    ``nl_product_idx`` maps each NL entry back to its global product-peak position.
+
+    Parameters
+    ----------
+    processed_peaks_list : list of ndarray
+        Each entry is a 2D array of shape (n_peaks, 2) with columns [mz, intensity].
+        May be empty (shape (0, 2)) if all peaks were filtered away.
+    precursor_mz_list : list of float or None
+        Precursor m/z for each spectrum (if known).
+    compute_neutral_loss : bool
+        If True, build neutral-loss arrays used by hybrid entropy and modified cosine.
+    compute_l2_norm : bool
+        If True, precompute the L2 norm of each spectrum's intensities (for cosine or modified cosine).
+    dtype : np.dtype
+        Float dtype for all arrays. Default is np.float32.
+
+    Returns
+    -------
+    _LibraryIndex
+        Compact structure used by row workers to accumulate scores quickly.
+        Empty inputs still return fully initialized arrays (often size 0), with
+        ``spec_offsets`` always shaped ``(n_specs + 1,)``.
+    """
+    idx = _LibraryIndex(dtype)
+    idx.n_specs = len(processed_peaks_list)
+
+    # Precursor array
+    prec = np.full(idx.n_specs, np.nan, dtype=dtype)
+    for k, pmz in enumerate(precursor_mz_list):
+        if pmz is not None:
+            prec[k] = pmz
+    idx.precursor_mz = prec
+
+    # Preallocate l2 norm array if needed (for cosine or modified cosine)
+    if compute_l2_norm:
+        spec_l2 = np.zeros(idx.n_specs, dtype=dtype)
+
+    # Concatenate all peaks
+    counts = np.array([p.shape[0] for p in processed_peaks_list], dtype=np.int64)
+    idx.spec_offsets = np.zeros(idx.n_specs + 1, dtype=np.int64)
+    if idx.n_specs > 0:
+        idx.spec_offsets[1:] = np.cumsum(counts, dtype=np.int64)
+    n_peaks = int(idx.spec_offsets[-1])
+    if n_peaks > (2**31 - 1):
+        int_dtype = np.int64
+        print(f"Too many total peaks ({n_peaks}) to build index using 32-bit integers (now using 64-bit integers).")
+    else:
+        int_dtype = np.int32 
+
+    # Return empty arrays if no peaks
+    if n_peaks == 0:
+        idx.peaks_mz = np.zeros(0, dtype=dtype)
+        idx.peaks_int = np.zeros(0, dtype=dtype)
+        idx.peaks_spec_idx = np.zeros(0, dtype=int_dtype)
+        idx.spec_mz = np.zeros(0, dtype=dtype)
+        idx.spec_int = np.zeros(0, dtype=dtype)
+        if compute_neutral_loss:
+            idx.nl_mz = np.zeros(0, dtype=dtype)
+            idx.nl_int = np.zeros(0, dtype=dtype)
+            idx.nl_spec_idx = np.zeros(0, dtype=int_dtype)
+            idx.nl_product_idx = np.zeros(0, dtype=int_dtype)
+        if compute_l2_norm:
+            idx.spec_l2 = spec_l2
+        return idx
+
+    mz_flat = np.empty(n_peaks, dtype=dtype)
+    int_flat = np.empty(n_peaks, dtype=dtype)
+    spec_flat = np.empty(n_peaks, dtype=int_dtype)
+
+    write = 0
+    for spec_id, peaks in enumerate(processed_peaks_list):
+        n = peaks.shape[0]
+        if n == 0:
+            continue
+        mz_flat[write:write+n] = peaks[:, 0]
+        int_flat[write:write+n] = peaks[:, 1]
+        spec_flat[write:write+n] = spec_id
+        if compute_l2_norm:
+            spec_l2[spec_id] = np.sqrt(np.sum((peaks[:, 1]).astype(np.float64)**2, dtype=np.float64)).astype(dtype)
+        write += n
+
+    idx.spec_mz = mz_flat.copy()
+    idx.spec_int = int_flat.copy()
+
+    # Sort by m/z
+    order = np.argsort(mz_flat)
+    idx.peaks_mz = mz_flat[order]
+    idx.peaks_int = int_flat[order]
+    idx.peaks_spec_idx = spec_flat[order]
+    product_pos = np.empty(n_peaks, dtype=np.int64)
+    product_pos[order] = np.arange(n_peaks, dtype=np.int64)
+
+    # Neutral-loss view (if requested)
+    if compute_neutral_loss:
+        pmz_per_peak = idx.precursor_mz[spec_flat]
+        have_pmz = ~np.isnan(pmz_per_peak)  # catch cases without precursor m/z
+        src_idx = np.nonzero(have_pmz)[0]
+        if src_idx.size == 0:
+            idx.nl_mz = np.zeros(0, dtype=dtype)
+            idx.nl_int = np.zeros(0, dtype=dtype)
+            idx.nl_spec_idx = np.zeros(0, dtype=int_dtype)
+            idx.nl_product_idx = np.zeros(0, dtype=int_dtype)
+        else:
+            nl_mz = (pmz_per_peak[src_idx] - mz_flat[src_idx]).astype(dtype, copy=False)
+            nl_int = int_flat[src_idx]
+            nl_spec = spec_flat[src_idx]
+            nl_prod = product_pos[src_idx]
+
+            # Sort neutral-losses by m/z
+            order_nl = np.argsort(nl_mz)
+            idx.nl_mz = nl_mz[order_nl]
+            idx.nl_int = nl_int[order_nl]
+            idx.nl_spec_idx = nl_spec[order_nl]
+            idx.nl_product_idx = nl_prod[order_nl]
+
+    if compute_l2_norm:
+        idx.spec_l2 = spec_l2
+
+    return idx
+
+
+# ===================== preprocessing =====================
+
+def _entropy_weight(intensities: np.ndarray, dtype: np.dtype) -> np.ndarray:
+    """
+    Apply entropy-based weighting to intensities as described by Li & Fiehn (2023).
+    """
+    total = float(intensities.sum(dtype=np.float64))  # sum in high precision for stability
+    if total <= 0.0:
+        return intensities.astype(dtype, copy=False)
+    p = intensities / total
+    with np.errstate(divide="ignore", invalid="ignore"):
+        logp = np.zeros_like(p, dtype=dtype)
+        mask = p > 0
+        # Keep the weighting rule aligned with ms_entropy (natural log entropy).
+        logp[mask] = np.log(p[mask]).astype(dtype, copy=False)
+
+    # Compute spectral entropy S
+    S = float((-p * logp).sum(dtype=np.float64))
+
+    # Compute weight w (used for scaling)
+    w = 1.0 if S >= 3.0 else (0.25 + 0.25 * S)
+    return np.power(intensities, w).astype(dtype, copy=False)
+
+
+def _clean_and_weight(
+        peaks: np.ndarray,
+        precursor_mz: float | None,
+        remove_precursor: bool,
+        offset_to_precursor: float,
+        noise_cutoff: float,
+        normalize_to_half: bool,
+        merge_within_da: float,
+        weighing_type: str,
+        intensity_power: float = 1.0,
+        dtype: np.dtype = np.float64
+        ) -> np.ndarray:
+    """
+    Apply the Flash preprocessing rules to a (mz, intensity) peak list.
+
+    Steps:
+      1) (Optional) Remove all peaks above (precursor_mz + offset_to_precursor).
+      2) (Optional) Remove noise: keep peaks with intensity >= noise_cutoff * max(intensity).
+      3) (Optional) Entropy-weight intensities (Li & Fiehn): raise intensities by a power derived 
+         from spectrum entropy.
+      4) (Optional) Merge peaks within a small m/z window by intensity-weighted centroid.
+      5) (Optional) normalize intensities to sum to 0.5 (recommended in the paper).
+
+    Parameters
+    ----------
+    peaks : ndarray of shape (N, 2)
+        Column 0 = m/z, column 1 = intensity.
+    precursor_mz : float or None
+        Precursor m/z for the spectrum (if known).
+    remove_precursor : bool
+        If True, remove the precursor and near-precursor peaks.
+    offset_to_precursor : float
+        Size (Da) to cut below the precursor (remove m/z > precursor_mz + offset_to_precursor).
+    noise_cutoff : float
+        Fraction of max intensity to keep (0.01 means keep peaks >= 1% of max).
+    normalize_to_half : bool
+        If True, scale intensities so their sum is 0.5.
+    merge_within_da : float
+        If > 0, merge peaks that are within this m/z distance.
+    weighing_type : str
+        One of "cosine" or "entropy". Fragment intensities will be weighted accordingly.
+        for "cosine", weighing is only changed if intensity_power != 1.0.
+    intensity_power : float
+        The power to raise intensity to in the cosine function. The default is 1.
+    dtype : np.dtype
+        Float dtype for outputs. Default is np.float64. TODO: should not be handled by this function?
+
+    Returns
+    -------
+    ndarray
+        Cleaned array with columns [mz, intensity], dtype=dtype, sorted by m/z.
+        May be empty with shape (0, 2) if everything is filtered away.
+    """
+    if peaks.size == 0:
+        return np.empty((0, 2), dtype=dtype)
+
+    mz = _as_dtype(peaks[:, 0], dtype)
+    intensities = _as_dtype(peaks[:, 1], dtype)
+
+    # (optional) remove precursor and nearby peaks
+    if remove_precursor and (precursor_mz is not None):
+        mz, intensities = filter_peaks_above_precursor(
+            mz,
+            intensities,
+            precursor_mz,
+            offset_to_precursor,
+        )
+        if mz.size == 0:
+            return np.empty((0, 2), dtype=dtype)
+
+    # (optional) remove noise peaks below a fraction of max intensity
+    if noise_cutoff and noise_cutoff > 0.0:
+        mz, intensities = filter_noise(mz, intensities, noise_cutoff)
+        if mz.size == 0:
+            return np.empty((0, 2), dtype=dtype)
+
+    # (optional) entropy-weight intensities (for flash entropy score)
+    if weighing_type == "entropy":
+        intensities = _entropy_weight(intensities, dtype)
+    elif weighing_type == "cosine":
+        if intensity_power != 1.0:
+            # Apply power-based weighing to intensities (for cosine or modified cosine)
+            intensities = np.power(intensities, intensity_power)
+    else:
+        raise ValueError(f"Score type '{weighing_type}' not recognized.")
+
+    # (optional) merge nearby peaks by intensity-weighted centroid
+    if merge_within_da and merge_within_da > 0.0 and mz.size > 1:
+        peaks = _merge_within(np.column_stack((mz, intensities)), merge_within_da)
+        mz, intensities = peaks[:, 0], peaks[:, 1]
+
+    # (optional) normalize intensities to sum to 0.5
+    if normalize_to_half:
+        sum_intensities = intensities.sum(dtype=np.float64)
+        if sum_intensities > 0.0:
+            intensities = (intensities * (0.5 / sum_intensities)).astype(dtype, copy=False)
+
+    return np.column_stack((mz, intensities))
+
+
+# ===================== smaller helper functions =====================
+
+def _as_dtype(a: np.ndarray, dtype: np.dtype) -> np.ndarray:
+    if a.dtype == dtype:
+        return a.astype(dtype, copy=False) 
+    return a.astype(dtype, copy=True)
+
+
+def _merge_within(
+        peaks: np.ndarray,
+        max_delta_da: float) -> np.ndarray:
+    """
+    Merges peaks within `max_delta_da` of each other by intensity-weighted averaging.
+    
+    Parameters
+    ---------- 
+    peaks : np.ndarray
+        2D array of shape (n_peaks, 2) with m/z values in first column and intensities in second column.
+    max_delta_da : float
+        Maximum difference in m/z values to consider peaks as the same (in Dalton).
+    """
+    if peaks.shape[0] <= 1 or max_delta_da <= 0.0:
+        return peaks
+    mz = peaks[:, 0]
+    intensities = peaks[:, 1]
+    new_mz = []
+    new_int = []
+    current_mz = mz[0]
+    current_int = intensities[0]
+    for k in range(1, mz.shape[0]):
+        if (mz[k] - current_mz) <= max_delta_da:
+            total = current_int + intensities[k]
+            if total > 0:
+                current_mz = (current_mz * current_int + mz[k] * intensities[k]) / total
+                current_int = total
+            else:
+                current_mz = mz[k]
+                current_int = 0.0
+        else:
+            new_mz.append(current_mz)
+            new_int.append(current_int)
+            current_mz = mz[k]
+            current_int = intensities[k]
+    new_mz.append(current_mz)
+    new_int.append(current_int)
+    out = np.column_stack((np.array(new_mz, dtype=mz.dtype),
+                           np.array(new_int, dtype=intensities.dtype)))
+    return out

--- a/tests/similarity/test_flash_similarity.py
+++ b/tests/similarity/test_flash_similarity.py
@@ -1,670 +1,91 @@
 import numpy as np
 import pytest
+from matchms import SpectraCollection
 from matchms.scores import Scores
-from matchms.similarity import CosineGreedy, ModifiedCosineGreedy
-from matchms.similarity.flash_similarity import CosineFlash, FlashEntropy
+from matchms.similarity.flash_similarity import (
+    CosineFlash,
+    FlashEntropy,
+)
+from matchms.similarity.flash_similarity_spectrum_list import (
+    CosineFlash as CosineFlashSL,
+    FlashEntropy as FlashEntropySL,
+)
 from ..builder_spectrum import SpectrumBuilder
 
 
-# ----------------------------
+# -------------------------------------------------------------------------
 # Helpers
-# ----------------------------
+# -------------------------------------------------------------------------
 
-def build_spectrum(mz, intens, precursor_mz=None):
-    """Build a Spectrum via SpectrumBuilder, setting precursor_mz when available."""
-    b = SpectrumBuilder().with_mz(np.asarray(mz, dtype="float")).with_intensities(
-        np.asarray(intens, dtype="float")
+def build_spectrum(
+    mz,
+    intens,
+    precursor_mz=None,
+):
+    builder = (
+        SpectrumBuilder()
+        .with_mz(
+            np.asarray(
+                mz,
+                dtype=float,
+            )
+        )
+        .with_intensities(
+            np.asarray(
+                intens,
+                dtype=float,
+            )
+        )
     )
-    if hasattr(b, "with_precursor_mz") and precursor_mz is not None:
-        b = b.with_precursor_mz(float(precursor_mz))
-    elif precursor_mz is not None and hasattr(b, "with_metadata"):
-        b = b.with_metadata({"precursor_mz": float(precursor_mz)})
-    return b.build()
+
+    if precursor_mz is not None:
+        if hasattr(
+            builder,
+            "with_precursor_mz",
+        ):
+            builder = builder.with_precursor_mz(
+                float(precursor_mz)
+            )
+        elif hasattr(
+            builder,
+            "with_metadata",
+        ):
+            builder = builder.with_metadata(
+                {
+                    "precursor_mz":
+                        float(precursor_mz)
+                }
+            )
+
+    return builder.build()
 
 
-# ----------------------------
-# Spectral-entropy path (public API level)
-# ----------------------------
-
-@pytest.mark.parametrize("use_ppm,tol", [(False, 0.1), (True, 100.0)])
-def test_entropy_pair_fragment_commutative_and_positive(use_ppm, tol):
-    s1 = build_spectrum([100, 200, 300], [0.2, 1.0, 0.4], precursor_mz=500.0)
-    s2 = build_spectrum([100, 200, 305], [0.1, 0.5, 0.2], precursor_mz=500.0)
-
-    fse = FlashEntropy(
-        tolerance=tol,
-        use_ppm=use_ppm,
-        matching_mode="fragment",
-        remove_precursor=False,
-        noise_cutoff=0.0,
-        normalize_to_half=False,
-        merge_within=0.0,
-        dtype=np.float32,
+def build_collection(spectra):
+    return SpectraCollection(
+        spectra,
+        mz_precision=1e-6,
     )
-    score12 = float(fse.pair(s1, s2))
-    score21 = float(fse.pair(s2, s1))
-    assert score12 == pytest.approx(score21, 1e-6)
-    assert score12 > 0.0
 
 
-def test_entropy_pair_returns_zero_when_empty_after_cleanup():
-    # Precursor window removes everything
-    s1 = build_spectrum([199.0, 199.5], [1.0, 0.5], precursor_mz=200.0)
-    s2 = build_spectrum([199.2, 199.7], [1.0, 0.5], precursor_mz=200.0)
-    fse = FlashEntropy(
-        tolerance=0.02,
-        matching_mode="fragment",
-        remove_precursor=True,
-        offset_to_precursor=-1.6,
-        noise_cutoff=0.0,
-        normalize_to_half=True,
-        merge_within=0.0,
-    )
-    assert float(fse.pair(s1, s2)) == 0.0
+# -------------------------------------------------------------------------
+# Input handling
+# -------------------------------------------------------------------------
 
-
-def test_entropy_identity_gate_da_and_ppm():
-    s1 = build_spectrum([100, 200], [1.0, 1.0], precursor_mz=500.0)
-    s2 = build_spectrum([100, 200], [1.0, 1.0], precursor_mz=500.3)
-
-    base = FlashEntropy(
-        tolerance=0.02, matching_mode="fragment", remove_precursor=False, noise_cutoff=0.0
-    )
-    base_score = float(base.pair(s1, s2))
-    assert base_score > 0.0
-
-    # Strict Da gate
-    gate_da_tight = FlashEntropy(
-        tolerance=0.02,
-        matching_mode="fragment",
-        identity_precursor_tolerance=0.2,
-        identity_use_ppm=False,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-    )
-    assert float(gate_da_tight.pair(s1, s2)) == 0.0
-
-    gate_da_loose = FlashEntropy(
-        tolerance=0.02,
-        matching_mode="fragment",
-        identity_precursor_tolerance=0.5,
-        identity_use_ppm=False,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-    )
-    assert float(gate_da_loose.pair(s1, s2)) == pytest.approx(base_score, abs=1e-7)
-
-    # PPM gate
-    gate_ppm_tight = FlashEntropy(
-        tolerance=0.02,
-        matching_mode="fragment",
-        identity_precursor_tolerance=300.0,
-        identity_use_ppm=True,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-    )
-    assert float(gate_ppm_tight.pair(s1, s2)) == 0.0
-
-    gate_ppm_loose = FlashEntropy(
-        tolerance=0.02,
-        matching_mode="fragment",
-        identity_precursor_tolerance=800.0,
-        identity_use_ppm=True,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-    )
-    assert float(gate_ppm_loose.pair(s1, s2)) == pytest.approx(base_score, abs=1e-7)
-
-
-def test_entropy_neutral_loss_vs_hybrid_prefers_fragments():
-    # NL hits duplicate fragment hits -> hybrid should equal fragment-only
-    q = build_spectrum([100, 200], [1.0, 1.0], precursor_mz=500.0)
-    r = build_spectrum([100, 200], [1.0, 1.0], precursor_mz=500.0)
-
-    kwargs = {
-        "tolerance": 0.1,
-        "use_ppm": False,
-        "remove_precursor": False,
-        "noise_cutoff": 0.0,
-        "normalize_to_half": False,
-        "merge_within": 0.0,
-    }
-
-    frag = FlashEntropy(matching_mode="fragment", **kwargs)
-    nl = FlashEntropy(matching_mode="neutral_loss", **kwargs)
-    hyb = FlashEntropy(matching_mode="hybrid", **kwargs)
-
-    s_frag = float(frag.pair(r, q))
-    s_nl = float(nl.pair(r, q))
-    s_hyb = float(hyb.pair(r, q))
-
-    assert s_frag > 0.0
-    assert s_hyb == pytest.approx(s_frag, abs=1e-7)
-    assert s_nl >= s_hyb
-
-
-def test_entropy_matrix_dense_matches_pair():
-    refs = [
-        build_spectrum([100, 200], [1.0, 0.5], precursor_mz=500.0),
-        build_spectrum([110, 300], [0.3, 1.0], precursor_mz=600.0),
-    ]
-    qs = [
-        build_spectrum([100, 205], [1.0, 0.5], precursor_mz=500.0),
-        build_spectrum([110, 300], [1.0, 0.3], precursor_mz=600.0),
-    ]
-    fse = FlashEntropy(
-        tolerance=0.1,
-        use_ppm=False,
-        matching_mode="fragment",
-        remove_precursor=False,
-        noise_cutoff=0.0,
-        normalize_to_half=False,
-        merge_within=0.0,
-    )
-    scores = fse.matrix(refs, qs, n_jobs=0, progress_bar=False)
-    assert isinstance(scores, Scores)
-    assert scores.is_sparse is False
-    assert scores.is_scalar is True
-
-    M = scores.to_array()
-    assert M.shape == (2, 2)
-    for i, r in enumerate(refs):
-        for j, q in enumerate(qs):
-            expected = float(fse.pair(r, q))
-            assert float(M[i, j]) == pytest.approx(expected, abs=1e-6)
-
-
-def test_entropy_matrix_self_comparison_returns_scores():
+def test_entropy_sc_matrix_accepts_spectrum_lists():
     spectra = [
-        build_spectrum([100, 200], [1.0, 0.5], precursor_mz=500.0),
-        build_spectrum([110, 300], [0.3, 1.0], precursor_mz=600.0),
-    ]
-    fse = FlashEntropy(
-        tolerance=0.1,
-        use_ppm=False,
-        matching_mode="fragment",
-        remove_precursor=False,
-        noise_cutoff=0.0,
-        normalize_to_half=False,
-        merge_within=0.0,
-    )
-
-    scores = fse.matrix(spectra, n_jobs=0, progress_bar=False)
-    assert isinstance(scores, Scores)
-    assert scores.shape == (2, 2)
-
-    M = scores.to_array()
-    assert M.shape == (2, 2)
-    assert np.allclose(M, M.T, atol=1e-6)
-
-
-def test_entropy_fragment_score_is_bounded_with_overlapping_windows():
-    # Overlapping tolerance windows used to cause many-to-many over-counting.
-    s1 = build_spectrum([100.000, 100.010], [1.0, 1.0], precursor_mz=250.0)
-    s2 = build_spectrum([100.005, 100.015], [1.0, 1.0], precursor_mz=250.0)
-
-    fse = FlashEntropy(
-        matching_mode="fragment",
-        tolerance=0.02,
-        use_ppm=False,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-        normalize_to_half=True,
-        merge_within=0.0,
-        dtype=np.float64,
-    )
-
-    score = float(fse.pair(s1, s2))
-    assert score <= 1.0 + 1e-7
-
-
-def test_entropy_fragment_ignores_non_positive_peaks_in_pairwise_matching():
-    ref_with_zero = build_spectrum([100.0, 100.1], [0.0, 1.0], precursor_mz=250.0)
-    ref_without_zero = build_spectrum([100.1], [1.0], precursor_mz=250.0)
-    query = build_spectrum([100.05], [1.0], precursor_mz=250.0)
-
-    fse = FlashEntropy(
-        matching_mode="fragment",
-        tolerance=0.1,
-        use_ppm=False,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-        normalize_to_half=False,
-        merge_within=0.0,
-        dtype=np.float64,
-    )
-
-    expected = float(fse.pair(ref_without_zero, query))
-    assert expected > 0.0
-    assert float(fse.pair(ref_with_zero, query)) == pytest.approx(expected, abs=1e-7)
-
-    matrix_scores = fse.matrix([ref_with_zero, ref_without_zero], [query], n_jobs=0, progress_bar=False)
-    M = matrix_scores.to_array()
-    assert float(M[0, 0]) == pytest.approx(expected, abs=1e-7)
-    assert float(M[1, 0]) == pytest.approx(expected, abs=1e-7)
-
-
-def test_entropy_fragment_matrix_matches_pair_with_sparse_candidate_columns():
-    spectrum_1 = build_spectrum([100.0, 200.0], [1.0, 0.8], precursor_mz=450.0)
-    spectra_2 = [
-        build_spectrum([100.005, 200.003], [1.0, 0.7], precursor_mz=450.0),
-        build_spectrum([100.01, 350.0], [0.9, 0.5], precursor_mz=450.0),
-        build_spectrum([199.99], [0.8], precursor_mz=450.0),
-    ]
-    for shift in range(15):
-        base = 500.0 + 10.0 * shift
-        spectra_2.append(build_spectrum([base, base + 0.3], [1.0, 0.5], precursor_mz=450.0))
-
-    fse = FlashEntropy(
-        matching_mode="fragment",
-        tolerance=0.02,
-        use_ppm=False,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-        normalize_to_half=False,
-        merge_within=0.0,
-        dtype=np.float64,
-    )
-
-    matrix_scores = fse.matrix([spectrum_1], spectra_2, n_jobs=0, progress_bar=False)
-    M = matrix_scores.to_array()
-    assert M.shape == (1, len(spectra_2))
-    assert np.count_nonzero(M[0] > 0.0) == 3
-
-    for j, query in enumerate(spectra_2):
-        expected = float(fse.pair(spectrum_1, query))
-        assert float(M[0, j]) == pytest.approx(expected, abs=1e-7)
-
-
-# ----------------------------
-# Cosine / Modified Cosine path + baseline parity
-# ----------------------------
-
-def _mc_flash(tolerance, intensity_power=1.0):
-    return CosineFlash(
-        matching_mode="hybrid",  # hybrid = "modified cosine"
-        tolerance=tolerance,
-        intensity_power=intensity_power,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-        normalize_to_half=True,
-        merge_within=0.0,
-        dtype=np.float64,
-    )
-
-
-@pytest.mark.parametrize(
-    "mz_a,int_a,pmz_a,mz_b,int_b,pmz_b,tol",
-    [
-        # 1) Clean shift, should match
-        pytest.param(
-            [100.0, 200.0, 300.0],
-            [0.8, 1.0, 0.6],
-            500.0,
-            [110.0, 210.002, 300.005],
-            [0.8, 1.0, 0.6],
-            510.0,
-            0.01,
-            id="pure_shift_exploited",
-        ),
-        # 2) Mixed: one shared unshifted fragment plus shifted set
-        # Expect both algorithms to pick the same best non-overlapping set.
-        pytest.param(
-            [100.0, 150.0, 200.0, 300.0],
-            [0.8, 0.2, 1.0, 0.6],
-            500.0,
-            [110.0, 150.0, 210.0005, 310.0],
-            [0.8, 0.2, 1.0, 0.6],
-            510.0,
-            0.01,
-            id="mixed_direct_and_shifted",
-        ),
-        # 3) Ambiguity: two query peaks within tolerance of the same shifted match
-        # This stresses greedy choice ordering and tie-breaking
-        pytest.param(
+        build_spectrum(
             [100.0, 200.0],
             [1.0, 0.5],
             500.0,
-            [110.0, 110.007, 210.0],
-            [1.0, 1.0, 0.5],
-            510.0,
-            0.01,
-            id="duplicate_candidates_nearby",
         ),
-        # 4) Competition: a direct fragment match competes with a shifted/NL match
-        # Constructed so dot products are close and greedy selection matters.
-        pytest.param(
-            [100.0, 200.0, 250.0],
-            [1.0, 0.9, 0.2],
-            500.0,
-            [110.0, 200.0, 260.0],
-            [1.0, 0.9, 0.2],
-            510.0,
-            0.01,
-            id="direct_competes_with_shifted",
-        ),
-        # 5) Edge tolerance: shifted peaks sit near the boundary
-        # To catch subtle differences in symmetric ppm/Da handling or window trimming.
-        pytest.param(
-            [100.0, 200.0, 300.0],
-            [0.8, 1.0, 0.6],
-            500.0,
-            [110.0099, 210.0099, 310.0099],
-            [0.8, 1.0, 0.6],
-            510.0,
-            0.01,
-            id="near_tolerance_boundary",
-        ),
-        # 6) Edge case: mass shift is inside the tolerance, so no shifted matches should be considered at all.
-        pytest.param(
-            [100.0],
-            [1.0],
-            500.009,
-            [99.985, 100.0],
-            [1.0, 0.1],
-            500.0,
-            0.01,
-            id="inside_tolerance_shift",
-        ),
-    ],
-)
-def test_flash_hybrid_cosine_matches_modified_cosine_greedy(mz_a, int_a, pmz_a, mz_b, int_b, pmz_b, tol):
-    a = build_spectrum(mz_a, int_a, precursor_mz=pmz_a)
-    b = build_spectrum(mz_b, int_b, precursor_mz=pmz_b)
-
-    for intensity_power in [1.0, 0.5]:  # Test with and without intensity weighting!
-        flash = _mc_flash(tol, intensity_power=intensity_power)
-        baseline = ModifiedCosineGreedy(tolerance=tol, intensity_power=intensity_power)
-
-        s_flash = float(flash.pair(a, b)["score"])
-        s_base = float(baseline.pair(a, b)["score"])
-        matches_flash = flash.pair(a, b)["matches"]
-        matches_base = baseline.pair(a, b)["matches"]
-
-        assert s_flash == pytest.approx(s_base, rel=1e-12, abs=1e-12)
-        assert matches_flash == matches_base
-
-
-def test_cosine_pair_matches_cosinegreedy_default_tolerance_001():
-    # Build a few pairs with clear fragment matches inside 0.01 Da
-    pairs = [
-        (
-            build_spectrum([100.000, 150.000, 200.000, 300.000], [0.6, 1.0, 0.8, 0.4], 500.0),
-            build_spectrum([100.005, 150.004, 200.007, 300.002], [0.6, 0.9, 0.8, 0.4], 500.0),
-        ),
-        (
-            build_spectrum([80.0, 120.0, 250.0], [0.9, 0.7, 1.0], 420.0),
-            build_spectrum([80.006, 120.004, 250.009], [0.9, 0.7, 1.0], 420.0),
+        build_spectrum(
+            [110.0, 300.0],
+            [0.3, 1.0],
+            600.0,
         ),
     ]
 
-    flash = CosineFlash(
-        matching_mode="fragment",
-        tolerance=0.01,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-        normalize_to_half=True,
-        merge_within=0.0,
-        dtype=np.float64,
-    )
-    baseline = CosineGreedy(tolerance=0.01)
-
-    for a, b in pairs:
-        s_flash = flash.pair(a, b)["score"]
-        s_base = baseline.pair(a, b)["score"]
-        assert s_flash == pytest.approx(s_base, rel=1e-12, abs=1e-12)
-
-        matches_flash = flash.pair(a, b)["matches"]
-        matches_base = baseline.pair(a, b)["matches"]
-        assert matches_flash == matches_base
-
-
-def test_cosine_matrix_dense_matches_pair():
-    refs = [
-        build_spectrum([100, 150, 300], [0.6, 1.0, 0.4], precursor_mz=500.0),
-        build_spectrum([110, 250, 400], [0.5, 0.9, 0.7], precursor_mz=600.0),
-    ]
-    qs = [
-        build_spectrum([100.007, 150.002, 300.000], [0.6, 1.0, 0.4], precursor_mz=500.0),
-        build_spectrum([110.004, 250.009, 400.006], [0.5, 0.9, 0.7], precursor_mz=600.0),
-    ]
-    flash = CosineFlash(
-        matching_mode="fragment",
-        tolerance=0.01,
-        remove_precursor=False,
-        noise_cutoff=0.0,
-        normalize_to_half=True,
-        merge_within=0.0,
-        dtype=np.float64,
-    )
-    scores = flash.matrix(refs, qs, n_jobs=0, progress_bar=False)
-    assert isinstance(scores, Scores)
-    M = scores.to_array("score")
-    assert M.shape == (2, 2)
-    for i, r in enumerate(refs):
-        for j, q in enumerate(qs):
-            expected = float(flash.pair(r, q)["score"])
-            assert float(M[i, j]) == pytest.approx(expected, abs=1e-12)
-
-
-def test_cosine_dtype_and_commutativity():
-    a = build_spectrum([100, 150, 300], [0.5, 1.0, 0.4], precursor_mz=600.0)
-    b = build_spectrum([100, 155, 295], [0.5, 0.8, 0.6], precursor_mz=600.0)
-    f32 = CosineFlash(dtype=np.float32, remove_precursor=False, noise_cutoff=0.0)
-    f64 = CosineFlash(dtype=np.float64, remove_precursor=False, noise_cutoff=0.0)
-
-    s_ab_32 = f32.pair(a, b)["score"]
-    s_ba_32 = f32.pair(b, a)["score"]
-    s_ab_64 = f64.pair(a, b)["score"]
-    s_ba_64 = f64.pair(b, a)["score"]
-
-    assert s_ab_32.dtype == np.float32 and s_ba_32.dtype == np.float32
-    assert s_ab_64.dtype == np.float64 and s_ba_64.dtype == np.float64
-    assert float(s_ab_32) == pytest.approx(float(s_ba_32), 1e-6)
-    assert float(s_ab_64) == pytest.approx(float(s_ba_64), 1e-12)
-
-
-def test_entropy_neutral_loss_does_not_include_fragment_matches():
-    reference = build_spectrum(
-        [100.0],
-        [1.0],
-        precursor_mz=500.0,
-    )
-    query = build_spectrum(
-        [100.0],
-        [1.0],
-        precursor_mz=510.0,
-    )
-
-    kwargs = {
-        "tolerance": 0.01,
-        "remove_precursor": False,
-        "noise_cutoff": 0.0,
-        "dtype": np.float64,
-    }
-
-    fragment = FlashEntropy(
-        matching_mode="fragment",
-        **kwargs,
-    ).pair(reference, query)
-
-    neutral_loss = FlashEntropy(
-        matching_mode="neutral_loss",
-        **kwargs,
-    ).pair(reference, query)
-
-    assert float(fragment) == pytest.approx(1.0)
-    assert float(neutral_loss) == 0.0
-
-
-def test_entropy_neutral_loss_matches_shifted_fragments():
-    reference = build_spectrum(
-        [100.0],
-        [1.0],
-        precursor_mz=500.0,
-    )
-    query = build_spectrum(
-        [110.0],
-        [1.0],
-        precursor_mz=510.0,
-    )
-
-    kwargs = {
-        "tolerance": 0.01,
-        "remove_precursor": False,
-        "noise_cutoff": 0.0,
-        "dtype": np.float64,
-    }
-
-    fragment = FlashEntropy(
-        matching_mode="fragment",
-        **kwargs,
-    ).pair(reference, query)
-
-    neutral_loss = FlashEntropy(
-        matching_mode="neutral_loss",
-        **kwargs,
-    ).pair(reference, query)
-
-    assert float(fragment) == 0.0
-    assert float(neutral_loss) == pytest.approx(1.0)
-
-
-def test_entropy_hybrid_combines_fragment_and_neutral_loss_matches():
-    reference = build_spectrum(
-        [100.0, 200.0],
-        [1.0, 1.0],
-        precursor_mz=500.0,
-    )
-    query = build_spectrum(
-        [100.0, 210.0],
-        [1.0, 1.0],
-        precursor_mz=510.0,
-    )
-
-    kwargs = {
-        "tolerance": 0.01,
-        "remove_precursor": False,
-        "noise_cutoff": 0.0,
-        "dtype": np.float64,
-    }
-
-    fragment = float(
-        FlashEntropy(matching_mode="fragment", **kwargs).pair(
-            reference, query
-        )
-    )
-    neutral_loss = float(
-        FlashEntropy(matching_mode="neutral_loss", **kwargs).pair(
-            reference, query
-        )
-    )
-    hybrid = float(
-        FlashEntropy(matching_mode="hybrid", **kwargs).pair(
-            reference, query
-        )
-    )
-
-    # 100 <-> 100 contributes 0.5 by fragment m/z.
-    assert fragment == pytest.approx(0.5)
-
-    # 200 <-> 210 contributes 0.5 by matching neutral loss 300.
-    assert neutral_loss == pytest.approx(0.5)
-
-    # Hybrid may use both because they involve different physical peaks.
-    assert hybrid == pytest.approx(1.0)
-
-
-def test_entropy_hybrid_does_not_double_count_fragment_and_neutral_loss():
-    reference = build_spectrum(
-        [100.0, 200.0],
-        [1.0, 1.0],
-        precursor_mz=500.0,
-    )
-    query = build_spectrum(
-        [100.0, 200.0],
-        [1.0, 1.0],
-        precursor_mz=500.0,
-    )
-
-    kwargs = {
-        "tolerance": 0.01,
-        "remove_precursor": False,
-        "noise_cutoff": 0.0,
-        "dtype": np.float64,
-    }
-
-    fragment = float(
-        FlashEntropy(matching_mode="fragment", **kwargs).pair(
-            reference, query
-        )
-    )
-    neutral_loss = float(
-        FlashEntropy(matching_mode="neutral_loss", **kwargs).pair(
-            reference, query
-        )
-    )
-    hybrid = float(
-        FlashEntropy(matching_mode="hybrid", **kwargs).pair(
-            reference, query
-        )
-    )
-
-    assert fragment == pytest.approx(1.0)
-    assert neutral_loss == pytest.approx(1.0)
-
-    # Same physical peaks cannot contribute twice.
-    assert hybrid == pytest.approx(1.0)
-
-
-def test_entropy_matching_modes_without_precursor_mz():
-    reference = build_spectrum([100.0], [1.0])
-    query = build_spectrum([100.0], [1.0])
-
-    kwargs = {
-        "tolerance": 0.01,
-        "remove_precursor": False,
-        "noise_cutoff": 0.0,
-        "dtype": np.float64,
-    }
-
-    fragment = float(
-        FlashEntropy(matching_mode="fragment", **kwargs).pair(
-            reference, query
-        )
-    )
-    neutral_loss = float(
-        FlashEntropy(matching_mode="neutral_loss", **kwargs).pair(
-            reference, query
-        )
-    )
-    hybrid = float(
-        FlashEntropy(matching_mode="hybrid", **kwargs).pair(
-            reference, query
-        )
-    )
-
-    assert fragment == pytest.approx(1.0)
-    assert neutral_loss == 0.0
-    assert hybrid == pytest.approx(fragment)
-
-
-@pytest.mark.parametrize(
-    "matching_mode",
-    ["fragment", "neutral_loss", "hybrid"],
-)
-def test_entropy_matrix_matches_pair_for_all_matching_modes(matching_mode):
-    refs = [
-        build_spectrum([100.0, 200.0], [1.0, 0.5], precursor_mz=500.0),
-        build_spectrum([110.0, 300.0], [0.3, 1.0], precursor_mz=600.0),
-    ]
-    queries = [
-        build_spectrum([100.0, 210.0], [1.0, 0.5], precursor_mz=510.0),
-        build_spectrum([110.0, 300.0], [1.0, 0.3], precursor_mz=600.0),
-    ]
-
-    similarity = FlashEntropy(
-        matching_mode=matching_mode,
+    similarity = FlashEntropySL(
         tolerance=0.01,
         remove_precursor=False,
         noise_cutoff=0.0,
@@ -672,16 +93,637 @@ def test_entropy_matrix_matches_pair_for_all_matching_modes(matching_mode):
     )
 
     scores = similarity.matrix(
-        refs,
+        spectra,
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    assert isinstance(
+        scores,
+        Scores,
+    )
+    assert scores.shape == (2, 2)
+
+
+def test_entropy_sc_matrix_accepts_spectra_collection():
+    spectra = [
+        build_spectrum(
+            [100.0, 200.0],
+            [1.0, 0.5],
+            500.0,
+        ),
+        build_spectrum(
+            [110.0, 300.0],
+            [0.3, 1.0],
+            600.0,
+        ),
+    ]
+    collection = build_collection(
+        spectra,
+    )
+
+    similarity = FlashEntropySL(
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    scores = similarity.matrix(
+        collection,
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    assert scores.shape == (2, 2)
+
+
+# -------------------------------------------------------------------------
+# Flash entropy
+# -------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "matching_mode",
+    [
+        "fragment",
+        "neutral_loss",
+        "hybrid",
+    ],
+)
+def test_entropy_sc_matches_existing_flash_matrix(
+    matching_mode,
+):
+    references = [
+        build_spectrum(
+            [100.0, 200.0],
+            [1.0, 0.5],
+            500.0,
+        ),
+        build_spectrum(
+            [110.0, 300.0],
+            [0.3, 1.0],
+            600.0,
+        ),
+        build_spectrum(
+            [125.0, 250.0, 400.0],
+            [0.4, 1.0, 0.2],
+            550.0,
+        ),
+    ]
+
+    queries = [
+        build_spectrum(
+            [100.005, 210.0],
+            [1.0, 0.5],
+            510.0,
+        ),
+        build_spectrum(
+            [110.0, 300.0],
+            [1.0, 0.3],
+            600.0,
+        ),
+    ]
+
+    kwargs = {
+        "matching_mode": matching_mode,
+        "tolerance": 0.01,
+        "use_ppm": False,
+        "remove_precursor": False,
+        "noise_cutoff": 0.0,
+        "normalize_to_half": True,
+        "merge_within": 0.0,
+        "dtype": np.float64,
+    }
+
+    old = FlashEntropy(
+        **kwargs,
+    )
+    sc = FlashEntropySL(
+        **kwargs,
+    )
+
+    expected = old.matrix(
+        references,
         queries,
         n_jobs=0,
         progress_bar=False,
     ).to_array()
 
-    for i, reference in enumerate(refs):
-        for j, query in enumerate(queries):
-            expected = similarity.pair(reference, query)
-            assert scores[i, j] == pytest.approx(
-                float(expected),
-                abs=1e-12,
-            )
+    actual = sc.matrix(
+        references,
+        queries,
+        n_jobs=0,
+        progress_bar=False,
+    ).to_array()
+
+    assert actual.shape == expected.shape
+    assert np.allclose(
+        actual,
+        expected,
+        atol=1e-12,
+    )
+
+
+@pytest.mark.parametrize(
+    "matching_mode",
+    [
+        "fragment",
+        "neutral_loss",
+        "hybrid",
+    ],
+)
+def test_entropy_sc_collection_input_matches_list_input(
+    matching_mode,
+):
+    references = [
+        build_spectrum(
+            [100.0, 200.0],
+            [1.0, 0.5],
+            500.0,
+        ),
+        build_spectrum(
+            [110.0, 300.0],
+            [0.3, 1.0],
+            600.0,
+        ),
+    ]
+
+    queries = [
+        build_spectrum(
+            [100.005, 210.0],
+            [1.0, 0.5],
+            510.0,
+        ),
+        build_spectrum(
+            [110.0, 300.0],
+            [1.0, 0.3],
+            600.0,
+        ),
+    ]
+
+    similarity = FlashEntropySL(
+        matching_mode=matching_mode,
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    from_lists = similarity.matrix(
+        references,
+        queries,
+        n_jobs=0,
+        progress_bar=False,
+    ).to_array()
+
+    from_collections = similarity.matrix(
+        build_collection(references),
+        build_collection(queries),
+        n_jobs=0,
+        progress_bar=False,
+    ).to_array()
+
+    assert np.allclose(
+        from_lists,
+        from_collections,
+        atol=1e-12,
+    )
+
+
+def test_entropy_sc_self_comparison_is_symmetric():
+    spectra = [
+        build_spectrum(
+            [100.0, 200.0],
+            [1.0, 0.5],
+            500.0,
+        ),
+        build_spectrum(
+            [110.0, 300.0],
+            [0.3, 1.0],
+            600.0,
+        ),
+        build_spectrum(
+            [100.0, 250.0],
+            [0.7, 0.9],
+            550.0,
+        ),
+    ]
+
+    similarity = FlashEntropySL(
+        matching_mode="fragment",
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    matrix = similarity.matrix(
+        build_collection(spectra),
+        n_jobs=0,
+        progress_bar=False,
+    ).to_array()
+
+    assert np.allclose(
+        matrix,
+        matrix.T,
+        atol=1e-12,
+    )
+
+
+def test_entropy_sc_pair_matches_matrix_element():
+    reference = build_spectrum(
+        [100.0, 200.0],
+        [1.0, 0.5],
+        500.0,
+    )
+    query = build_spectrum(
+        [100.005, 210.0],
+        [1.0, 0.5],
+        510.0,
+    )
+
+    similarity = FlashEntropySL(
+        matching_mode="hybrid",
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    pair_score = float(
+        similarity.pair(
+            reference,
+            query,
+        )
+    )
+
+    matrix_score = float(
+        similarity.matrix(
+            [reference],
+            [query],
+            n_jobs=0,
+            progress_bar=False,
+        ).to_array()[0, 0]
+    )
+
+    assert pair_score == pytest.approx(
+        matrix_score,
+        abs=1e-12,
+    )
+
+
+def test_entropy_sc_neutral_loss_requires_precursor():
+    reference = build_spectrum(
+        [100.0],
+        [1.0],
+    )
+    query = build_spectrum(
+        [100.0],
+        [1.0],
+    )
+
+    similarity = FlashEntropySL(
+        matching_mode="neutral_loss",
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    score = similarity.matrix(
+        [reference],
+        [query],
+        n_jobs=0,
+        progress_bar=False,
+    ).to_array()[0, 0]
+
+    assert score == 0.0
+
+
+def test_entropy_sc_hybrid_combines_distinct_fragment_and_loss_matches():
+    reference = build_spectrum(
+        [100.0, 200.0],
+        [1.0, 1.0],
+        500.0,
+    )
+    query = build_spectrum(
+        [100.0, 210.0],
+        [1.0, 1.0],
+        510.0,
+    )
+
+    similarity = FlashEntropySL(
+        matching_mode="hybrid",
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    score = similarity.matrix(
+        [reference],
+        [query],
+        n_jobs=0,
+        progress_bar=False,
+    ).to_array()[0, 0]
+
+    assert score == pytest.approx(
+        1.0,
+        abs=1e-12,
+    )
+
+
+def test_entropy_sc_identity_precursor_gate():
+    reference = build_spectrum(
+        [100.0, 200.0],
+        [1.0, 1.0],
+        500.0,
+    )
+    query = build_spectrum(
+        [100.0, 200.0],
+        [1.0, 1.0],
+        500.3,
+    )
+
+    similarity = FlashEntropySL(
+        matching_mode="fragment",
+        tolerance=0.01,
+        identity_precursor_tolerance=0.2,
+        identity_use_ppm=False,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    score = similarity.matrix(
+        [reference],
+        [query],
+        n_jobs=0,
+        progress_bar=False,
+    ).to_array()[0, 0]
+
+    assert score == 0.0
+
+
+# -------------------------------------------------------------------------
+# Cosine Flash SC
+# -------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "matching_mode",
+    [
+        "fragment",
+        "hybrid",
+    ],
+)
+def test_cosine_sc_matches_existing_flash_matrix(
+    matching_mode,
+):
+    references = [
+        build_spectrum(
+            [100.0, 150.0, 300.0],
+            [0.6, 1.0, 0.4],
+            500.0,
+        ),
+        build_spectrum(
+            [110.0, 250.0, 400.0],
+            [0.5, 0.9, 0.7],
+            600.0,
+        ),
+    ]
+
+    queries = [
+        build_spectrum(
+            [100.007, 150.002, 300.0],
+            [0.6, 1.0, 0.4],
+            500.0,
+        ),
+        build_spectrum(
+            [120.0, 260.0, 410.0],
+            [0.5, 0.9, 0.7],
+            610.0,
+        ),
+    ]
+
+    kwargs = {
+        "matching_mode": matching_mode,
+        "tolerance": 0.01,
+        "intensity_power": 1.0,
+        "remove_precursor": False,
+        "noise_cutoff": 0.0,
+        "normalize_to_half": True,
+        "merge_within": 0.0,
+        "dtype": np.float64,
+    }
+
+    old = CosineFlash(
+        **kwargs,
+    )
+    sc = CosineFlashSL(
+        **kwargs,
+    )
+
+    expected = old.matrix(
+        references,
+        queries,
+        n_jobs=0,
+        progress_bar=False,
+    )
+    actual = sc.matrix(
+        references,
+        queries,
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    assert np.allclose(
+        actual.to_array("score"),
+        expected.to_array("score"),
+        atol=1e-12,
+    )
+
+    assert np.array_equal(
+        actual.to_array("matches"),
+        expected.to_array("matches"),
+    )
+
+
+@pytest.mark.parametrize(
+    "intensity_power",
+    [1.0, 0.5],
+)
+def test_cosine_sc_intensity_power_matches_existing_flash(
+    intensity_power,
+):
+    references = [
+        build_spectrum(
+            [100.0, 150.0, 300.0],
+            [0.6, 1.0, 0.4],
+            500.0,
+        ),
+    ]
+
+    queries = [
+        build_spectrum(
+            [100.005, 150.005, 300.0],
+            [0.3, 1.0, 0.7],
+            500.0,
+        ),
+    ]
+
+    kwargs = {
+        "matching_mode": "fragment",
+        "tolerance": 0.01,
+        "intensity_power": intensity_power,
+        "remove_precursor": False,
+        "noise_cutoff": 0.0,
+        "normalize_to_half": True,
+        "merge_within": 0.0,
+        "dtype": np.float64,
+    }
+
+    old = CosineFlash(
+        **kwargs,
+    ).matrix(
+        references,
+        queries,
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    sc = CosineFlashSL(
+        **kwargs,
+    ).matrix(
+        references,
+        queries,
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    assert np.allclose(
+        sc.to_array("score"),
+        old.to_array("score"),
+        atol=1e-12,
+    )
+
+    assert np.array_equal(
+        sc.to_array("matches"),
+        old.to_array("matches"),
+    )
+
+
+def test_cosine_sc_pair_matches_matrix():
+    reference = build_spectrum(
+        [100.0, 150.0, 300.0],
+        [0.6, 1.0, 0.4],
+        500.0,
+    )
+    query = build_spectrum(
+        [100.005, 150.005, 300.0],
+        [0.6, 0.9, 0.4],
+        500.0,
+    )
+
+    similarity = CosineFlashSL(
+        matching_mode="fragment",
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    pair = similarity.pair(
+        reference,
+        query,
+    )
+
+    matrix = similarity.matrix(
+        [reference],
+        [query],
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    assert float(
+        pair["score"]
+    ) == pytest.approx(
+        matrix.to_array("score")[0, 0],
+        abs=1e-12,
+    )
+
+    assert int(
+        pair["matches"]
+    ) == int(
+        matrix.to_array("matches")[0, 0]
+    )
+
+
+def test_cosine_sc_score_field_selection():
+    spectra = [
+        build_spectrum(
+            [100.0, 200.0],
+            [1.0, 0.5],
+            500.0,
+        ),
+    ]
+
+    similarity = CosineFlashSL(
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+    )
+
+    score_only = similarity.matrix(
+        spectra,
+        score_fields=("score",),
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    matches_only = similarity.matrix(
+        spectra,
+        score_fields=("matches",),
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    assert score_only.score_fields == (
+        "score",
+    )
+    assert matches_only.score_fields == (
+        "matches",
+    )
+
+
+def test_cosine_sc_dtype():
+    reference = build_spectrum(
+        [100.0],
+        [1.0],
+        500.0,
+    )
+    query = build_spectrum(
+        [100.0],
+        [1.0],
+        500.0,
+    )
+
+    score_32 = CosineFlashSL(
+        dtype=np.float32,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+    ).pair(
+        reference,
+        query,
+    )
+
+    score_64 = CosineFlashSL(
+        dtype=np.float64,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+    ).pair(
+        reference,
+        query,
+    )
+
+    assert score_32["score"].dtype == np.float32
+    assert score_64["score"].dtype == np.float64

--- a/tests/similarity/test_flash_similarity.py
+++ b/tests/similarity/test_flash_similarity.py
@@ -753,7 +753,7 @@ def test_optimize_matrix_orientation_puts_smaller_collection_first():
         queries,
         is_symmetric,
     )
-
+    assert transpose_output is True
     assert refs.n_specs == 2
     assert queries.n_specs == 5
 

--- a/tests/similarity/test_flash_similarity.py
+++ b/tests/similarity/test_flash_similarity.py
@@ -8,6 +8,8 @@ from matchms.similarity.flash_similarity import (
 )
 from matchms.similarity.flash_similarity_spectrum_list import (
     CosineFlash as CosineFlashSL,
+)
+from matchms.similarity.flash_similarity_spectrum_list import (
     FlashEntropy as FlashEntropySL,
 )
 from ..builder_spectrum import SpectrumBuilder

--- a/tests/similarity/test_flash_similarity.py
+++ b/tests/similarity/test_flash_similarity.py
@@ -729,3 +729,117 @@ def test_cosine_sc_dtype():
 
     assert score_32["score"].dtype == np.float32
     assert score_64["score"].dtype == np.float64
+
+
+def test_optimize_matrix_orientation_puts_smaller_collection_first():
+    spectra_large = [
+        build_spectrum([100.0 + i], [1.0], precursor_mz=500.0)
+        for i in range(5)
+    ]
+    spectra_small = spectra_large[:2]
+
+    similarity = CosineFlash(
+        remove_precursor=False,
+        noise_cutoff=0.0,
+    )
+
+    refs, queries, is_symmetric = similarity._prepare_matrix_inputs(
+        spectra_large,
+        spectra_small,
+    )
+
+    refs, queries, transpose_output = similarity._optimize_matrix_orientation(
+        refs,
+        queries,
+        is_symmetric,
+    )
+
+    assert refs.n_specs == 2
+    assert queries.n_specs == 5
+
+
+def test_cosine_matrix_swap_preserves_requested_orientation():
+    spectra_large = [
+        build_spectrum(
+            [100.0 + i, 200.0 + i],
+            [1.0, 0.5],
+            precursor_mz=500.0 + i,
+        )
+        for i in range(5)
+    ]
+    spectra_small = spectra_large[:2]
+
+    similarity = CosineFlash(
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    large_small = similarity.matrix(
+        spectra_large,
+        spectra_small,
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    small_large = similarity.matrix(
+        spectra_small,
+        spectra_large,
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    assert large_small.shape == (5, 2)
+    assert small_large.shape == (2, 5)
+
+    assert np.array_equal(
+        large_small.to_array("score"),
+        small_large.to_array("score").T,
+    )
+
+    assert np.array_equal(
+        large_small.to_array("matches"),
+        small_large.to_array("matches").T,
+    )
+
+
+def test_entropy_matrix_swap_preserves_requested_orientation():
+    spectra_large = [
+        build_spectrum(
+            [100.0 + i, 200.0 + i],
+            [1.0, 0.5],
+            precursor_mz=500.0 + i,
+        )
+        for i in range(5)
+    ]
+    spectra_small = spectra_large[:2]
+
+    similarity = FlashEntropy(
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    large_small = similarity.matrix(
+        spectra_large,
+        spectra_small,
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    small_large = similarity.matrix(
+        spectra_small,
+        spectra_large,
+        n_jobs=0,
+        progress_bar=False,
+    )
+
+    assert large_small.shape == (5, 2)
+    assert small_large.shape == (2, 5)
+
+    assert np.array_equal(
+        large_small.to_array("score"),
+        small_large.to_array("score").T,
+    )

--- a/tests/similarity/test_flash_similarity_spectrum_list.py
+++ b/tests/similarity/test_flash_similarity_spectrum_list.py
@@ -1,0 +1,687 @@
+import numpy as np
+import pytest
+from matchms.scores import Scores
+from matchms.similarity import CosineGreedy, ModifiedCosineGreedy
+from matchms.similarity.flash_similarity_spectrum_list import CosineFlash, FlashEntropy
+from ..builder_spectrum import SpectrumBuilder
+
+
+# ----------------------------
+# Helpers
+# ----------------------------
+
+def build_spectrum(mz, intens, precursor_mz=None):
+    """Build a Spectrum via SpectrumBuilder, setting precursor_mz when available."""
+    b = SpectrumBuilder().with_mz(np.asarray(mz, dtype="float")).with_intensities(
+        np.asarray(intens, dtype="float")
+    )
+    if hasattr(b, "with_precursor_mz") and precursor_mz is not None:
+        b = b.with_precursor_mz(float(precursor_mz))
+    elif precursor_mz is not None and hasattr(b, "with_metadata"):
+        b = b.with_metadata({"precursor_mz": float(precursor_mz)})
+    return b.build()
+
+
+# ----------------------------
+# Spectral-entropy path (public API level)
+# ----------------------------
+
+@pytest.mark.parametrize("use_ppm,tol", [(False, 0.1), (True, 100.0)])
+def test_entropy_pair_fragment_commutative_and_positive(use_ppm, tol):
+    s1 = build_spectrum([100, 200, 300], [0.2, 1.0, 0.4], precursor_mz=500.0)
+    s2 = build_spectrum([100, 200, 305], [0.1, 0.5, 0.2], precursor_mz=500.0)
+
+    fse = FlashEntropy(
+        tolerance=tol,
+        use_ppm=use_ppm,
+        matching_mode="fragment",
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=False,
+        merge_within=0.0,
+        dtype=np.float32,
+    )
+    score12 = float(fse.pair(s1, s2))
+    score21 = float(fse.pair(s2, s1))
+    assert score12 == pytest.approx(score21, 1e-6)
+    assert score12 > 0.0
+
+
+def test_entropy_pair_returns_zero_when_empty_after_cleanup():
+    # Precursor window removes everything
+    s1 = build_spectrum([199.0, 199.5], [1.0, 0.5], precursor_mz=200.0)
+    s2 = build_spectrum([199.2, 199.7], [1.0, 0.5], precursor_mz=200.0)
+    fse = FlashEntropy(
+        tolerance=0.02,
+        matching_mode="fragment",
+        remove_precursor=True,
+        offset_to_precursor=-1.6,
+        noise_cutoff=0.0,
+        normalize_to_half=True,
+        merge_within=0.0,
+    )
+    assert float(fse.pair(s1, s2)) == 0.0
+
+
+def test_entropy_identity_gate_da_and_ppm():
+    s1 = build_spectrum([100, 200], [1.0, 1.0], precursor_mz=500.0)
+    s2 = build_spectrum([100, 200], [1.0, 1.0], precursor_mz=500.3)
+
+    base = FlashEntropy(
+        tolerance=0.02, matching_mode="fragment", remove_precursor=False, noise_cutoff=0.0
+    )
+    base_score = float(base.pair(s1, s2))
+    assert base_score > 0.0
+
+    # Strict Da gate
+    gate_da_tight = FlashEntropy(
+        tolerance=0.02,
+        matching_mode="fragment",
+        identity_precursor_tolerance=0.2,
+        identity_use_ppm=False,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+    )
+    assert float(gate_da_tight.pair(s1, s2)) == 0.0
+
+    gate_da_loose = FlashEntropy(
+        tolerance=0.02,
+        matching_mode="fragment",
+        identity_precursor_tolerance=0.5,
+        identity_use_ppm=False,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+    )
+    assert float(gate_da_loose.pair(s1, s2)) == pytest.approx(base_score, abs=1e-7)
+
+    # PPM gate
+    gate_ppm_tight = FlashEntropy(
+        tolerance=0.02,
+        matching_mode="fragment",
+        identity_precursor_tolerance=300.0,
+        identity_use_ppm=True,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+    )
+    assert float(gate_ppm_tight.pair(s1, s2)) == 0.0
+
+    gate_ppm_loose = FlashEntropy(
+        tolerance=0.02,
+        matching_mode="fragment",
+        identity_precursor_tolerance=800.0,
+        identity_use_ppm=True,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+    )
+    assert float(gate_ppm_loose.pair(s1, s2)) == pytest.approx(base_score, abs=1e-7)
+
+
+def test_entropy_neutral_loss_vs_hybrid_prefers_fragments():
+    # NL hits duplicate fragment hits -> hybrid should equal fragment-only
+    q = build_spectrum([100, 200], [1.0, 1.0], precursor_mz=500.0)
+    r = build_spectrum([100, 200], [1.0, 1.0], precursor_mz=500.0)
+
+    kwargs = {
+        "tolerance": 0.1,
+        "use_ppm": False,
+        "remove_precursor": False,
+        "noise_cutoff": 0.0,
+        "normalize_to_half": False,
+        "merge_within": 0.0,
+    }
+
+    frag = FlashEntropy(matching_mode="fragment", **kwargs)
+    nl = FlashEntropy(matching_mode="neutral_loss", **kwargs)
+    hyb = FlashEntropy(matching_mode="hybrid", **kwargs)
+
+    s_frag = float(frag.pair(r, q))
+    s_nl = float(nl.pair(r, q))
+    s_hyb = float(hyb.pair(r, q))
+
+    assert s_frag > 0.0
+    assert s_hyb == pytest.approx(s_frag, abs=1e-7)
+    assert s_nl >= s_hyb
+
+
+def test_entropy_matrix_dense_matches_pair():
+    refs = [
+        build_spectrum([100, 200], [1.0, 0.5], precursor_mz=500.0),
+        build_spectrum([110, 300], [0.3, 1.0], precursor_mz=600.0),
+    ]
+    qs = [
+        build_spectrum([100, 205], [1.0, 0.5], precursor_mz=500.0),
+        build_spectrum([110, 300], [1.0, 0.3], precursor_mz=600.0),
+    ]
+    fse = FlashEntropy(
+        tolerance=0.1,
+        use_ppm=False,
+        matching_mode="fragment",
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=False,
+        merge_within=0.0,
+    )
+    scores = fse.matrix(refs, qs, n_jobs=0, progress_bar=False)
+    assert isinstance(scores, Scores)
+    assert scores.is_sparse is False
+    assert scores.is_scalar is True
+
+    M = scores.to_array()
+    assert M.shape == (2, 2)
+    for i, r in enumerate(refs):
+        for j, q in enumerate(qs):
+            expected = float(fse.pair(r, q))
+            assert float(M[i, j]) == pytest.approx(expected, abs=1e-6)
+
+
+def test_entropy_matrix_self_comparison_returns_scores():
+    spectra = [
+        build_spectrum([100, 200], [1.0, 0.5], precursor_mz=500.0),
+        build_spectrum([110, 300], [0.3, 1.0], precursor_mz=600.0),
+    ]
+    fse = FlashEntropy(
+        tolerance=0.1,
+        use_ppm=False,
+        matching_mode="fragment",
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=False,
+        merge_within=0.0,
+    )
+
+    scores = fse.matrix(spectra, n_jobs=0, progress_bar=False)
+    assert isinstance(scores, Scores)
+    assert scores.shape == (2, 2)
+
+    M = scores.to_array()
+    assert M.shape == (2, 2)
+    assert np.allclose(M, M.T, atol=1e-6)
+
+
+def test_entropy_fragment_score_is_bounded_with_overlapping_windows():
+    # Overlapping tolerance windows used to cause many-to-many over-counting.
+    s1 = build_spectrum([100.000, 100.010], [1.0, 1.0], precursor_mz=250.0)
+    s2 = build_spectrum([100.005, 100.015], [1.0, 1.0], precursor_mz=250.0)
+
+    fse = FlashEntropy(
+        matching_mode="fragment",
+        tolerance=0.02,
+        use_ppm=False,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=True,
+        merge_within=0.0,
+        dtype=np.float64,
+    )
+
+    score = float(fse.pair(s1, s2))
+    assert score <= 1.0 + 1e-7
+
+
+def test_entropy_fragment_ignores_non_positive_peaks_in_pairwise_matching():
+    ref_with_zero = build_spectrum([100.0, 100.1], [0.0, 1.0], precursor_mz=250.0)
+    ref_without_zero = build_spectrum([100.1], [1.0], precursor_mz=250.0)
+    query = build_spectrum([100.05], [1.0], precursor_mz=250.0)
+
+    fse = FlashEntropy(
+        matching_mode="fragment",
+        tolerance=0.1,
+        use_ppm=False,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=False,
+        merge_within=0.0,
+        dtype=np.float64,
+    )
+
+    expected = float(fse.pair(ref_without_zero, query))
+    assert expected > 0.0
+    assert float(fse.pair(ref_with_zero, query)) == pytest.approx(expected, abs=1e-7)
+
+    matrix_scores = fse.matrix([ref_with_zero, ref_without_zero], [query], n_jobs=0, progress_bar=False)
+    M = matrix_scores.to_array()
+    assert float(M[0, 0]) == pytest.approx(expected, abs=1e-7)
+    assert float(M[1, 0]) == pytest.approx(expected, abs=1e-7)
+
+
+def test_entropy_fragment_matrix_matches_pair_with_sparse_candidate_columns():
+    spectrum_1 = build_spectrum([100.0, 200.0], [1.0, 0.8], precursor_mz=450.0)
+    spectra_2 = [
+        build_spectrum([100.005, 200.003], [1.0, 0.7], precursor_mz=450.0),
+        build_spectrum([100.01, 350.0], [0.9, 0.5], precursor_mz=450.0),
+        build_spectrum([199.99], [0.8], precursor_mz=450.0),
+    ]
+    for shift in range(15):
+        base = 500.0 + 10.0 * shift
+        spectra_2.append(build_spectrum([base, base + 0.3], [1.0, 0.5], precursor_mz=450.0))
+
+    fse = FlashEntropy(
+        matching_mode="fragment",
+        tolerance=0.02,
+        use_ppm=False,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=False,
+        merge_within=0.0,
+        dtype=np.float64,
+    )
+
+    matrix_scores = fse.matrix([spectrum_1], spectra_2, n_jobs=0, progress_bar=False)
+    M = matrix_scores.to_array()
+    assert M.shape == (1, len(spectra_2))
+    assert np.count_nonzero(M[0] > 0.0) == 3
+
+    for j, query in enumerate(spectra_2):
+        expected = float(fse.pair(spectrum_1, query))
+        assert float(M[0, j]) == pytest.approx(expected, abs=1e-7)
+
+
+# ----------------------------
+# Cosine / Modified Cosine path + baseline parity
+# ----------------------------
+
+def _mc_flash(tolerance, intensity_power=1.0):
+    return CosineFlash(
+        matching_mode="hybrid",  # hybrid = "modified cosine"
+        tolerance=tolerance,
+        intensity_power=intensity_power,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=True,
+        merge_within=0.0,
+        dtype=np.float64,
+    )
+
+
+@pytest.mark.parametrize(
+    "mz_a,int_a,pmz_a,mz_b,int_b,pmz_b,tol",
+    [
+        # 1) Clean shift, should match
+        pytest.param(
+            [100.0, 200.0, 300.0],
+            [0.8, 1.0, 0.6],
+            500.0,
+            [110.0, 210.002, 300.005],
+            [0.8, 1.0, 0.6],
+            510.0,
+            0.01,
+            id="pure_shift_exploited",
+        ),
+        # 2) Mixed: one shared unshifted fragment plus shifted set
+        # Expect both algorithms to pick the same best non-overlapping set.
+        pytest.param(
+            [100.0, 150.0, 200.0, 300.0],
+            [0.8, 0.2, 1.0, 0.6],
+            500.0,
+            [110.0, 150.0, 210.0005, 310.0],
+            [0.8, 0.2, 1.0, 0.6],
+            510.0,
+            0.01,
+            id="mixed_direct_and_shifted",
+        ),
+        # 3) Ambiguity: two query peaks within tolerance of the same shifted match
+        # This stresses greedy choice ordering and tie-breaking
+        pytest.param(
+            [100.0, 200.0],
+            [1.0, 0.5],
+            500.0,
+            [110.0, 110.007, 210.0],
+            [1.0, 1.0, 0.5],
+            510.0,
+            0.01,
+            id="duplicate_candidates_nearby",
+        ),
+        # 4) Competition: a direct fragment match competes with a shifted/NL match
+        # Constructed so dot products are close and greedy selection matters.
+        pytest.param(
+            [100.0, 200.0, 250.0],
+            [1.0, 0.9, 0.2],
+            500.0,
+            [110.0, 200.0, 260.0],
+            [1.0, 0.9, 0.2],
+            510.0,
+            0.01,
+            id="direct_competes_with_shifted",
+        ),
+        # 5) Edge tolerance: shifted peaks sit near the boundary
+        # To catch subtle differences in symmetric ppm/Da handling or window trimming.
+        pytest.param(
+            [100.0, 200.0, 300.0],
+            [0.8, 1.0, 0.6],
+            500.0,
+            [110.0099, 210.0099, 310.0099],
+            [0.8, 1.0, 0.6],
+            510.0,
+            0.01,
+            id="near_tolerance_boundary",
+        ),
+        # 6) Edge case: mass shift is inside the tolerance, so no shifted matches should be considered at all.
+        pytest.param(
+            [100.0],
+            [1.0],
+            500.009,
+            [99.985, 100.0],
+            [1.0, 0.1],
+            500.0,
+            0.01,
+            id="inside_tolerance_shift",
+        ),
+    ],
+)
+def test_flash_hybrid_cosine_matches_modified_cosine_greedy(mz_a, int_a, pmz_a, mz_b, int_b, pmz_b, tol):
+    a = build_spectrum(mz_a, int_a, precursor_mz=pmz_a)
+    b = build_spectrum(mz_b, int_b, precursor_mz=pmz_b)
+
+    for intensity_power in [1.0, 0.5]:  # Test with and without intensity weighting!
+        flash = _mc_flash(tol, intensity_power=intensity_power)
+        baseline = ModifiedCosineGreedy(tolerance=tol, intensity_power=intensity_power)
+
+        s_flash = float(flash.pair(a, b)["score"])
+        s_base = float(baseline.pair(a, b)["score"])
+        matches_flash = flash.pair(a, b)["matches"]
+        matches_base = baseline.pair(a, b)["matches"]
+
+        assert s_flash == pytest.approx(s_base, rel=1e-12, abs=1e-12)
+        assert matches_flash == matches_base
+
+
+def test_cosine_pair_matches_cosinegreedy_default_tolerance_001():
+    # Build a few pairs with clear fragment matches inside 0.01 Da
+    pairs = [
+        (
+            build_spectrum([100.000, 150.000, 200.000, 300.000], [0.6, 1.0, 0.8, 0.4], 500.0),
+            build_spectrum([100.005, 150.004, 200.007, 300.002], [0.6, 0.9, 0.8, 0.4], 500.0),
+        ),
+        (
+            build_spectrum([80.0, 120.0, 250.0], [0.9, 0.7, 1.0], 420.0),
+            build_spectrum([80.006, 120.004, 250.009], [0.9, 0.7, 1.0], 420.0),
+        ),
+    ]
+
+    flash = CosineFlash(
+        matching_mode="fragment",
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=True,
+        merge_within=0.0,
+        dtype=np.float64,
+    )
+    baseline = CosineGreedy(tolerance=0.01)
+
+    for a, b in pairs:
+        s_flash = flash.pair(a, b)["score"]
+        s_base = baseline.pair(a, b)["score"]
+        assert s_flash == pytest.approx(s_base, rel=1e-12, abs=1e-12)
+
+        matches_flash = flash.pair(a, b)["matches"]
+        matches_base = baseline.pair(a, b)["matches"]
+        assert matches_flash == matches_base
+
+
+def test_cosine_matrix_dense_matches_pair():
+    refs = [
+        build_spectrum([100, 150, 300], [0.6, 1.0, 0.4], precursor_mz=500.0),
+        build_spectrum([110, 250, 400], [0.5, 0.9, 0.7], precursor_mz=600.0),
+    ]
+    qs = [
+        build_spectrum([100.007, 150.002, 300.000], [0.6, 1.0, 0.4], precursor_mz=500.0),
+        build_spectrum([110.004, 250.009, 400.006], [0.5, 0.9, 0.7], precursor_mz=600.0),
+    ]
+    flash = CosineFlash(
+        matching_mode="fragment",
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=True,
+        merge_within=0.0,
+        dtype=np.float64,
+    )
+    scores = flash.matrix(refs, qs, n_jobs=0, progress_bar=False)
+    assert isinstance(scores, Scores)
+    M = scores.to_array("score")
+    assert M.shape == (2, 2)
+    for i, r in enumerate(refs):
+        for j, q in enumerate(qs):
+            expected = float(flash.pair(r, q)["score"])
+            assert float(M[i, j]) == pytest.approx(expected, abs=1e-12)
+
+
+def test_cosine_dtype_and_commutativity():
+    a = build_spectrum([100, 150, 300], [0.5, 1.0, 0.4], precursor_mz=600.0)
+    b = build_spectrum([100, 155, 295], [0.5, 0.8, 0.6], precursor_mz=600.0)
+    f32 = CosineFlash(dtype=np.float32, remove_precursor=False, noise_cutoff=0.0)
+    f64 = CosineFlash(dtype=np.float64, remove_precursor=False, noise_cutoff=0.0)
+
+    s_ab_32 = f32.pair(a, b)["score"]
+    s_ba_32 = f32.pair(b, a)["score"]
+    s_ab_64 = f64.pair(a, b)["score"]
+    s_ba_64 = f64.pair(b, a)["score"]
+
+    assert s_ab_32.dtype == np.float32 and s_ba_32.dtype == np.float32
+    assert s_ab_64.dtype == np.float64 and s_ba_64.dtype == np.float64
+    assert float(s_ab_32) == pytest.approx(float(s_ba_32), 1e-6)
+    assert float(s_ab_64) == pytest.approx(float(s_ba_64), 1e-12)
+
+
+def test_entropy_neutral_loss_does_not_include_fragment_matches():
+    reference = build_spectrum(
+        [100.0],
+        [1.0],
+        precursor_mz=500.0,
+    )
+    query = build_spectrum(
+        [100.0],
+        [1.0],
+        precursor_mz=510.0,
+    )
+
+    kwargs = {
+        "tolerance": 0.01,
+        "remove_precursor": False,
+        "noise_cutoff": 0.0,
+        "dtype": np.float64,
+    }
+
+    fragment = FlashEntropy(
+        matching_mode="fragment",
+        **kwargs,
+    ).pair(reference, query)
+
+    neutral_loss = FlashEntropy(
+        matching_mode="neutral_loss",
+        **kwargs,
+    ).pair(reference, query)
+
+    assert float(fragment) == pytest.approx(1.0)
+    assert float(neutral_loss) == 0.0
+
+
+def test_entropy_neutral_loss_matches_shifted_fragments():
+    reference = build_spectrum(
+        [100.0],
+        [1.0],
+        precursor_mz=500.0,
+    )
+    query = build_spectrum(
+        [110.0],
+        [1.0],
+        precursor_mz=510.0,
+    )
+
+    kwargs = {
+        "tolerance": 0.01,
+        "remove_precursor": False,
+        "noise_cutoff": 0.0,
+        "dtype": np.float64,
+    }
+
+    fragment = FlashEntropy(
+        matching_mode="fragment",
+        **kwargs,
+    ).pair(reference, query)
+
+    neutral_loss = FlashEntropy(
+        matching_mode="neutral_loss",
+        **kwargs,
+    ).pair(reference, query)
+
+    assert float(fragment) == 0.0
+    assert float(neutral_loss) == pytest.approx(1.0)
+
+
+def test_entropy_hybrid_combines_fragment_and_neutral_loss_matches():
+    reference = build_spectrum(
+        [100.0, 200.0],
+        [1.0, 1.0],
+        precursor_mz=500.0,
+    )
+    query = build_spectrum(
+        [100.0, 210.0],
+        [1.0, 1.0],
+        precursor_mz=510.0,
+    )
+
+    kwargs = {
+        "tolerance": 0.01,
+        "remove_precursor": False,
+        "noise_cutoff": 0.0,
+        "dtype": np.float64,
+    }
+
+    fragment = float(
+        FlashEntropy(matching_mode="fragment", **kwargs).pair(
+            reference, query
+        )
+    )
+    neutral_loss = float(
+        FlashEntropy(matching_mode="neutral_loss", **kwargs).pair(
+            reference, query
+        )
+    )
+    hybrid = float(
+        FlashEntropy(matching_mode="hybrid", **kwargs).pair(
+            reference, query
+        )
+    )
+
+    # 100 <-> 100 contributes 0.5 by fragment m/z.
+    assert fragment == pytest.approx(0.5)
+
+    # 200 <-> 210 contributes 0.5 by matching neutral loss 300.
+    assert neutral_loss == pytest.approx(0.5)
+
+    # Hybrid may use both because they involve different physical peaks.
+    assert hybrid == pytest.approx(1.0)
+
+
+def test_entropy_hybrid_does_not_double_count_fragment_and_neutral_loss():
+    reference = build_spectrum(
+        [100.0, 200.0],
+        [1.0, 1.0],
+        precursor_mz=500.0,
+    )
+    query = build_spectrum(
+        [100.0, 200.0],
+        [1.0, 1.0],
+        precursor_mz=500.0,
+    )
+
+    kwargs = {
+        "tolerance": 0.01,
+        "remove_precursor": False,
+        "noise_cutoff": 0.0,
+        "dtype": np.float64,
+    }
+
+    fragment = float(
+        FlashEntropy(matching_mode="fragment", **kwargs).pair(
+            reference, query
+        )
+    )
+    neutral_loss = float(
+        FlashEntropy(matching_mode="neutral_loss", **kwargs).pair(
+            reference, query
+        )
+    )
+    hybrid = float(
+        FlashEntropy(matching_mode="hybrid", **kwargs).pair(
+            reference, query
+        )
+    )
+
+    assert fragment == pytest.approx(1.0)
+    assert neutral_loss == pytest.approx(1.0)
+
+    # Same physical peaks cannot contribute twice.
+    assert hybrid == pytest.approx(1.0)
+
+
+def test_entropy_matching_modes_without_precursor_mz():
+    reference = build_spectrum([100.0], [1.0])
+    query = build_spectrum([100.0], [1.0])
+
+    kwargs = {
+        "tolerance": 0.01,
+        "remove_precursor": False,
+        "noise_cutoff": 0.0,
+        "dtype": np.float64,
+    }
+
+    fragment = float(
+        FlashEntropy(matching_mode="fragment", **kwargs).pair(
+            reference, query
+        )
+    )
+    neutral_loss = float(
+        FlashEntropy(matching_mode="neutral_loss", **kwargs).pair(
+            reference, query
+        )
+    )
+    hybrid = float(
+        FlashEntropy(matching_mode="hybrid", **kwargs).pair(
+            reference, query
+        )
+    )
+
+    assert fragment == pytest.approx(1.0)
+    assert neutral_loss == 0.0
+    assert hybrid == pytest.approx(fragment)
+
+
+@pytest.mark.parametrize(
+    "matching_mode",
+    ["fragment", "neutral_loss", "hybrid"],
+)
+def test_entropy_matrix_matches_pair_for_all_matching_modes(matching_mode):
+    refs = [
+        build_spectrum([100.0, 200.0], [1.0, 0.5], precursor_mz=500.0),
+        build_spectrum([110.0, 300.0], [0.3, 1.0], precursor_mz=600.0),
+    ]
+    queries = [
+        build_spectrum([100.0, 210.0], [1.0, 0.5], precursor_mz=510.0),
+        build_spectrum([110.0, 300.0], [1.0, 0.3], precursor_mz=600.0),
+    ]
+
+    similarity = FlashEntropy(
+        matching_mode=matching_mode,
+        tolerance=0.01,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        dtype=np.float64,
+    )
+
+    scores = similarity.matrix(
+        refs,
+        queries,
+        n_jobs=0,
+        progress_bar=False,
+    ).to_array()
+
+    for i, reference in enumerate(refs):
+        for j, query in enumerate(queries):
+            expected = similarity.pair(reference, query)
+            assert scores[i, j] == pytest.approx(
+                float(expected),
+                abs=1e-12,
+            )

--- a/tests/similarity/test_flash_utils.py
+++ b/tests/similarity/test_flash_utils.py
@@ -1,4 +1,3 @@
-import math
 import numpy as np
 import pytest
 from matchms import SpectraCollection

--- a/tests/similarity/test_flash_utils.py
+++ b/tests/similarity/test_flash_utils.py
@@ -1,236 +1,762 @@
 import math
 import numpy as np
 import pytest
+from matchms import SpectraCollection
 from matchms.similarity.flash_utils import (
-    _build_library_index,
+    _build_library_index_from_prepared,
     _clean_and_weight,
+    _compute_l2_by_row,
     _entropy_weight,
+    _entropy_weight_packed,
     _LibraryIndex,
-    _merge_within,
+    _prepare_collection,
+    _rebuild_offsets,
+    _row_ids_from_offsets,
 )
+from matchms.similarity.flash_utils_spectrum_list import _clean_and_weight as _clean_and_weight_old
+from ..builder_spectrum import SpectrumBuilder
 
 
-# ----------------------------
-# Entropy weighting
-# ----------------------------
+# -------------------------------------------------------------------------
+# Helpers
+# -------------------------------------------------------------------------
+
+def build_spectrum(mz, intens, precursor_mz=None):
+    builder = (
+        SpectrumBuilder()
+        .with_mz(np.asarray(mz, dtype=float))
+        .with_intensities(np.asarray(intens, dtype=float))
+    )
+
+    if precursor_mz is not None:
+        if hasattr(builder, "with_precursor_mz"):
+            builder = builder.with_precursor_mz(float(precursor_mz))
+        elif hasattr(builder, "with_metadata"):
+            builder = builder.with_metadata(
+                {"precursor_mz": float(precursor_mz)}
+            )
+
+    return builder.build()
+
+
+def build_collection(*spectra):
+    return SpectraCollection(
+        list(spectra),
+        mz_precision=1e-6,
+    )
+
+
+def prepared_row(prepared, row):
+    start = prepared.spec_offsets[row]
+    end = prepared.spec_offsets[row + 1]
+    return np.column_stack(
+        (
+            prepared.spec_mz[start:end],
+            prepared.spec_int[start:end],
+        )
+    )
+
+
+# -------------------------------------------------------------------------
+# Existing single-spectrum helper behaviour
+# -------------------------------------------------------------------------
 
 def test_entropy_weight_behaviour():
-    intens = np.array([1.0, 2.0, 3.0, 4.0], dtype=float)
-    p = intens / intens.sum()
-    # ms_entropy uses natural-log spectral entropy in the weighting step.
+    intensities = np.array([1.0, 2.0, 3.0, 4.0], dtype=float)
+
+    p = intensities / intensities.sum()
     entropy = float(-np.sum(p * np.log(p)))
-    w = 0.25 + 0.25 * entropy
-    expected = np.power(intens, w).astype(np.float32)
-    got = _entropy_weight(intens, np.float32)
-    assert np.allclose(got, expected, rtol=0, atol=1e-7)
+    weight = 0.25 + 0.25 * entropy
 
+    expected = np.power(intensities, weight).astype(np.float32)
+    result = _entropy_weight(intensities, np.float32)
 
-def test_entropy_weight_zero_total_returns_input():
-    intens = np.array([0.0, 0.0, 0.0, 0.0], dtype=float)
-    got = _entropy_weight(intens, np.float32)
-    # Should be returned as-is (dtype conversion allowed)
-    assert got.dtype == np.float32
-    assert np.allclose(got, 0.0, atol=0.0)
-
-
-def test_entropy_weight_saturation_at_ge3_nats():
-    # 32 equal bins => entropy = ln(32) > 3.0 -> no weighting should be applied.
-    intens = np.ones(32, dtype=float)
-    got = _entropy_weight(intens, np.float32)
-    assert np.allclose(got, intens.astype(np.float32), atol=0.0)
-
-
-# ----------------------------
-# Merge-within
-# ----------------------------
-
-def test_merge_within_weighted_average():
-    # two close peaks at 100.00 and 100.03 within 0.05 should merge
-    peaks = np.column_stack([
-        np.array([100.00, 100.03, 120.0], dtype=np.float32),
-        np.array([1.0,    3.0,    2.0], dtype=np.float32),
-    ])
-    out = _merge_within(peaks, max_delta_da=0.05)
-    # first two merged into weighted center: (100*1 + 100.03*3) / (1+3) = 100.0225
-    assert out.shape == (2, 2)
-    assert math.isclose(out[0, 0], np.array(100.0225, dtype=np.float32), rel_tol=0, abs_tol=1e-6)
-    assert math.isclose(out[0, 1], 4.0, rel_tol=0, abs_tol=1e-6)
-    assert math.isclose(out[1, 0], 120.0, rel_tol=0, abs_tol=1e-6)
-    assert math.isclose(out[1, 1], 2.0, rel_tol=0, abs_tol=1e-6)
-
-
-def test_merge_within_no_merge_and_zero_total_behaviour():
-    # No merge if beyond threshold
-    peaks_far = np.array([[100.0, 1.0], [100.2, 2.0]], dtype=np.float32)
-    out_far = _merge_within(peaks_far, max_delta_da=0.05)
-    assert np.allclose(out_far, peaks_far)
-
-    # Merge two zero-intensity peaks within threshold -> intensity remains 0,
-    # mz becomes last seen (code path total <= 0)
-    peaks_zero = np.array([[100.00, 0.0], [100.02, 0.0]], dtype=np.float32)
-    out_zero = _merge_within(peaks_zero, max_delta_da=0.05)
-    assert out_zero.shape == (1, 2)
-    assert math.isclose(out_zero[0, 0], 100.02, rel_tol=1e-6)
-    assert math.isclose(out_zero[0, 1], 0.0, abs_tol=0.0)
-
-
-# ----------------------------
-# Preprocessing pipeline
-# ----------------------------
-
-def test_clean_and_weight_pipeline_precursor_noise_norm_merge():
-    # Note: pass peaks as shape (N, 2)
-    mz = np.array([100, 199.0, 199.5, 199.9, 210], dtype=float)
-    intens = np.array([0.05, 0.2, 0.01, 0.2,  0.01], dtype=float)
-    pmz = 200.0
-    out = _clean_and_weight(
-        np.column_stack([mz, intens]),
-        precursor_mz=pmz,
-        remove_precursor=True,
-        offset_to_precursor=-1.6,   # keep only <= 198.4
-        noise_cutoff=0.05,      # remove peaks below 5% of max (max AFTER precursor filter)
-        normalize_to_half=True,
-        merge_within_da=0.5,    # merge anything within 0.5 Da
-        weighing_type="entropy",
-        dtype=np.float32
+    assert np.allclose(
+        result,
+        expected,
+        rtol=0,
+        atol=1e-7,
     )
-    # Only m/z=100 survives precursor filter (<=198.4); others removed
-    assert out.shape[0] == 1
-    assert math.isclose(out[0, 0], 100.0, rel_tol=0, abs_tol=1e-12)
-    # Intensities are entropy-weighted then normalized to sum 0.5
-    assert math.isclose(float(out[:, 1].sum()), 0.5, rel_tol=0, abs_tol=1e-7)
 
 
-def test_clean_and_weight_cosine_weighting_no_change_when_not_normalized():
-    peaks = np.array([[100.0, 1.0], [150.0, 2.0], [200.0, 3.0]], dtype=float)
-    out = _clean_and_weight(peaks,
-                            precursor_mz=None,
-                            remove_precursor=False,
-                            offset_to_precursor=-1.6,
-                            noise_cutoff=0.0,
-                            normalize_to_half=False,   # ensure no scaling applied
-                            merge_within_da=0.0,
-                            weighing_type="cosine",
-                            dtype=np.float32)
-    assert out.dtype == np.float32
-    assert np.allclose(out[:, 0], peaks[:, 0])
-    assert np.allclose(out[:, 1], peaks[:, 1])
+def test_entropy_weight_zero_total_returns_zero():
+    intensities = np.zeros(4, dtype=float)
+
+    result = _entropy_weight(
+        intensities,
+        np.float32,
+    )
+
+    assert result.dtype == np.float32
+    assert np.allclose(result, 0.0)
 
 
-def test_clean_and_weight_raises_on_unknown_weighing_type():
-    peaks = np.array([[100.0, 1.0]], dtype=float)
-    with pytest.raises(ValueError, match="Score type '.*' not recognized"):
-        _clean_and_weight(peaks,
-                          precursor_mz=None,
-                          remove_precursor=False,
-                          offset_to_precursor=-1.6,
-                          noise_cutoff=0.0,
-                          normalize_to_half=False,
-                          merge_within_da=0.0,
-                          weighing_type="nope",
-                          dtype=np.float32)
+def test_entropy_weight_saturation_at_three_nats():
+    intensities = np.ones(32, dtype=float)
+
+    result = _entropy_weight(
+        intensities,
+        np.float32,
+    )
+
+    assert np.allclose(
+        result,
+        intensities.astype(np.float32),
+        atol=0.0,
+    )
 
 
-# ----------------------------
-# _LibraryIndex / _build_library_index
-# ----------------------------
+def test_clean_and_weight_matches_old_implementation():
+    peaks = np.array(
+        [
+            [100.00, 0.05],
+            [150.00, 1.00],
+            [150.03, 0.50],
+            [198.00, 0.20],
+            [199.00, 0.90],
+        ],
+        dtype=float,
+    )
 
-def test_library_index_empty_with_neutral_loss_and_l2():
-    idx = _build_library_index([],
-                               [],
-                               compute_neutral_loss=True,
-                               compute_l2_norm=True,
-                               dtype=np.float32)
-    assert isinstance(idx, _LibraryIndex)
-    assert idx.n_specs == 0
-    assert idx.peaks_mz.size == 0 and idx.peaks_int.size == 0 and idx.peaks_spec_idx.size == 0
-    assert idx.spec_offsets.shape == (1,)
-    assert idx.spec_mz.size == 0 and idx.spec_int.size == 0
-    assert idx.nl_mz.size == 0 and idx.nl_int.size == 0 and idx.nl_spec_idx.size == 0 and idx.nl_product_idx.size == 0
-    assert idx.spec_l2.size == 0
-    assert idx.precursor_mz.size == 0
-    assert idx.dtype == np.float32
+    kwargs = {
+        "precursor_mz": 200.0,
+        "remove_precursor": True,
+        "offset_to_precursor": -1.6,
+        "noise_cutoff": 0.05,
+        "normalize_to_half": True,
+        "merge_within_da": 0.05,
+        "weighing_type": "entropy",
+        "dtype": np.float32,
+    }
 
+    old = _clean_and_weight_old(
+        peaks,
+        **kwargs,
+    )
+    new = _clean_and_weight(
+        peaks,
+        **kwargs,
+    )
 
-def test_library_index_single_spec_no_precursor_no_nl():
-    # One spectrum, no precursor -> NL arrays empty; L2 present if requested.
-    p = np.array([[100.0, 1.0], [200.0, 2.0]], dtype=np.float32)
-    idx = _build_library_index([p], [None],
-                               compute_neutral_loss=True,
-                               compute_l2_norm=True,
-                               dtype=np.float32)
-    assert idx.n_specs == 1
-    assert np.all(idx.spec_offsets == np.array([0, 2], dtype=np.int64))
-    assert np.allclose(idx.spec_mz, [100.0, 200.0])
-    assert np.allclose(idx.spec_int, [1.0, 2.0])
-    # Peaks sorted ascending
-    assert np.allclose(idx.peaks_mz, [100.0, 200.0])
-    assert np.allclose(idx.peaks_int, [1.0, 2.0])
-    assert idx.peaks_spec_idx.dtype == np.int32
-    assert np.all(idx.peaks_spec_idx == np.array([0, 0], dtype=np.int32))
-    # NL empty due to missing pmz
-    assert idx.nl_mz.size == 0 and idx.nl_int.size == 0
-    # L2 norm sqrt(1^2+2^2)
-    assert math.isclose(float(idx.spec_l2[0]), math.sqrt(5.0), rel_tol=0, abs_tol=1e-6)
-    # precursor array filled with NaN
-    assert np.isnan(idx.precursor_mz[0])
+    assert new.dtype == np.float32
+    assert np.allclose(
+        new,
+        old,
+        atol=1e-6,
+    )
 
 
-def test_library_index_two_specs_with_pmz_nl_sorted_and_product_mapping():
-    # Spec 0: pmz=500 peaks -> products [100, 300], NL [400, 200]
-    # Spec 1: pmz=510 peaks -> product [150], NL [360]
-    p0 = np.array([[100.0, 0.5], [300.0, 0.2]], dtype=np.float32)
-    p1 = np.array([[150.0, 0.8]], dtype=np.float32)
-    idx = _build_library_index([p0, p1], [500.0, 510.0],
-                               compute_neutral_loss=True,
-                               compute_l2_norm=True,
-                               dtype=np.float32)
+@pytest.mark.parametrize(
+    "weighing_type",
+    ["cosine", "entropy"],
+)
+def test_clean_and_weight_empty_input(weighing_type):
+    peaks = np.empty((0, 2), dtype=float)
 
-    # Spectrum-major view keeps per-spectrum ordering.
-    assert np.all(idx.spec_offsets == np.array([0, 2, 3], dtype=np.int64))
-    assert np.allclose(idx.spec_mz, [100.0, 300.0, 150.0], atol=1e-12)
-    assert np.allclose(idx.spec_int, [0.5, 0.2, 0.8], atol=1e-12)
+    result = _clean_and_weight(
+        peaks,
+        precursor_mz=None,
+        remove_precursor=False,
+        offset_to_precursor=-1.6,
+        noise_cutoff=0.0,
+        normalize_to_half=False,
+        merge_within_da=0.0,
+        weighing_type=weighing_type,
+        dtype=np.float32,
+    )
 
-    # Product arrays are globally sorted by m/z
-    assert np.allclose(idx.peaks_mz, [100.0, 150.0, 300.0], atol=1e-12)
-    assert np.all(idx.peaks_spec_idx == np.array([0, 1, 0], dtype=np.int32))
-    assert np.allclose(idx.peaks_int, [0.5, 0.8, 0.2], atol=1e-12)
+    assert result.shape == (0, 2)
+    assert result.dtype == np.float32
 
-    # Neutral-loss values (unsorted would be [400,200,360]); verify sorted ascending
-    assert np.allclose(np.sort(idx.nl_mz), idx.nl_mz, atol=0.0)
-    assert idx.nl_mz.size == 3
-    # Spec indices carried along and product index maps to corresponding product peak
+
+def test_clean_and_weight_rejects_unknown_weighing_type():
+    peaks = np.array([[100.0, 1.0]])
+
+    with pytest.raises(
+        ValueError,
+        match="Score type '.*' not recognized",
+    ):
+        _clean_and_weight(
+            peaks,
+            precursor_mz=None,
+            remove_precursor=False,
+            offset_to_precursor=-1.6,
+            noise_cutoff=0.0,
+            normalize_to_half=False,
+            merge_within_da=0.0,
+            weighing_type="invalid",
+        )
+
+
+# -------------------------------------------------------------------------
+# Packed-row helpers
+# -------------------------------------------------------------------------
+
+def test_row_ids_from_offsets():
+    offsets = np.array(
+        [0, 2, 2, 5],
+        dtype=np.int64,
+    )
+
+    result = _row_ids_from_offsets(offsets)
+
+    assert np.array_equal(
+        result,
+        np.array(
+            [0, 0, 2, 2, 2],
+            dtype=np.int32,
+        ),
+    )
+
+
+def test_rebuild_offsets_with_empty_rows():
+    spec_idx = np.array(
+        [0, 0, 2, 2, 2],
+        dtype=np.int32,
+    )
+
+    offsets = _rebuild_offsets(
+        spec_idx,
+        n_specs=4,
+    )
+
+    assert np.array_equal(
+        offsets,
+        np.array(
+            [0, 2, 2, 5, 5],
+            dtype=np.int64,
+        ),
+    )
+
+
+def test_compute_l2_by_row():
+    intensities = np.array(
+        [3.0, 4.0, 2.0],
+        dtype=np.float64,
+    )
+    offsets = np.array(
+        [0, 2, 2, 3],
+        dtype=np.int64,
+    )
+
+    result = _compute_l2_by_row(
+        intensities,
+        offsets,
+        np.float64,
+    )
+
+    assert np.allclose(
+        result,
+        [5.0, 0.0, 2.0],
+        atol=1e-12,
+    )
+
+
+def test_entropy_weight_packed_matches_per_spectrum_weighting():
+    intensities = np.array(
+        [1.0, 2.0, 3.0, 4.0, 2.0],
+        dtype=np.float64,
+    )
+    spec_idx = np.array(
+        [0, 0, 1, 1, 1],
+        dtype=np.int32,
+    )
+
+    result = _entropy_weight_packed(
+        intensities,
+        spec_idx,
+        n_specs=2,
+        dtype=np.float64,
+    )
+
+    expected = np.concatenate(
+        [
+            _entropy_weight(
+                intensities[:2],
+                np.float64,
+            ),
+            _entropy_weight(
+                intensities[2:],
+                np.float64,
+            ),
+        ]
+    )
+
+    assert np.allclose(
+        result,
+        expected,
+        atol=1e-12,
+    )
+
+
+# -------------------------------------------------------------------------
+# SpectraCollection preprocessing
+# -------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "weighing_type,normalize_to_half,compute_l2",
+    [
+        ("cosine", False, True),
+        ("cosine", True, True),
+        ("entropy", False, False),
+        ("entropy", True, False),
+    ],
+)
+def test_prepare_collection_matches_single_spectrum_preprocessing(
+    weighing_type,
+    normalize_to_half,
+    compute_l2,
+):
+    spectra = [
+        build_spectrum(
+            [100.0, 150.0, 150.03, 199.0],
+            [0.05, 1.0, 0.5, 0.2],
+            precursor_mz=200.0,
+        ),
+        build_spectrum(
+            [80.0, 120.0, 250.0],
+            [0.1, 0.7, 1.0],
+            precursor_mz=300.0,
+        ),
+        build_spectrum(
+            [50.0, 70.0],
+            [0.0, 0.0],
+            precursor_mz=None,
+        ),
+    ]
+
+    collection = build_collection(*spectra)
+
+    kwargs = {
+        "intensity_power": 0.5,
+        "remove_precursor": True,
+        "offset_to_precursor": -1.6,
+        "noise_cutoff": 0.05,
+        "normalize_to_half": normalize_to_half,
+        "merge_within_da": 0.05,
+        "weighing_type": weighing_type,
+        "compute_l2_norm": compute_l2,
+        "dtype": np.float64,
+    }
+
+    prepared = _prepare_collection(
+        collection,
+        **kwargs,
+    )
+
+    assert prepared.n_specs == len(spectra)
+    assert prepared.spec_offsets.shape == (
+        len(spectra) + 1,
+    )
+
+    for row, spectrum in enumerate(spectra):
+        expected = _clean_and_weight(
+            spectrum.peaks.to_numpy,
+            precursor_mz=spectrum.get(
+                "precursor_mz",
+                None,
+            ),
+            remove_precursor=kwargs["remove_precursor"],
+            offset_to_precursor=kwargs[
+                "offset_to_precursor"
+            ],
+            noise_cutoff=kwargs["noise_cutoff"],
+            normalize_to_half=kwargs[
+                "normalize_to_half"
+            ],
+            merge_within_da=kwargs[
+                "merge_within_da"
+            ],
+            weighing_type=kwargs[
+                "weighing_type"
+            ],
+            intensity_power=kwargs[
+                "intensity_power"
+            ],
+            dtype=kwargs["dtype"],
+        )
+
+        actual = prepared_row(
+            prepared,
+            row,
+        )
+
+        assert actual.shape == expected.shape
+        assert np.allclose(
+            actual,
+            expected,
+            atol=2e-6,
+        )
+
+
+def test_prepare_collection_precursor_filter_is_row_specific():
+    collection = build_collection(
+        build_spectrum(
+            [100.0, 199.0],
+            [1.0, 1.0],
+            precursor_mz=200.0,
+        ),
+        build_spectrum(
+            [100.0, 199.0],
+            [1.0, 1.0],
+            precursor_mz=250.0,
+        ),
+    )
+
+    prepared = _prepare_collection(
+        collection,
+        remove_precursor=True,
+        offset_to_precursor=-1.6,
+        noise_cutoff=0.0,
+        weighing_type="cosine",
+        dtype=np.float64,
+    )
+
+    first = prepared_row(
+        prepared,
+        0,
+    )
+    second = prepared_row(
+        prepared,
+        1,
+    )
+
+    assert np.allclose(
+        first[:, 0],
+        [100.0],
+    )
+    assert np.allclose(
+        second[:, 0],
+        [100.0, 199.0],
+    )
+
+
+def test_prepare_collection_missing_precursor_keeps_peaks():
+    collection = build_collection(
+        build_spectrum(
+            [100.0, 300.0],
+            [1.0, 1.0],
+        ),
+    )
+
+    prepared = _prepare_collection(
+        collection,
+        remove_precursor=True,
+        offset_to_precursor=-1.6,
+        noise_cutoff=0.0,
+        weighing_type="cosine",
+        dtype=np.float64,
+    )
+
+    row = prepared_row(
+        prepared,
+        0,
+    )
+
+    assert np.allclose(
+        row[:, 0],
+        [100.0, 300.0],
+    )
+    assert np.isnan(
+        prepared.precursor_mz[0]
+    )
+
+
+def test_prepare_collection_relative_noise_filter_is_per_row():
+    collection = build_collection(
+        build_spectrum(
+            [100.0, 200.0],
+            [100.0, 5.0],
+        ),
+        build_spectrum(
+            [100.0, 200.0],
+            [1.0, 0.2],
+        ),
+    )
+
+    prepared = _prepare_collection(
+        collection,
+        remove_precursor=False,
+        noise_cutoff=0.1,
+        weighing_type="cosine",
+        dtype=np.float64,
+    )
+
+    row_0 = prepared_row(
+        prepared,
+        0,
+    )
+    row_1 = prepared_row(
+        prepared,
+        1,
+    )
+
+    assert np.allclose(
+        row_0[:, 0],
+        [100.0],
+    )
+    assert np.allclose(
+        row_1[:, 0],
+        [100.0, 200.0],
+    )
+
+
+def test_prepare_collection_normalizes_each_row_to_half():
+    collection = build_collection(
+        build_spectrum(
+            [100.0, 200.0],
+            [1.0, 3.0],
+        ),
+        build_spectrum(
+            [100.0, 200.0],
+            [2.0, 2.0],
+        ),
+    )
+
+    prepared = _prepare_collection(
+        collection,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=True,
+        weighing_type="cosine",
+        dtype=np.float64,
+    )
+
+    for row in range(2):
+        actual = prepared_row(
+            prepared,
+            row,
+        )
+        assert actual[:, 1].sum() == pytest.approx(
+            0.5,
+            abs=1e-12,
+        )
+
+
+def test_prepare_collection_computes_l2_after_preprocessing():
+    collection = build_collection(
+        build_spectrum(
+            [100.0, 200.0],
+            [3.0, 4.0],
+        ),
+    )
+
+    prepared = _prepare_collection(
+        collection,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        normalize_to_half=False,
+        weighing_type="cosine",
+        compute_l2_norm=True,
+        dtype=np.float64,
+    )
+
+    assert prepared.spec_l2 is not None
+    assert prepared.spec_l2[0] == pytest.approx(
+        5.0,
+        abs=1e-12,
+    )
+
+
+def test_prepare_collection_rejects_unknown_weighing_type():
+    collection = build_collection(
+        build_spectrum(
+            [100.0],
+            [1.0],
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Score type '.*' not recognized",
+    ):
+        _prepare_collection(
+            collection,
+            weighing_type="invalid",
+        )
+
+
+# -------------------------------------------------------------------------
+# Library index
+# -------------------------------------------------------------------------
+
+def test_library_index_from_prepared_fragment_arrays():
+    collection = build_collection(
+        build_spectrum(
+            [100.0, 300.0],
+            [0.5, 0.2],
+            precursor_mz=500.0,
+        ),
+        build_spectrum(
+            [150.0],
+            [0.8],
+            precursor_mz=510.0,
+        ),
+    )
+
+    prepared = _prepare_collection(
+        collection,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        weighing_type="cosine",
+        compute_l2_norm=True,
+        dtype=np.float32,
+    )
+
+    idx = _build_library_index_from_prepared(
+        prepared,
+        compute_neutral_loss=True,
+        compute_l2_norm=True,
+    )
+
+    assert isinstance(
+        idx,
+        _LibraryIndex,
+    )
+    assert idx.n_specs == 2
+
+    # Spectrum-major representation.
+    assert np.array_equal(
+        idx.spec_offsets,
+        np.array(
+            [0, 2, 3],
+            dtype=np.int64,
+        ),
+    )
+    assert np.allclose(
+        idx.spec_mz,
+        [100.0, 300.0, 150.0],
+        atol=1e-6,
+    )
+    assert np.allclose(
+        idx.spec_int,
+        [0.5, 0.2, 0.8],
+        atol=1e-6,
+    )
+
+    # Globally sorted fragment index.
+    assert np.allclose(
+        idx.peaks_mz,
+        [100.0, 150.0, 300.0],
+        atol=1e-6,
+    )
+    assert np.array_equal(
+        idx.peaks_spec_idx,
+        np.array(
+            [0, 1, 0],
+            dtype=np.int32,
+        ),
+    )
+
+
+def test_library_index_neutral_loss_mapping_points_to_product_peak():
+    collection = build_collection(
+        build_spectrum(
+            [100.0, 300.0],
+            [0.5, 0.2],
+            precursor_mz=500.0,
+        ),
+        build_spectrum(
+            [150.0],
+            [0.8],
+            precursor_mz=510.0,
+        ),
+    )
+
+    prepared = _prepare_collection(
+        collection,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        weighing_type="cosine",
+        dtype=np.float64,
+    )
+
+    idx = _build_library_index_from_prepared(
+        prepared,
+        compute_neutral_loss=True,
+    )
+
+    assert np.all(
+        np.diff(idx.nl_mz) >= 0
+    )
+
     for k in range(idx.nl_mz.size):
-        col = int(idx.nl_spec_idx[k])
-        pmz = float(idx.precursor_mz[col])
-        loss = float(idx.nl_mz[k])
-        # product m/z that generated this loss
-        expected_prod_mz = pmz - loss
-        prod_pos = int(idx.nl_product_idx[k])
-        assert math.isclose(float(idx.peaks_mz[prod_pos]), expected_prod_mz, abs_tol=1e-6)
+        spectrum_idx = int(
+            idx.nl_spec_idx[k]
+        )
+        precursor_mz = float(
+            idx.precursor_mz[spectrum_idx]
+        )
+        neutral_loss = float(
+            idx.nl_mz[k]
+        )
 
-    # L2 per spectrum
-    # spec0: sqrt(0.5^2 + 0.2^2) ; spec1: sqrt(0.8^2)
-    expected0 = math.sqrt(0.25 + 0.04)
-    expected1 = 0.8
-    assert math.isclose(float(idx.spec_l2[0]), expected0, abs_tol=1e-6)
-    assert math.isclose(float(idx.spec_l2[1]), expected1, abs_tol=1e-6)
-    # dtype preserved
-    assert idx.dtype == np.float32
-    assert idx.peaks_mz.dtype == np.float32
-    assert idx.nl_mz.dtype == np.float32
+        product_position = int(
+            idx.nl_product_idx[k]
+        )
+        product_mz = float(
+            idx.peaks_mz[
+                product_position
+            ]
+        )
+
+        assert product_mz == pytest.approx(
+            precursor_mz - neutral_loss,
+            abs=1e-8,
+        )
 
 
-def test_library_index_dtype_float64_and_values():
-    p = np.array([[100.0, 1.0], [200.0, 2.0]], dtype=np.float64)
-    idx = _build_library_index([p], [500.0],
-                               compute_neutral_loss=True,
-                               compute_l2_norm=True,
-                               dtype=np.float64)
-    assert idx.dtype == np.float64
-    assert idx.peaks_mz.dtype == np.float64
-    assert idx.nl_mz.dtype == np.float64
-    # NL values should be [400, 300] (sorted -> [300, 400])
-    assert np.allclose(idx.nl_mz, [300.0, 400.0], atol=1e-12)
-    # L2 = sqrt(1^2 + 2^2)
-    assert math.isclose(float(idx.spec_l2[0]), math.sqrt(5.0), abs_tol=1e-12)
+def test_library_index_omits_neutral_losses_for_missing_precursor():
+    collection = build_collection(
+        build_spectrum(
+            [100.0, 200.0],
+            [1.0, 2.0],
+        ),
+    )
+
+    prepared = _prepare_collection(
+        collection,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        weighing_type="cosine",
+        dtype=np.float64,
+    )
+
+    idx = _build_library_index_from_prepared(
+        prepared,
+        compute_neutral_loss=True,
+    )
+
+    assert idx.nl_mz.size == 0
+    assert idx.nl_int.size == 0
+    assert idx.nl_spec_idx.size == 0
+    assert idx.nl_product_idx.size == 0
+
+
+def test_library_index_reuses_precomputed_l2():
+    collection = build_collection(
+        build_spectrum(
+            [100.0, 200.0],
+            [3.0, 4.0],
+        ),
+    )
+
+    prepared = _prepare_collection(
+        collection,
+        remove_precursor=False,
+        noise_cutoff=0.0,
+        weighing_type="cosine",
+        compute_l2_norm=True,
+        dtype=np.float64,
+    )
+
+    idx = _build_library_index_from_prepared(
+        prepared,
+        compute_l2_norm=True,
+    )
+
+    assert idx.spec_l2 is prepared.spec_l2
+    assert idx.spec_l2[0] == pytest.approx(
+        5.0,
+        abs=1e-12,
+    )

--- a/tests/similarity/test_flash_utils_spectrum_list.py
+++ b/tests/similarity/test_flash_utils_spectrum_list.py
@@ -1,0 +1,236 @@
+import math
+import numpy as np
+import pytest
+from matchms.similarity.flash_utils_spectrum_list import (
+    _build_library_index,
+    _clean_and_weight,
+    _entropy_weight,
+    _LibraryIndex,
+    _merge_within,
+)
+
+
+# ----------------------------
+# Entropy weighting
+# ----------------------------
+
+def test_entropy_weight_behaviour():
+    intens = np.array([1.0, 2.0, 3.0, 4.0], dtype=float)
+    p = intens / intens.sum()
+    # ms_entropy uses natural-log spectral entropy in the weighting step.
+    entropy = float(-np.sum(p * np.log(p)))
+    w = 0.25 + 0.25 * entropy
+    expected = np.power(intens, w).astype(np.float32)
+    got = _entropy_weight(intens, np.float32)
+    assert np.allclose(got, expected, rtol=0, atol=1e-7)
+
+
+def test_entropy_weight_zero_total_returns_input():
+    intens = np.array([0.0, 0.0, 0.0, 0.0], dtype=float)
+    got = _entropy_weight(intens, np.float32)
+    # Should be returned as-is (dtype conversion allowed)
+    assert got.dtype == np.float32
+    assert np.allclose(got, 0.0, atol=0.0)
+
+
+def test_entropy_weight_saturation_at_ge3_nats():
+    # 32 equal bins => entropy = ln(32) > 3.0 -> no weighting should be applied.
+    intens = np.ones(32, dtype=float)
+    got = _entropy_weight(intens, np.float32)
+    assert np.allclose(got, intens.astype(np.float32), atol=0.0)
+
+
+# ----------------------------
+# Merge-within
+# ----------------------------
+
+def test_merge_within_weighted_average():
+    # two close peaks at 100.00 and 100.03 within 0.05 should merge
+    peaks = np.column_stack([
+        np.array([100.00, 100.03, 120.0], dtype=np.float32),
+        np.array([1.0,    3.0,    2.0], dtype=np.float32),
+    ])
+    out = _merge_within(peaks, max_delta_da=0.05)
+    # first two merged into weighted center: (100*1 + 100.03*3) / (1+3) = 100.0225
+    assert out.shape == (2, 2)
+    assert math.isclose(out[0, 0], np.array(100.0225, dtype=np.float32), rel_tol=0, abs_tol=1e-6)
+    assert math.isclose(out[0, 1], 4.0, rel_tol=0, abs_tol=1e-6)
+    assert math.isclose(out[1, 0], 120.0, rel_tol=0, abs_tol=1e-6)
+    assert math.isclose(out[1, 1], 2.0, rel_tol=0, abs_tol=1e-6)
+
+
+def test_merge_within_no_merge_and_zero_total_behaviour():
+    # No merge if beyond threshold
+    peaks_far = np.array([[100.0, 1.0], [100.2, 2.0]], dtype=np.float32)
+    out_far = _merge_within(peaks_far, max_delta_da=0.05)
+    assert np.allclose(out_far, peaks_far)
+
+    # Merge two zero-intensity peaks within threshold -> intensity remains 0,
+    # mz becomes last seen (code path total <= 0)
+    peaks_zero = np.array([[100.00, 0.0], [100.02, 0.0]], dtype=np.float32)
+    out_zero = _merge_within(peaks_zero, max_delta_da=0.05)
+    assert out_zero.shape == (1, 2)
+    assert math.isclose(out_zero[0, 0], 100.02, rel_tol=1e-6)
+    assert math.isclose(out_zero[0, 1], 0.0, abs_tol=0.0)
+
+
+# ----------------------------
+# Preprocessing pipeline
+# ----------------------------
+
+def test_clean_and_weight_pipeline_precursor_noise_norm_merge():
+    # Note: pass peaks as shape (N, 2)
+    mz = np.array([100, 199.0, 199.5, 199.9, 210], dtype=float)
+    intens = np.array([0.05, 0.2, 0.01, 0.2,  0.01], dtype=float)
+    pmz = 200.0
+    out = _clean_and_weight(
+        np.column_stack([mz, intens]),
+        precursor_mz=pmz,
+        remove_precursor=True,
+        offset_to_precursor=-1.6,   # keep only <= 198.4
+        noise_cutoff=0.05,      # remove peaks below 5% of max (max AFTER precursor filter)
+        normalize_to_half=True,
+        merge_within_da=0.5,    # merge anything within 0.5 Da
+        weighing_type="entropy",
+        dtype=np.float32
+    )
+    # Only m/z=100 survives precursor filter (<=198.4); others removed
+    assert out.shape[0] == 1
+    assert math.isclose(out[0, 0], 100.0, rel_tol=0, abs_tol=1e-12)
+    # Intensities are entropy-weighted then normalized to sum 0.5
+    assert math.isclose(float(out[:, 1].sum()), 0.5, rel_tol=0, abs_tol=1e-7)
+
+
+def test_clean_and_weight_cosine_weighting_no_change_when_not_normalized():
+    peaks = np.array([[100.0, 1.0], [150.0, 2.0], [200.0, 3.0]], dtype=float)
+    out = _clean_and_weight(peaks,
+                            precursor_mz=None,
+                            remove_precursor=False,
+                            offset_to_precursor=-1.6,
+                            noise_cutoff=0.0,
+                            normalize_to_half=False,   # ensure no scaling applied
+                            merge_within_da=0.0,
+                            weighing_type="cosine",
+                            dtype=np.float32)
+    assert out.dtype == np.float32
+    assert np.allclose(out[:, 0], peaks[:, 0])
+    assert np.allclose(out[:, 1], peaks[:, 1])
+
+
+def test_clean_and_weight_raises_on_unknown_weighing_type():
+    peaks = np.array([[100.0, 1.0]], dtype=float)
+    with pytest.raises(ValueError, match="Score type '.*' not recognized"):
+        _clean_and_weight(peaks,
+                          precursor_mz=None,
+                          remove_precursor=False,
+                          offset_to_precursor=-1.6,
+                          noise_cutoff=0.0,
+                          normalize_to_half=False,
+                          merge_within_da=0.0,
+                          weighing_type="nope",
+                          dtype=np.float32)
+
+
+# ----------------------------
+# _LibraryIndex / _build_library_index
+# ----------------------------
+
+def test_library_index_empty_with_neutral_loss_and_l2():
+    idx = _build_library_index([],
+                               [],
+                               compute_neutral_loss=True,
+                               compute_l2_norm=True,
+                               dtype=np.float32)
+    assert isinstance(idx, _LibraryIndex)
+    assert idx.n_specs == 0
+    assert idx.peaks_mz.size == 0 and idx.peaks_int.size == 0 and idx.peaks_spec_idx.size == 0
+    assert idx.spec_offsets.shape == (1,)
+    assert idx.spec_mz.size == 0 and idx.spec_int.size == 0
+    assert idx.nl_mz.size == 0 and idx.nl_int.size == 0 and idx.nl_spec_idx.size == 0 and idx.nl_product_idx.size == 0
+    assert idx.spec_l2.size == 0
+    assert idx.precursor_mz.size == 0
+    assert idx.dtype == np.float32
+
+
+def test_library_index_single_spec_no_precursor_no_nl():
+    # One spectrum, no precursor -> NL arrays empty; L2 present if requested.
+    p = np.array([[100.0, 1.0], [200.0, 2.0]], dtype=np.float32)
+    idx = _build_library_index([p], [None],
+                               compute_neutral_loss=True,
+                               compute_l2_norm=True,
+                               dtype=np.float32)
+    assert idx.n_specs == 1
+    assert np.all(idx.spec_offsets == np.array([0, 2], dtype=np.int64))
+    assert np.allclose(idx.spec_mz, [100.0, 200.0])
+    assert np.allclose(idx.spec_int, [1.0, 2.0])
+    # Peaks sorted ascending
+    assert np.allclose(idx.peaks_mz, [100.0, 200.0])
+    assert np.allclose(idx.peaks_int, [1.0, 2.0])
+    assert idx.peaks_spec_idx.dtype == np.int32
+    assert np.all(idx.peaks_spec_idx == np.array([0, 0], dtype=np.int32))
+    # NL empty due to missing pmz
+    assert idx.nl_mz.size == 0 and idx.nl_int.size == 0
+    # L2 norm sqrt(1^2+2^2)
+    assert math.isclose(float(idx.spec_l2[0]), math.sqrt(5.0), rel_tol=0, abs_tol=1e-6)
+    # precursor array filled with NaN
+    assert np.isnan(idx.precursor_mz[0])
+
+
+def test_library_index_two_specs_with_pmz_nl_sorted_and_product_mapping():
+    # Spec 0: pmz=500 peaks -> products [100, 300], NL [400, 200]
+    # Spec 1: pmz=510 peaks -> product [150], NL [360]
+    p0 = np.array([[100.0, 0.5], [300.0, 0.2]], dtype=np.float32)
+    p1 = np.array([[150.0, 0.8]], dtype=np.float32)
+    idx = _build_library_index([p0, p1], [500.0, 510.0],
+                               compute_neutral_loss=True,
+                               compute_l2_norm=True,
+                               dtype=np.float32)
+
+    # Spectrum-major view keeps per-spectrum ordering.
+    assert np.all(idx.spec_offsets == np.array([0, 2, 3], dtype=np.int64))
+    assert np.allclose(idx.spec_mz, [100.0, 300.0, 150.0], atol=1e-12)
+    assert np.allclose(idx.spec_int, [0.5, 0.2, 0.8], atol=1e-12)
+
+    # Product arrays are globally sorted by m/z
+    assert np.allclose(idx.peaks_mz, [100.0, 150.0, 300.0], atol=1e-12)
+    assert np.all(idx.peaks_spec_idx == np.array([0, 1, 0], dtype=np.int32))
+    assert np.allclose(idx.peaks_int, [0.5, 0.8, 0.2], atol=1e-12)
+
+    # Neutral-loss values (unsorted would be [400,200,360]); verify sorted ascending
+    assert np.allclose(np.sort(idx.nl_mz), idx.nl_mz, atol=0.0)
+    assert idx.nl_mz.size == 3
+    # Spec indices carried along and product index maps to corresponding product peak
+    for k in range(idx.nl_mz.size):
+        col = int(idx.nl_spec_idx[k])
+        pmz = float(idx.precursor_mz[col])
+        loss = float(idx.nl_mz[k])
+        # product m/z that generated this loss
+        expected_prod_mz = pmz - loss
+        prod_pos = int(idx.nl_product_idx[k])
+        assert math.isclose(float(idx.peaks_mz[prod_pos]), expected_prod_mz, abs_tol=1e-6)
+
+    # L2 per spectrum
+    # spec0: sqrt(0.5^2 + 0.2^2) ; spec1: sqrt(0.8^2)
+    expected0 = math.sqrt(0.25 + 0.04)
+    expected1 = 0.8
+    assert math.isclose(float(idx.spec_l2[0]), expected0, abs_tol=1e-6)
+    assert math.isclose(float(idx.spec_l2[1]), expected1, abs_tol=1e-6)
+    # dtype preserved
+    assert idx.dtype == np.float32
+    assert idx.peaks_mz.dtype == np.float32
+    assert idx.nl_mz.dtype == np.float32
+
+
+def test_library_index_dtype_float64_and_values():
+    p = np.array([[100.0, 1.0], [200.0, 2.0]], dtype=np.float64)
+    idx = _build_library_index([p], [500.0],
+                               compute_neutral_loss=True,
+                               compute_l2_norm=True,
+                               dtype=np.float64)
+    assert idx.dtype == np.float64
+    assert idx.peaks_mz.dtype == np.float64
+    assert idx.nl_mz.dtype == np.float64
+    # NL values should be [400, 300] (sorted -> [300, 400])
+    assert np.allclose(idx.nl_mz, [300.0, 400.0], atol=1e-12)
+    # L2 = sqrt(1^2 + 2^2)
+    assert math.isclose(float(idx.spec_l2[0]), math.sqrt(5.0), abs_tol=1e-12)


### PR DESCRIPTION
- Instead of converting a list of `Spectrum` objects into a Flash-Index, we can do this quicker if we start from the CSR-based representation in `SpectraCollection`.
- The matrix() function now internally also switches the spectra1 vs spectra2 order depending on what computes faster (this makes a very notable difference if spectra1 and spectr2 have very different number of spectra).

I benchmarked this against the former FlashEntropy / CosineFlash implementation and this is notably faster (mostly in the Index computation, so the relative gain is larger for smaller datasets than for very large ones).

The "old" implementations remain in `flash_similarity_spectrum_list.py` and `flash_utils_spectrum_list.py`, at least for now. They can probably be removed in the near future.