### PR TITLE
Use `None` for unsuccessfully derived entries

### DIFF
--- a/matchms/filtering/filter_order.py
+++ b/matchms/filtering/filter_order.py
@@ -2,7 +2,7 @@ from matchms import filtering as msfilters
 
 
 # List all filters in a functionally working order
-# TODO: Check if some filters might need more than one pass to be fully applied.
+# TODO: Check if some filters might need more than one pass to be fully applied. --> e.g. harmonize_missing_entries
 
 # IMPORTANT!! IF YOU CHANGE ANYTHING HERE PLEASE ADD A TEST to test_all_filter_order.py
 # to ensure it is not changed back by accident later.

--- a/matchms/filtering/metadata_processing/derive_adduct_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_adduct_from_name.py
@@ -65,7 +65,7 @@ def _derive_adduct_from_name(
             x for x in name_split if x not in parts_that_look_like_adduct
         )
         name_adduct_removed = name_adduct_removed.strip("; ")
-        updates["compound_name"] = name_adduct_removed
+        updates["compound_name"] = name_adduct_removed or None
         logger.info(
             "Removed adduct %s from compound name.",
             parts_that_look_like_adduct,
@@ -129,4 +129,7 @@ def _looks_like_adduct(adduct):
     return re.search(regexp1, adduct) is not None
 
 
-derive_adduct_from_name = metadata_update_filter(_derive_adduct_from_name)
+derive_adduct_from_name = metadata_update_filter(
+    _derive_adduct_from_name,
+    drop_missing_updates=False,
+)

--- a/matchms/filtering/metadata_processing/derive_formula_from_name.py
+++ b/matchms/filtering/metadata_processing/derive_formula_from_name.py
@@ -54,7 +54,7 @@ def _derive_formula_from_name(
 
     if remove_formula_from_name:
         name_formula_removed = " ".join(name.split(" ")[:-1])
-        updates["compound_name"] = name_formula_removed
+        updates["compound_name"] = name_formula_removed or None
         logger.info("Removed formula %s from compound name.", formula_from_name)
 
     if metadata.get("formula", None) is None:
@@ -76,4 +76,7 @@ def _looks_like_formula(formula):
     return (atom_count > 2) and (re.search(regexp, formula) is not None)
 
 
-derive_formula_from_name = metadata_update_filter(_derive_formula_from_name)
+derive_formula_from_name = metadata_update_filter(
+    _derive_formula_from_name,
+    drop_missing_updates=False,
+)

--- a/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
+++ b/matchms/filtering/metadata_processing/repair_inchi_inchikey_smiles.py
@@ -3,30 +3,28 @@ from matchms.filtering.filter_utils.metadata_conversions import as_string_or_non
 from matchms.filtering.species_string import SpeciesString
 
 
-def _repair_species_values(inchi, inchiaux, inchikey, smiles) -> dict[str, str]:
-    """Repair and assign inchi, inchikey, and smiles values."""
+def _repair_species_values(
+    inchi, inchiaux, inchikey, smiles
+) -> dict[str, str | None]:
     cleaneds = [SpeciesString(s) for s in [inchi, inchiaux, inchikey, smiles]]
 
     inchis = [
-        c.cleaned
-        for c in cleaneds
+        c.cleaned for c in cleaneds
         if c.target == "inchi" and c.cleaned != ""
     ]
     inchikeys = [
-        c.cleaned
-        for c in cleaneds
+        c.cleaned for c in cleaneds
         if c.target == "inchikey" and c.cleaned != ""
     ]
     smiles_values = [
-        c.cleaned
-        for c in cleaneds
+        c.cleaned for c in cleaneds
         if c.target == "smiles" and c.cleaned != ""
     ]
 
     return {
-        "inchi": inchis[0] if inchis else "",
-        "inchikey": inchikeys[0] if inchikeys else "",
-        "smiles": smiles_values[0] if smiles_values else "",
+        "inchi": inchis[0] if inchis else None,
+        "inchikey": inchikeys[0] if inchikeys else None,
+        "smiles": smiles_values[0] if smiles_values else None,
     }
 
 
@@ -51,5 +49,6 @@ def _repair_inchi_inchikey_smiles(metadata) -> dict[str, str]:
 
 
 repair_inchi_inchikey_smiles = metadata_update_filter(
-    _repair_inchi_inchikey_smiles
+    _repair_inchi_inchikey_smiles,
+    drop_missing_updates=False,
 )

--- a/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
+++ b/matchms/filtering/metadata_processing/repair_smiles_of_salts.py
@@ -80,7 +80,7 @@ def _create_possible_ions(smiles):
 
     if "." in smiles:
         single_ions = smiles.split(".")
-        for r in range(1, len(single_ions) + 1):
+        for r in range(1, len(single_ions)):
             combinations = itertools.combinations(single_ions, r)
             for combination in combinations:
                 combined_ion = ".".join(combination)

--- a/tests/filtering/test_derive_adduct_from_name.py
+++ b/tests/filtering/test_derive_adduct_from_name.py
@@ -26,7 +26,7 @@ def matchms_info_logger():
         ({"compound_name": "peptideXYZ [M+H+K]"}, False, "[M+H+K]", "peptideXYZ [M+H+K]", None),
         ({"Name": "peptideXYZ [M+H+K]", "adduct": "M+H"}, True, "M+H", "peptideXYZ", "[M+H+K]"),
         ({"compound_name": "peptideXYZ [M+H+K] C16H12"}, True, "[M+H+K]", "peptideXYZ C16H12", "[M+H+K]"),
-        ({"name": ""}, True, None, None, None),
+        ({"name": ""}, True, None, "", None),
     ],
 )
 def test_derive_adduct_from_name_parametrized(

--- a/tests/filtering/test_derive_adduct_from_name.py
+++ b/tests/filtering/test_derive_adduct_from_name.py
@@ -26,7 +26,7 @@ def matchms_info_logger():
         ({"compound_name": "peptideXYZ [M+H+K]"}, False, "[M+H+K]", "peptideXYZ [M+H+K]", None),
         ({"Name": "peptideXYZ [M+H+K]", "adduct": "M+H"}, True, "M+H", "peptideXYZ", "[M+H+K]"),
         ({"compound_name": "peptideXYZ [M+H+K] C16H12"}, True, "[M+H+K]", "peptideXYZ C16H12", "[M+H+K]"),
-        ({"name": ""}, True, None, "", None),
+        ({"name": ""}, True, None, None, None),
     ],
 )
 def test_derive_adduct_from_name_parametrized(
@@ -177,3 +177,21 @@ def test_looks_like_adduct_accepts_adduct_like_strings(adduct):
 )
 def test_looks_like_adduct_rejects_non_adduct_like_strings(adduct):
     assert not _looks_like_adduct(adduct)
+
+
+@pytest.mark.parametrize("as_collection", [False, True], ids=["spectrum", "collection"])
+def test_derive_adduct_from_name_does_not_create_empty_compound_name(as_collection):
+    spectrum_in = (
+        SpectrumBuilder()
+        .with_metadata({"compound_name": "[M+H]+"})
+        .build()
+    )
+
+    spectrum = run_filter_as_spectrum_or_collection(
+        derive_adduct_from_name,
+        spectrum_in,
+        as_collection,
+    )
+
+    assert spectrum.get("adduct") == "[M+H]+"
+    assert spectrum.get("compound_name") is None

--- a/tests/filtering/test_derive_formula_from_name.py
+++ b/tests/filtering/test_derive_formula_from_name.py
@@ -115,3 +115,21 @@ def test_derive_formula_from_name_collection_clone_false_modifies_input():
 
 def test_derive_formula_from_name_empty_spectrum():
     assert derive_formula_from_name(None) is None
+
+
+@pytest.mark.parametrize("as_collection", [False, True], ids=["spectrum", "collection"])
+def test_derive_formula_from_name_does_not_create_empty_compound_name(as_collection):
+    spectrum_in = (
+        SpectrumBuilder()
+        .with_metadata({"compound_name": "C5H12NO2"})
+        .build()
+    )
+
+    spectrum = run_filter_as_spectrum_or_collection(
+        derive_formula_from_name,
+        spectrum_in,
+        as_collection,
+    )
+
+    assert spectrum.get("formula") == "C5H12NO2"
+    assert spectrum.get("compound_name") is None

--- a/tests/filtering/test_repair_inchi_inchikey_smiles.py
+++ b/tests/filtering/test_repair_inchi_inchikey_smiles.py
@@ -80,8 +80,8 @@ def test_repair_inchi_inchikey_smiles_various_inchi_entered_as_smiles(as_collect
         )
 
         assert spectrum.get("inchi") == "InChI=" + inchi.replace("InChI=", "").replace('"', "")
-        assert spectrum.get("inchikey") == None
-        assert spectrum.get("smiles") == None
+        assert spectrum.get("inchikey") is None
+        assert spectrum.get("smiles") is None
 
 
 def test_repair_inchi_inchikey_smiles_collection_multiple_rows():
@@ -97,17 +97,17 @@ def test_repair_inchi_inchikey_smiles_collection_multiple_rows():
     assert repaired is not collection
     assert len(repaired) == 3
 
-    assert repaired.metadata.loc[0, "inchi"] == None
+    assert repaired.metadata.loc[0, "inchi"] is None
     assert repaired.metadata.loc[0, "inchikey"] == "ABTNALLHJFCFRZ-UHFFFAOYSA-N"
-    assert repaired.metadata.loc[0, "smiles"] == None
+    assert repaired.metadata.loc[0, "smiles"] is None
 
-    assert repaired.metadata.loc[1, "inchi"] == None
-    assert repaired.metadata.loc[1, "inchikey"] == None
+    assert repaired.metadata.loc[1, "inchi"] is None
+    assert repaired.metadata.loc[1, "inchikey"] is None
     assert repaired.metadata.loc[1, "smiles"] == "C[C@H](Cc1ccccc1)N(C)CC#C"
 
     assert repaired.metadata.loc[2, "inchi"] == "InChI=" + TEST_INCHIS[0].replace("InChI=", "").replace('"', "")
-    assert repaired.metadata.loc[2, "inchikey"] == None
-    assert repaired.metadata.loc[2, "smiles"] == None
+    assert repaired.metadata.loc[2, "inchikey"] is None
+    assert repaired.metadata.loc[2, "smiles"] is None
 
 
 def test_repair_inchi_inchikey_smiles_clone_false_modifies_collection_in_place():

--- a/tests/filtering/test_repair_inchi_inchikey_smiles.py
+++ b/tests/filtering/test_repair_inchi_inchikey_smiles.py
@@ -9,27 +9,27 @@ REPAIR_TEST_CASES = [
     [
         {"inchi": "InChI=1/C2H4N4/c3-2-4-1-5-6-2/h1H,(H3,3,4,5,6)/f/h6H,3H2"},
         "InChI=1/C2H4N4/c3-2-4-1-5-6-2/h1H,(H3,3,4,5,6)/f/h6H,3H2",
-        "",
-        "",
+        None,
+        None,
     ],
     [
         {"inchikey": "InChI=1/C2H4N4/c3-2-4-1-5-6-2/h1H,(H3,3,4,5,6)/f/h6H,3H2"},
         "InChI=1/C2H4N4/c3-2-4-1-5-6-2/h1H,(H3,3,4,5,6)/f/h6H,3H2",
-        "",
-        "",
+        None,
+        None,
     ],
     [
         {"smiles": "InChI=1/C2H4N4/c3-2-4-1-5-6-2/h1H,(H3,3,4,5,6)/f/h6H,3H2"},
         "InChI=1/C2H4N4/c3-2-4-1-5-6-2/h1H,(H3,3,4,5,6)/f/h6H,3H2",
-        "",
-        "",
+        None,
+        None,
     ],
-    [{"inchi": "ABTNALLHJFCFRZ-UHFFFAOYSA-N"}, "", "ABTNALLHJFCFRZ-UHFFFAOYSA-N", ""],
-    [{"inchikey": "ABTNALLHJFCFRZ-UHFFFAOYSA-N"}, "", "ABTNALLHJFCFRZ-UHFFFAOYSA-N", ""],
-    [{"smiles": "ABTNALLHJFCFRZ-UHFFFAOYSA-N"}, "", "ABTNALLHJFCFRZ-UHFFFAOYSA-N", ""],
-    [{"inchi": "C[C@H](Cc1ccccc1)N(C)CC#C"}, "", "", "C[C@H](Cc1ccccc1)N(C)CC#C"],
-    [{"inchikey": "C[C@H](Cc1ccccc1)N(C)CC#C"}, "", "", "C[C@H](Cc1ccccc1)N(C)CC#C"],
-    [{"smiles": "C[C@H](Cc1ccccc1)N(C)CC#C"}, "", "", "C[C@H](Cc1ccccc1)N(C)CC#C"],
+    [{"inchi": "ABTNALLHJFCFRZ-UHFFFAOYSA-N"}, None, "ABTNALLHJFCFRZ-UHFFFAOYSA-N", None],
+    [{"inchikey": "ABTNALLHJFCFRZ-UHFFFAOYSA-N"}, None, "ABTNALLHJFCFRZ-UHFFFAOYSA-N", None],
+    [{"smiles": "ABTNALLHJFCFRZ-UHFFFAOYSA-N"}, None, "ABTNALLHJFCFRZ-UHFFFAOYSA-N", None],
+    [{"inchi": "C[C@H](Cc1ccccc1)N(C)CC#C"}, None, None, "C[C@H](Cc1ccccc1)N(C)CC#C"],
+    [{"inchikey": "C[C@H](Cc1ccccc1)N(C)CC#C"}, None, None, "C[C@H](Cc1ccccc1)N(C)CC#C"],
+    [{"smiles": "C[C@H](Cc1ccccc1)N(C)CC#C"}, None, None, "C[C@H](Cc1ccccc1)N(C)CC#C"],
 ]
 
 
@@ -80,8 +80,8 @@ def test_repair_inchi_inchikey_smiles_various_inchi_entered_as_smiles(as_collect
         )
 
         assert spectrum.get("inchi") == "InChI=" + inchi.replace("InChI=", "").replace('"', "")
-        assert spectrum.get("inchikey") == ""
-        assert spectrum.get("smiles") == ""
+        assert spectrum.get("inchikey") == None
+        assert spectrum.get("smiles") == None
 
 
 def test_repair_inchi_inchikey_smiles_collection_multiple_rows():
@@ -97,17 +97,17 @@ def test_repair_inchi_inchikey_smiles_collection_multiple_rows():
     assert repaired is not collection
     assert len(repaired) == 3
 
-    assert repaired.metadata.loc[0, "inchi"] == ""
+    assert repaired.metadata.loc[0, "inchi"] == None
     assert repaired.metadata.loc[0, "inchikey"] == "ABTNALLHJFCFRZ-UHFFFAOYSA-N"
-    assert repaired.metadata.loc[0, "smiles"] == ""
+    assert repaired.metadata.loc[0, "smiles"] == None
 
-    assert repaired.metadata.loc[1, "inchi"] == ""
-    assert repaired.metadata.loc[1, "inchikey"] == ""
+    assert repaired.metadata.loc[1, "inchi"] == None
+    assert repaired.metadata.loc[1, "inchikey"] == None
     assert repaired.metadata.loc[1, "smiles"] == "C[C@H](Cc1ccccc1)N(C)CC#C"
 
     assert repaired.metadata.loc[2, "inchi"] == "InChI=" + TEST_INCHIS[0].replace("InChI=", "").replace('"', "")
-    assert repaired.metadata.loc[2, "inchikey"] == ""
-    assert repaired.metadata.loc[2, "smiles"] == ""
+    assert repaired.metadata.loc[2, "inchikey"] == None
+    assert repaired.metadata.loc[2, "smiles"] == None
 
 
 def test_repair_inchi_inchikey_smiles_clone_false_modifies_collection_in_place():

--- a/tests/filtering/test_repair_inchi_inchikey_smiles.py
+++ b/tests/filtering/test_repair_inchi_inchikey_smiles.py
@@ -129,3 +129,41 @@ def test_repair_inchi_inchikey_smiles_empty_spectrum():
     spectrum = repair_inchi_inchikey_smiles(None)
 
     assert spectrum is None, "Expected different handling of None spectrum."
+
+
+@pytest.mark.parametrize("as_collection", [False, True], ids=["spectrum", "collection"])
+def test_repair_inchi_inchikey_smiles_does_not_create_empty_strings(as_collection):
+    spectrum_in = (
+        SpectrumBuilder()
+        .with_metadata({"smiles": "ABTNALLHJFCFRZ-UHFFFAOYSA-N"})
+        .build()
+    )
+
+    spectrum = run_filter_as_spectrum_or_collection(
+        repair_inchi_inchikey_smiles,
+        spectrum_in,
+        as_collection,
+    )
+
+    assert spectrum.get("inchi") is None
+    assert spectrum.get("inchikey") == "ABTNALLHJFCFRZ-UHFFFAOYSA-N"
+    assert spectrum.get("smiles") is None
+
+
+def test_repair_inchi_inchikey_smiles_collection_uses_missing_values_not_empty_strings():
+    collection = SpectraCollection(
+        [
+            SpectrumBuilder()
+            .with_metadata({"smiles": "ABTNALLHJFCFRZ-UHFFFAOYSA-N"})
+            .build(),
+            SpectrumBuilder()
+            .with_metadata({"inchi": "C[C@H](Cc1ccccc1)N(C)CC#C"})
+            .build(),
+        ]
+    )
+
+    repaired = repair_inchi_inchikey_smiles(collection)
+
+    structure_metadata = repaired.metadata[["inchi", "inchikey", "smiles"]]
+
+    assert not (structure_metadata == "").any().any()

--- a/tests/filtering/test_repair_parent_mass/test_repair_smiles_of_salts.py
+++ b/tests/filtering/test_repair_parent_mass/test_repair_smiles_of_salts.py
@@ -2,6 +2,9 @@ import pandas as pd
 import pytest
 from matchms import SpectraCollection
 from matchms.filtering import repair_smiles_of_salts
+from matchms.filtering.metadata_processing.repair_smiles_of_salts import (
+    _create_possible_ions,
+)
 from tests.builder_spectrum import SpectrumBuilder
 from tests.run_spectrum_and_collection import run_filter_as_spectrum_or_collection
 
@@ -150,3 +153,12 @@ def test_repair_smiles_of_salts_collection_clone_false_modifies_input():
     assert repaired is collection
     assert collection.metadata.loc[0, "smiles"] == "C1=NC2=NC=NC(=C2N1)N"
     assert collection.metadata.loc[0, "salt_ions"] == "Cl"
+
+
+def test_create_possible_ions_does_not_include_noop_combination():
+    smiles = "CCO.Cl"
+
+    possible_ions = _create_possible_ions(smiles)
+
+    assert all(removed_ions != "" for _, removed_ions in possible_ions)
+    assert all(ion != smiles for ion, _ in possible_ions)


### PR DESCRIPTION
Several filter functions added `""` entries when deriving was not possible, this was now changed to `None` entries, which properly represent missing entries in `SpectraCollection`. Addresses #951 